### PR TITLE
 cut bpfman-operator release 0.5.0-rc2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: release
+
+on: # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - v*
+
+jobs:
+  # Creates Release with just the changelog
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          if [[ ${GITHUB_REF#refs/*/} =~ "rc" ]]; then
+            echo "PRE_RELEASE=true" >> $GITHUB_ENV
+          else
+            echo "PRE_RELEASE=false" >> $GITHUB_ENV
+          fi
+      - name: release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: ./changelogs/CHANGELOG-${{ env.RELEASE_VERSION }}.md
+          prerelease: ${{ env.PRE_RELEASE }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.5.0-rc1
+VERSION ?= 0.5.0-rc2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -296,7 +296,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
-    createdAt: "2024-07-10T22:28:17Z"
+    createdAt: "2024-07-11T20:30:36Z"
     operatorframework.io/suggested-namespace-template: |-
       {
         "apiVersion": "v1",
@@ -316,7 +316,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/bpfman/bpfman
-  name: bpfman-operator.v0.5.0-rc1
+  name: bpfman-operator.v0.5.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1131,4 +1131,4 @@ spec:
   provider:
     name: The bpfman Community
     url: https://bpfman.io/
-  version: 0.5.0-rc1
+  version: 0.5.0-rc2

--- a/changelogs/CHANGELOG-v0.5.0-rc2.md
+++ b/changelogs/CHANGELOG-v0.5.0-rc2.md
@@ -1,0 +1,19 @@
+Pre-release 2 for 0.5.0
+
+The v0.5.0-rc2 release is a minor release that is the first official release that
+supports the BpfApplication CRD
+
+## What's Changed
+* SDN-5007: introducing bfpapplication object by @msherif1234 in https://github.com/bpfman/bpfman-operator/pull/6
+* Fixups for pr #6 by @anfredette in https://github.com/bpfman/bpfman-operator/pull/31
+* build(deps): bump the production-dependencies group with 2 updates by @dependabot in https://github.com/bpfman/bpfman-operator/pull/32
+* Add app integeration test by @msherif1234 in https://github.com/bpfman/bpfman-operator/pull/23
+* remove api doc gen by @astoycos in https://github.com/bpfman/bpfman-operator/pull/34
+* fix broken link the readme and few minor edits by @msherif1234 in https://github.com/bpfman/bpfman-operator/pull/33
+* build(deps): bump google.golang.org/grpc from 1.64.0 to 1.65.0 in the production-dependencies group by @dependabot in https://github.com/bpfman/bpfman-operator/pull/39
+* handle update app object by removing an existing program by @msherif1234 in https://github.com/bpfman/bpfman-operator/pull/38
+* More concise naming scheme for BpfPrograms by @anfredette in https://github.com/bpfman/bpfman-operator/pull/37
+* update build-release-yamls target by @msherif1234 in https://github.com/bpfman/bpfman-operator/pull/42
+* cut v0.5.0-rc1 release by @anfredette in https://github.com/bpfman/bpfman-operator/pull/41
+
+**Full Changelog**: https://github.com/bpfman/bpfman-operator/compare/v0.4.2...v0.5.0-rc2


### PR DESCRIPTION
- [x] Add a release workflow for bpfman-operator
- [x] Update the bpfman-operator version in Makefile
- [x] Run make bundle from the bpfman-operator directory

NOTE: I'm leaving the version in the go.mod and README.md at v0.5.0-rc1 since that already exists and I'm not planning to do an rc2 for bpfman.