### PR TITLE
More concise naming scheme for BpfPrograms

### DIFF
--- a/controllers/bpfman-agent/application-program.go
+++ b/controllers/bpfman-agent/application-program.go
@@ -95,7 +95,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				fentryObjects := []client.Object{&fentryProgram}
-				appProgramMap[fentryProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile FentryProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, fentryObjects)
 
@@ -117,7 +117,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				fexitObjects := []client.Object{&fexitProgram}
-				appProgramMap[fexitProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile FexitProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, fexitObjects)
 
@@ -140,7 +140,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				kprobeObjects := []client.Object{&kprobeProgram}
-				appProgramMap[kprobeProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile KprobeProgram or KpretprobeProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, kprobeObjects)
 
@@ -163,7 +163,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				uprobeObjects := []client.Object{&uprobeProgram}
-				appProgramMap[uprobeProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile UprobeProgram or UpretprobeProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, uprobeObjects)
 
@@ -185,7 +185,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				tracepointObjects := []client.Object{&tracepointProgram}
-				appProgramMap[tracepointProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile TracepointProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, tracepointObjects)
 
@@ -214,7 +214,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				tcObjects := []client.Object{&tcProgram}
-				appProgramMap[tcProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile TcProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, tcObjects)
 
@@ -242,7 +242,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				rec.appOwner = &a
 				xdpObjects := []client.Object{&xdpProgram}
-				appProgramMap[xdpProgram.Name] = true
+				appProgramMap[appProgramId] = true
 				// Reconcile XdpProgram.
 				complete, res, err = r.reconcileCommon(ctx, rec, xdpObjects)
 
@@ -267,15 +267,15 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			bpfPrograms := &bpfmaniov1alpha1.BpfProgramList{}
 			bpfDeletedPrograms := &bpfmaniov1alpha1.BpfProgramList{}
 			// find programs that need to be deleted and delete them
-			opts := []client.ListOption{client.MatchingLabels{internal.BpfProgramOwnerLabel: a.Name}}
+			opts := []client.ListOption{client.MatchingLabels{internal.BpfProgramOwner: a.Name}}
 			if err := r.List(ctx, bpfPrograms, opts...); err != nil {
 				ctxLogger.Error(err, "failed to get freshPrograms for full reconcile")
 				return ctrl.Result{}, err
 			}
 			for _, bpfProgram := range bpfPrograms.Items {
-				progName := bpfProgram.Labels[internal.BpfParentProgram]
-				if _, ok := appProgramMap[progName]; !ok {
-					ctxLogger.Info("Deleting BpfProgram", "BpfProgram", progName)
+				id := bpfProgram.Labels[internal.AppProgramId]
+				if _, ok := appProgramMap[id]; !ok {
+					ctxLogger.Info("Deleting BpfProgram", "AppProgramId", id, "BpfProgram", bpfProgram.Name)
 					bpfDeletedPrograms.Items = append(bpfDeletedPrograms.Items, bpfProgram)
 				}
 			}

--- a/controllers/bpfman-agent/fentry-program.go
+++ b/controllers/bpfman-agent/fentry-program.go
@@ -85,6 +85,10 @@ func (r *FentryProgramReconciler) getBpfGlobalData() map[string][]byte {
 	return r.currentFentryProgram.Spec.GlobalData
 }
 
+func (r *FentryProgramReconciler) getAppProgramId() string {
+	return appProgramId(r.currentFentryProgram.GetLabels())
+}
+
 func (r *FentryProgramReconciler) setCurrentProgram(program client.Object) error {
 	var ok bool
 
@@ -123,14 +127,13 @@ func (r *FentryProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *FentryProgramReconciler) getExpectedBpfPrograms(ctx context.Context) (*bpfmaniov1alpha1.BpfProgramList, error) {
 	progs := &bpfmaniov1alpha1.BpfProgramList{}
 
-	sanatizedFentry := sanitize(r.currentFentryProgram.Spec.FunctionName)
-	bpfProgramName := fmt.Sprintf("%s-%s-%s", r.currentFentryProgram.Name, r.NodeName, sanatizedFentry)
+	attachPoint := sanitize(r.currentFentryProgram.Spec.FunctionName)
 
 	annotations := map[string]string{internal.FentryProgramFunction: r.currentFentryProgram.Spec.FunctionName}
 
-	prog, err := r.createBpfProgram(bpfProgramName, r, annotations)
+	prog, err := r.createBpfProgram(attachPoint, r, annotations)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create BpfProgram %s: %v", bpfProgramName, err)
+		return nil, fmt.Errorf("failed to create BpfProgram %s: %v", attachPoint, err)
 	}
 
 	progs.Items = append(progs.Items, *prog)

--- a/controllers/bpfman-agent/fentry-program_test.go
+++ b/controllers/bpfman-agent/fentry-program_test.go
@@ -18,7 +18,6 @@ package bpfmanagent
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -52,7 +51,8 @@ func TestFentryProgramControllerCreate(t *testing.T) {
 		functionName    = "do_unlinkat"
 		fakeNode        = testutils.NewNode("fake-control-plane")
 		ctx             = context.TODO()
-		bpfProgName     = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, "do-unlinkat")
+		appProgramId    = ""
+		attachPoint     = sanitize(functionName)
 		bpfProg         = &bpfmaniov1alpha1.BpfProgram{}
 		fakeUID         = "ef71d42c-aa21-48e8-a697-82391d801a81"
 	)
@@ -121,14 +121,14 @@ func TestFentryProgramControllerCreate(t *testing.T) {
 	}
 
 	// Check the BpfProgram Object was created successfully
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, bpfProg)
 	// Finalizer is written
 	require.Equal(t, r.getFinalizer(), bpfProg.Finalizers[0])
 	// owningConfig Label was correctly set
-	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwnerLabel], name)
+	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwner], name)
 	// node Label was correctly set
 	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
 	// fentry function Annotation was correctly set
@@ -170,7 +170,7 @@ func TestFentryProgramControllerCreate(t *testing.T) {
 	}
 
 	// Check that the bpfProgram's programs was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	// prog ID should already have been set
@@ -194,7 +194,7 @@ func TestFentryProgramControllerCreate(t *testing.T) {
 	require.False(t, res.Requeue)
 
 	// Check that the bpfProgram's status was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	require.Equal(t, string(bpfmaniov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)

--- a/controllers/bpfman-agent/fexit-program.go
+++ b/controllers/bpfman-agent/fexit-program.go
@@ -85,6 +85,10 @@ func (r *FexitProgramReconciler) getBpfGlobalData() map[string][]byte {
 	return r.currentFexitProgram.Spec.GlobalData
 }
 
+func (r *FexitProgramReconciler) getAppProgramId() string {
+	return appProgramId(r.currentFexitProgram.GetLabels())
+}
+
 func (r *FexitProgramReconciler) setCurrentProgram(program client.Object) error {
 	var ok bool
 
@@ -123,14 +127,13 @@ func (r *FexitProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *FexitProgramReconciler) getExpectedBpfPrograms(ctx context.Context) (*bpfmaniov1alpha1.BpfProgramList, error) {
 	progs := &bpfmaniov1alpha1.BpfProgramList{}
 
-	sanatizedFexit := sanitize(r.currentFexitProgram.Spec.FunctionName)
-	bpfProgramName := fmt.Sprintf("%s-%s-%s", r.currentFexitProgram.Name, r.NodeName, sanatizedFexit)
+	attachPoint := sanitize(r.currentFexitProgram.Spec.FunctionName)
 
 	annotations := map[string]string{internal.FexitProgramFunction: r.currentFexitProgram.Spec.FunctionName}
 
-	prog, err := r.createBpfProgram(bpfProgramName, r, annotations)
+	prog, err := r.createBpfProgram(attachPoint, r, annotations)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create BpfProgram %s: %v", bpfProgramName, err)
+		return nil, fmt.Errorf("failed to create BpfProgram %s: %v", attachPoint, err)
 	}
 
 	progs.Items = append(progs.Items, *prog)

--- a/controllers/bpfman-agent/fexit-program_test.go
+++ b/controllers/bpfman-agent/fexit-program_test.go
@@ -18,7 +18,6 @@ package bpfmanagent
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -52,7 +51,8 @@ func TestFexitProgramControllerCreate(t *testing.T) {
 		functionName    = "do_unlinkat"
 		fakeNode        = testutils.NewNode("fake-control-plane")
 		ctx             = context.TODO()
-		bpfProgName     = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, "do-unlinkat")
+		appProgramId    = ""
+		attachPoint     = sanitize(functionName)
 		bpfProg         = &bpfmaniov1alpha1.BpfProgram{}
 		fakeUID         = "ef71d42c-aa21-48e8-a697-82391d801a81"
 	)
@@ -121,14 +121,14 @@ func TestFexitProgramControllerCreate(t *testing.T) {
 	}
 
 	// Check the BpfProgram Object was created successfully
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, bpfProg)
 	// Finalizer is written
 	require.Equal(t, r.getFinalizer(), bpfProg.Finalizers[0])
 	// owningConfig Label was correctly set
-	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwnerLabel], name)
+	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwner], name)
 	// node Label was correctly set
 	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
 	// fexit function Annotation was correctly set
@@ -170,7 +170,7 @@ func TestFexitProgramControllerCreate(t *testing.T) {
 	}
 
 	// Check that the bpfProgram's programs was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	// prog ID should already have been set
@@ -194,7 +194,7 @@ func TestFexitProgramControllerCreate(t *testing.T) {
 	require.False(t, res.Requeue)
 
 	// Check that the bpfProgram's status was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	require.Equal(t, string(bpfmaniov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)

--- a/controllers/bpfman-agent/kprobe-program_test.go
+++ b/controllers/bpfman-agent/kprobe-program_test.go
@@ -18,7 +18,6 @@ package bpfmanagent
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -55,7 +54,8 @@ func TestKprobeProgramControllerCreate(t *testing.T) {
 		kprobecontainerpid int32 = 0
 		fakeNode                 = testutils.NewNode("fake-control-plane")
 		ctx                      = context.TODO()
-		bpfProgName              = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, "try-to-wake-up")
+		appProgramId             = ""
+		attachPoint              = sanitize(functionName)
 		bpfProg                  = &bpfmaniov1alpha1.BpfProgram{}
 		fakeUID                  = "ef71d42c-aa21-48e8-a697-82391d801a81"
 	)
@@ -126,14 +126,14 @@ func TestKprobeProgramControllerCreate(t *testing.T) {
 	}
 
 	// Check the BpfProgram Object was created successfully
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, bpfProg)
 	// Finalizer is written
 	require.Equal(t, r.getFinalizer(), bpfProg.Finalizers[0])
 	// owningConfig Label was correctly set
-	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwnerLabel], name)
+	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwner], name)
 	// node Label was correctly set
 	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
 	// kprobe function Annotation was correctly set
@@ -178,7 +178,7 @@ func TestKprobeProgramControllerCreate(t *testing.T) {
 	}
 
 	// Check that the bpfProgram's programs was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	// prog ID should already have been set
@@ -202,7 +202,7 @@ func TestKprobeProgramControllerCreate(t *testing.T) {
 	require.False(t, res.Requeue)
 
 	// Check that the bpfProgram's status was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
+	err = rc.getBpfProgram(ctx, name, appProgramId, attachPoint, bpfProg)
 	require.NoError(t, err)
 
 	require.Equal(t, string(bpfmaniov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)

--- a/controllers/bpfman-agent/xdp-program.go
+++ b/controllers/bpfman-agent/xdp-program.go
@@ -86,6 +86,10 @@ func (r *XdpProgramReconciler) getBpfGlobalData() map[string][]byte {
 	return r.currentXdpProgram.Spec.GlobalData
 }
 
+func (r *XdpProgramReconciler) getAppProgramId() string {
+	return appProgramId(r.currentXdpProgram.GetLabels())
+}
+
 func (r *XdpProgramReconciler) setCurrentProgram(program client.Object) error {
 	var err error
 	var ok bool
@@ -155,12 +159,12 @@ func (r *XdpProgramReconciler) getExpectedBpfPrograms(ctx context.Context) (*bpf
 	progs := &bpfmaniov1alpha1.BpfProgramList{}
 
 	for _, iface := range r.interfaces {
-		bpfProgramName := fmt.Sprintf("%s-%s-%s", r.currentXdpProgram.Name, r.NodeName, iface)
+		attachPoint := iface
 		annotations := map[string]string{internal.XdpProgramInterface: iface}
 
-		prog, err := r.createBpfProgram(bpfProgramName, r, annotations)
+		prog, err := r.createBpfProgram(attachPoint, r, annotations)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create BpfProgram %s: %v", bpfProgramName, err)
+			return nil, fmt.Errorf("failed to create BpfProgram %s: %v", attachPoint, err)
 		}
 
 		progs.Items = append(progs.Items, *prog)

--- a/controllers/bpfman-agent/xdp-program_test.go
+++ b/controllers/bpfman-agent/xdp-program_test.go
@@ -18,7 +18,6 @@ package bpfmanagent
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -57,8 +56,10 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 		fakeInt0        = "eth0"
 		fakeInt1        = "eth1"
 		ctx             = context.TODO()
-		bpfProgName0    = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInt0)
-		bpfProgName1    = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInt1)
+		appProgramId0   = ""
+		attachPoint0    = fakeInt0
+		appProgramId1   = ""
+		attachPoint1    = fakeInt1
 		bpfProgEth0     = &bpfmaniov1alpha1.BpfProgram{}
 		bpfProgEth1     = &bpfmaniov1alpha1.BpfProgram{}
 		fakeUID0        = "ef71d42c-aa21-48e8-a697-82391d801a80"
@@ -143,12 +144,12 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 	}
 
 	// Check the first BpfProgram Object was created successfully
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProgEth0)
+	err = rc.getBpfProgram(ctx, name, appProgramId0, attachPoint0, bpfProgEth0)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, bpfProgEth0)
 	// owningConfig Label was correctly set
-	require.Equal(t, bpfProgEth0.Labels[internal.BpfProgramOwnerLabel], name)
+	require.Equal(t, bpfProgEth0.Labels[internal.BpfProgramOwner], name)
 	// node Label was correctly set
 	require.Equal(t, bpfProgEth0.Labels[internal.K8sHostLabel], fakeNode.Name)
 	// Finalizer is written
@@ -194,7 +195,7 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 	}
 
 	// Check that the bpfProgram's maps was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProgEth0)
+	err = rc.getBpfProgram(ctx, name, appProgramId0, attachPoint0, bpfProgEth0)
 	require.NoError(t, err)
 
 	// prog ID should already have been set
@@ -234,7 +235,7 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 	require.False(t, res.Requeue)
 
 	// Get program object
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProgEth0)
+	err = rc.getBpfProgram(ctx, name, appProgramId0, attachPoint0, bpfProgEth0)
 	require.NoError(t, err)
 
 	// Check that the bpfProgram's status was correctly updated
@@ -254,12 +255,12 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 		require.False(t, res.Requeue)
 
 		// Check the Second BpfProgram Object was created successfully
-		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		err = rc.getBpfProgram(ctx, name, appProgramId1, attachPoint1, bpfProgEth1)
 		require.NoError(t, err)
 
 		require.NotEmpty(t, bpfProgEth1)
 		// owningConfig Label was correctly set
-		require.Equal(t, bpfProgEth1.Labels[internal.BpfProgramOwnerLabel], name)
+		require.Equal(t, bpfProgEth1.Labels[internal.BpfProgramOwner], name)
 		// node Label was correctly set
 		require.Equal(t, bpfProgEth1.Labels[internal.K8sHostLabel], fakeNode.Name)
 		// Finalizer is written
@@ -314,7 +315,7 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 		}
 
 		// Check that the bpfProgram's maps was correctly updated
-		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		err = rc.getBpfProgram(ctx, name, appProgramId1, attachPoint1, bpfProgEth1)
 		require.NoError(t, err)
 
 		// prog ID should already have been set
@@ -328,7 +329,7 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 		}
 
 		// Get program object
-		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		err = rc.getBpfProgram(ctx, name, appProgramId1, attachPoint1, bpfProgEth1)
 		require.NoError(t, err)
 
 		// Check that the bpfProgram's status was correctly updated

--- a/controllers/bpfman-operator/application-program_test.go
+++ b/controllers/bpfman-operator/application-program_test.go
@@ -112,7 +112,7 @@ func appProgramReconcile(t *testing.T, multiCondition bool) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: App.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: App.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.BpfApplicationControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/common.go
+++ b/controllers/bpfman-operator/common.go
@@ -77,7 +77,7 @@ func reconcileBpfProgram(ctx context.Context, rec ProgramReconciler, prog client
 	bpfPrograms := &bpfmaniov1alpha1.BpfProgramList{}
 
 	// Only list bpfPrograms for this Program
-	opts := []client.ListOption{client.MatchingLabels{internal.BpfProgramOwnerLabel: progName}}
+	opts := []client.ListOption{client.MatchingLabels{internal.BpfProgramOwner: progName}}
 
 	if err := r.List(ctx, bpfPrograms, opts...); err != nil {
 		r.Logger.Error(err, "failed to get freshPrograms for full reconcile")
@@ -97,7 +97,7 @@ func reconcileBpfProgram(ctx context.Context, rec ProgramReconciler, prog client
 		for _, node := range nodes.Items {
 			nodeFound := false
 			for _, program := range bpfPrograms.Items {
-				bpfProgramNode := program.ObjectMeta.Labels[internal.K8sHostLabel]
+				bpfProgramNode := program.GetLabels()[internal.K8sHostLabel]
 				if node.Name == bpfProgramNode {
 					nodeFound = true
 					break

--- a/controllers/bpfman-operator/fentry-program_test.go
+++ b/controllers/bpfman-operator/fentry-program_test.go
@@ -82,7 +82,7 @@ func fentryProgramReconcile(t *testing.T, multiCondition bool) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: Fentry.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: Fentry.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.FentryProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/fexit-program_test.go
+++ b/controllers/bpfman-operator/fexit-program_test.go
@@ -82,7 +82,7 @@ func fexitProgramReconcile(t *testing.T, multiCondition bool) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: Fexit.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: Fexit.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.FexitProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/kprobe-program_test.go
+++ b/controllers/bpfman-operator/kprobe-program_test.go
@@ -86,7 +86,7 @@ func kprobeProgramReconcile(t *testing.T, multiCondition bool) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: Kprobe.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: Kprobe.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.KprobeProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/tc-program_test.go
+++ b/controllers/bpfman-operator/tc-program_test.go
@@ -89,7 +89,7 @@ func TestTcProgramReconcile(t *testing.T) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: tc.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: tc.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.TcProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/tracepoint-program_test.go
+++ b/controllers/bpfman-operator/tracepoint-program_test.go
@@ -79,7 +79,7 @@ func TestTracepointProgramReconcile(t *testing.T) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: Tracepoint.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: Tracepoint.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.TracepointProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/uprobe-program_test.go
+++ b/controllers/bpfman-operator/uprobe-program_test.go
@@ -85,7 +85,7 @@ func TestUprobeProgramReconcile(t *testing.T) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: Uprobe.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: Uprobe.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.UprobeProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/controllers/bpfman-operator/xdp-program_test.go
+++ b/controllers/bpfman-operator/xdp-program_test.go
@@ -85,7 +85,7 @@ func TestXdpProgramReconcile(t *testing.T) {
 					Controller: &[]bool{true}[0],
 				},
 			},
-			Labels:     map[string]string{internal.BpfProgramOwnerLabel: Xdp.Name, internal.K8sHostLabel: fakeNode.Name},
+			Labels:     map[string]string{internal.BpfProgramOwner: Xdp.Name, internal.K8sHostLabel: fakeNode.Name},
 			Finalizers: []string{internal.TcProgramControllerFinalizer},
 		},
 		Spec: bpfmaniov1alpha1.BpfProgramSpec{

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,16 +49,17 @@ const (
 	DefaultPath                 = "/run/bpfman-sock/bpfman.sock"
 	DefaultPort                 = 50051
 	DefaultEnabled              = true
-	// BpfProgramOwnerLabel is the name of the object that owns the BpfProgram
-	// object.  In the case of a *Program, it will be the name of the *Program
-	// object.  In the case of a BpfApplication, it will be the name of the
+	// BpfProgramOwner is the name of the object that owns the BpfProgram
+	// object. In the case of a *Program, it will be the name of the *Program
+	// object. In the case of a BpfApplication, it will be the name of the
 	// BpfApplication object.
-	BpfProgramOwnerLabel = "bpfman.io/ownedByProgram"
-	// BpfParentProgram is the name of the current program that caused the
-	// creation of the BpfProgram object.  In the case of a *Program, it will be
-	// the name of the *Program object.  In the case of a BpfApplication, it
-	// will be the name generated for the given BpfApplication program.
-	BpfParentProgram = "bpfman.io/parentProgram"
+	BpfProgramOwner = "bpfman.io/ownedByProgram"
+	// AppProgramId is an identifier that is used to identify individual
+	// programs that are part of a given BpfApplication object.  *Programs have
+	// an AppProgramId of "".
+	AppProgramId = "bpfman.io/appProgramId"
+	// BpfProgramAttachPoint is the attach point for a given BpfProgram.
+	BpfProgramAttachPoint = "bpfman.io/bpfProgramAttachPoint"
 )
 
 // -----------------------------------------------------------------------------
@@ -233,7 +234,7 @@ func (p ProgramType) String() string {
 	}
 }
 
-// Define a constant strings for Uprobe, Fentry and Fexit.  Uprobe has the same
+// Define a constant strings for Uprobe, Fentry and Fexit. Uprobe has the same
 // kernel ProgramType as Kprobe, and Fentry and Fexit both have the Tracing
 // ProgramType, so we can't use the ProgramType String() method above.
 const UprobeString = "uprobe"
@@ -249,11 +250,11 @@ const (
 	// programs in it's list.
 	Unchanged ReconcileResult = 0
 	// Changes were made to k8s objects that we know will trigger another
-	// reconcile.  Calling code should stop reconciling additional programs and
+	// reconcile. Calling code should stop reconciling additional programs and
 	// return immediately to avoid multiple concurrent reconcile threads.
 	Updated ReconcileResult = 1
 	// A retry should be scheduled. This should only be used when "Updated"
-	// doesn't apply, but we want to trigger another reconcile anyway.  For
+	// doesn't apply, but we want to trigger another reconcile anyway. For
 	// example, there was a transient error. The calling code may continue
 	// reconciling other programs in it's list.
 	Requeue ReconcileResult = 2


### PR DESCRIPTION
Create a shorter unique name for `BpfProgram` objects. For *Programs, the name is `<*Program name>-<random string>`.  For `BpfApplications`, the unique name is `<BpfApplication name>-<bpf program type>-<random string>`.

Then, the identifying info for BpfProgram that used to be in the name is stored in the BpfProgram object.

Fixes: #28