### PR TITLE
Add pprof port to bpfagent controller

### DIFF
--- a/cmd/bpfman-agent/main.go
+++ b/cmd/bpfman-agent/main.go
@@ -62,10 +62,12 @@ func main() {
 	var probeAddr string
 	var opts zap.Options
 	var enableHTTP2 bool
+	var pprofAddr string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8174", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8175", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
+	flag.StringVar(&pprofAddr, "profiling-bind-address", "", "The address the profiling endpoint binds to, such as ':6060'. Leave unset to disable profiling.")
 	flag.Parse()
 
 	// Get the Log level for bpfman deployment where this pod is running
@@ -109,6 +111,7 @@ func main() {
 			Port:    9443,
 			TLSOpts: []func(*tls.Config){disableHTTP2},
 		}),
+		PprofBindAddress:       pprofAddr,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         false,
 		// Specify that Secrets's should not be cached.

--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -109,6 +109,7 @@ spec:
           args:
             - --health-probe-bind-address=:8175
             - --metrics-bind-address=127.0.0.1:8174
+            - --profiling-bind-address=:6060
           image: quay.io/bpfman/bpfman-agent:latest
           securityContext:
             privileged: true


### PR DESCRIPTION
add pprof port for profile to collect pprof
1- set `profiling-bind-address` to `:6060`
2- setup port forwarding `oc -n bpfman port-forward bpfman-daemon-2hgf6 6060`
3- collect cpu profile `curl "http://localhost:6060/debug/pprof/profile?duration=20" -o cpu-profile.out`
4- use web interface to view profile `go tool pprof -http=:8080 ./cpu-profile.out`
