### PR TITLE
cut v0.5.0-rc1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.4.1
+VERSION ?= 0.5.0-rc1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ object to find references to the bpfMap pinpoints (`spec.maps`) in order to conf
 ## Developer
 
 For more architecture details about `bpfman-operator`, refer to
-[Developing the bpfman-operator](https://bpfman.io/v0.4.1/developer-guide/develop-operator)
+[Developing the bpfman-operator](https://bpfman.io/v0.5.0-rc1/developer-guide/develop-operator)

--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
           "spec": {
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/go-application-counter:latest"
+                "url": "quay.io/bpfman-bytecode/go-application-counter:v0.5.0-rc1"
               }
             },
             "nodeselector": {},
@@ -97,7 +97,7 @@ metadata:
             "bpffunctionname": "test_fentry",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/fentry:latest"
+                "url": "quay.io/bpfman-bytecode/fentry:v0.5.0-rc1"
               }
             },
             "func_name": "do_unlinkat",
@@ -117,7 +117,7 @@ metadata:
             "bpffunctionname": "test_fexit",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/fexit:latest"
+                "url": "quay.io/bpfman-bytecode/fexit:v0.5.0-rc1"
               }
             },
             "func_name": "do_unlinkat",
@@ -137,7 +137,7 @@ metadata:
             "bpffunctionname": "my_kprobe",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/kprobe:latest"
+                "url": "quay.io/bpfman-bytecode/kprobe:v0.5.0-rc1"
               }
             },
             "func_name": "try_to_wake_up",
@@ -170,7 +170,7 @@ metadata:
             "bpffunctionname": "pass",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/tc_pass:latest"
+                "url": "quay.io/bpfman-bytecode/tc_pass:v0.5.0-rc1"
               }
             },
             "direction": "ingress",
@@ -205,7 +205,7 @@ metadata:
             "bpffunctionname": "enter_openat",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/tracepoint:latest"
+                "url": "quay.io/bpfman-bytecode/tracepoint:v0.5.0-rc1"
               }
             },
             "globaldata": {
@@ -238,7 +238,7 @@ metadata:
             "bpffunctionname": "my_uprobe",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/uprobe:latest"
+                "url": "quay.io/bpfman-bytecode/uprobe:v0.5.0-rc1"
               }
             },
             "func_name": "syscall",
@@ -271,7 +271,7 @@ metadata:
             "bpffunctionname": "pass",
             "bytecode": {
               "image": {
-                "url": "quay.io/bpfman-bytecode/xdp_pass:latest"
+                "url": "quay.io/bpfman-bytecode/xdp_pass:v0.5.0-rc1"
               }
             },
             "globaldata": {
@@ -295,8 +295,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: OpenShift Optional
-    containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
-    createdAt: "2024-06-20T14:00:22Z"
+    containerImage: quay.io/bpfman/bpfman-operator:v0.5.0-rc1
+    createdAt: "2024-06-20T19:30:45Z"
     operatorframework.io/suggested-namespace-template: |-
       {
         "apiVersion": "v1",
@@ -316,7 +316,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/bpfman/bpfman
-  name: bpfman-operator.v0.4.1
+  name: bpfman-operator.v0.5.0-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -373,8 +373,8 @@ spec:
     configmap is automatically created in the `bpfman` namespace and used to configure
     the bpfman deployment.\n\nTo edit the config simply run\n\n```bash\nkubectl edit
     cm bpfman-config\n```\n\nThe following fields are adjustable\n\n- `bpfman.agent.image`:
-    The image used for the bpfman-agent, defaults to `quay.io/bpfman/bpfman-agent:latest`\n-
-    `bpfman.image`: The image used for bpfman, defaults to `quay.io/bpfman/bpfman:latest`\n-
+    The image used for the bpfman-agent, defaults to `quay.io/bpfman/bpfman-agent:v0.5.0-rc1`\n-
+    `bpfman.image`: The image used for bpfman, defaults to `quay.io/bpfman/bpfman:v0.5.0-rc1`\n-
     `bpfman.log.level`: the log level for bpfman, currently supports `debug`, `info`,
     `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`:
     the log level for the bpfman-agent currently supports `info`, `debug`, and `trace`
@@ -1043,7 +1043,7 @@ spec:
                 env:
                 - name: GO_LOG
                   value: debug
-                image: quay.io/bpfman/bpfman-operator:latest
+                image: quay.io/bpfman/bpfman-operator:v0.5.0-rc1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -1131,4 +1131,4 @@ spec:
   provider:
     name: The bpfman Community
     url: https://bpfman.io/
-  version: 0.4.1
+  version: 0.5.0-rc1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
-	github.com/bpfman/bpfman v0.4.1
+	github.com/bpfman/bpfman v0.5.0-r1
 	github.com/containers/image v3.0.2+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
This is dependent on https://github.com/bpfman/bpfman/pull/1165 since the new version of the bpfman go grpc api bindings `github.com/bpfman/bpfman v0.5.0-r1` need to exist, CI on this will fail until that package exists.