### PR TITLE
Add make catalog-deploy to allow loading dev operator from console

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ To clean up at a later time, execute:
 operator-sdk cleanup bpfman-operator
 ```
 
+#### 3. Deploy as a bundle from the Console's OperatorHub page
+
+This mode is recommended when you want to test the customer experience of navigating through the operators'
+catalog and installing/configuring it manually through the UI, prior to committing the bundle to either: -
+
+- https://github.com/redhat-openshift-ecosystem/community-operators-prod
+ 
+or
+
+- https://github.com/k8s-operatorhub/community-operators/pulls
+
+```sh
+export BUNDLE_IMG=quay.io/$USER/bpfman-operator-bundle:developement
+make bundle bundle-build bundle-push
+export CATALOG_IMG=quay.io/$USER/bpfman-operator-catalog:developement
+make catalog-build catalog-push catalog-deploy
+```
+
+To clean up at a later time, execute:
+
+```bash
+make catalog-undeploy
+```
+
 ## Verify the Installation
 
 Regardless of the deployment method, if the `bpfman-operator` was deployed successfully,

--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -296,7 +296,18 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
-    createdAt: "2024-07-12T15:52:56Z"
+    createdAt: "2024-07-12T16:12:00Z"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "true"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: bpfman
     operatorframework.io/suggested-namespace-template: |-
       {
         "apiVersion": "v1",
@@ -313,9 +324,17 @@ metadata:
           },
         }
       }
+    operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/bpfman/bpfman
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: bpfman-operator.v0.5.0-rc3
   namespace: placeholder
 spec:

--- a/config/catalog/catalog.yaml
+++ b/config/catalog/catalog.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: bpfmanoperator-dev-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: <IMAGE>
+  displayName: Bpfman Operator development catalog
+  publisher: Me
+  updateStrategy:
+    registryPoll:
+      interval: 1m

--- a/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     capabilities: Basic Install
     containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
     repository: https://github.com/bpfman/bpfman
+    operatorframework.io/suggested-namespace: bpfman
     operatorframework.io/suggested-namespace-template: |-
       {
         "apiVersion": "v1",
@@ -23,6 +24,23 @@ metadata:
           },
         }
       }
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: bpfman-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
fixes https://github.com/bpfman/bpfman/issues/1178

Steps
```sh
export CATALOG_IMG=quay.io/$USER/bpfman-operator-catalog:v$VERSION
make catalog-build
make catalog-push
make catalog-deploy
```

![image](https://github.com/user-attachments/assets/fdc7e82a-26ae-46eb-a90e-c194ab15e6ef)

![image](https://github.com/user-attachments/assets/9a76e756-ebd5-4f37-9d56-7d2d08cfe7e9)

```sh
oc get pods -n openshift-bpfman
NAME                              READY   STATUS    RESTARTS   AGE
bpfman-operator-dd8b8887c-5sxfl   2/2     Running   0          4m16s
```