### PR TITLE
fix kind and ocp deploy and run on targets

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,6 +47,19 @@ jobs:
         fail_ci_if_error: true
         verbose: true   
 
+  bundle-check:
+    runs-on: ubuntu-latest
+    name: Checking bundle up-to-date
+    steps:
+    - name: install make
+      run: sudo apt-get install make
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: Verify generated bundle manifest
+      run: |
+        make bundle
+        git diff --exit-code -I'^    createdAt: ' bundle
+
   kubernetes-integration-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -113,6 +126,7 @@ jobs:
       [
         check-license,
         build-lint-test,
+        bundle-check,
         kubernetes-integration-tests,
       ]
     runs-on: ubuntu-latest

--- a/bundle/manifests/bpfman-config_v1_configmap.yaml
+++ b/bundle/manifests/bpfman-config_v1_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   bpfman.agent.healthprobe.addr: :8175
-  bpfman.agent.image: quay.io/bpfman/bpfman-agent:latest
+  bpfman.agent.image: quay.io/bpfman/bpfman-agent:latest-amd64
   bpfman.agent.log.level: info
   bpfman.agent.metric.addr: 127.0.0.1:8174
   bpfman.image: quay.io/bpfman/bpfman:latest

--- a/bundle/manifests/bpfman-config_v1_configmap.yaml
+++ b/bundle/manifests/bpfman-config_v1_configmap.yaml
@@ -12,4 +12,6 @@ data:
     millisec_delay = 10000
 kind: ConfigMap
 metadata:
+  annotations: {}
+  labels: {}
   name: bpfman-config


### PR DESCRIPTION
- fix deploy and run-on-kind targets
- allow to run make commands on MacOS BSD env
- add bundle check PR workflow job

Example:
```sh
BPFMAN_AGENT_IMG=quay.io/mmahmoud/bpfman-agent:pr-1150  BPFMAN_OPERATOR_IMG=quay.io/mmahmoud/bpfman-operator:pr-1150 make build-images

BPFMAN_AGENT_IMG=quay.io/mmahmoud/bpfman-agent:pr-1150  BPFMAN_OPERATOR_IMG=quay.io/mmahmoud/bpfman-operator:pr-1150 make run-on-kind 

oc get pods -n bpfman
NAME                               READY   STATUS    RESTARTS   AGE
bpfman-daemon-hdzqg                3/3     Running   0          9m29s
bpfman-operator-55d6cb6c57-fzw4f   2/2     Running   0          9m32s
```