### PR TITLE
Fixups for pr #6

### DIFF
--- a/controllers/bpfman-agent/application-program.go
+++ b/controllers/bpfman-agent/application-program.go
@@ -280,5 +280,11 @@ func (r *BpfApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(predicate.And(predicate.LabelChangedPredicate{}, nodePredicate(r.NodeName))),
 		).
+		// Watch for changes in Pod resources in case we are using a container selector.
+		Watches(
+			&v1.Pod{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(podOnNodePredicate(r.NodeName)),
+		).
 		Complete(r)
 }

--- a/controllers/bpfman-agent/common.go
+++ b/controllers/bpfman-agent/common.go
@@ -896,5 +896,6 @@ func getClientset() (*kubernetes.Clientset, error) {
 // sanitize a string to work as a bpfProgram name
 func sanitize(name string) string {
 	name = strings.TrimPrefix(name, "/")
-	return strings.Replace(strings.Replace(name, "/", "-", -1), "_", "-", -1)
+	name = strings.Replace(strings.Replace(name, "/", "-", -1), "_", "-", -1)
+	return strings.ToLower(name)
 }


### PR DESCRIPTION
Add watch on pod events back to `BpfApplicationReconciler`.  It was there but got dropped at some point.

Also, added a `strings.ToLower()` to the name `sanitize()` function.