### PR TITLE
Fix OOM because of watching configmap resource

### DIFF
--- a/cmd/bpfman-operator/main.go
+++ b/cmd/bpfman-operator/main.go
@@ -27,6 +27,8 @@ import (
 
 	osv1 "github.com/openshift/api/security/v1"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
@@ -34,6 +36,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -146,6 +150,13 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ConfigMap{}: {
+					Field: fields.SelectorFromSet(fields.Set{"metadata.name": internal.BpfmanConfigName}),
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Fix #56 reproduce steps are also doc in the issue

- before the fix
```sh
 oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=cri-containerd-499c6676bdf79e4157b694d4730d50eec01501a8c4faea1395a1fc62e2d52b73.scope,mems_allowed=0,oom_memcg=/system.slice/docker-113354b7db17a99a283c23fa84fb21b639ee29a2ec5a747c7f7c033a5e19b39f.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podfd0578d2_fe8d_4c8d_ba5f_20c00dede626.slice/cri-containerd-499c6676bdf79e4157b694d4730d50eec01501a8c4faea1395a1fc62e2d52b73.scope,task_memcg=/system.slice/docker-113354b7db17a99a283c23fa84fb21b639ee29a2ec5a747c7f7c033a5e19b39f.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podfd0578d2_fe8d_4c8d_ba5f_20c00dede626.slice/cri-containerd-499c6676bdf79e4157b694d4730d50eec01501a8c4faea1395a1fc62e2d52b73.scope,task=bpfman-operator,pid=2304220,uid=65532
[534829.056623] Memory cgroup out of memory: Killed process 2304220 (bpfman-operator) total-vm:1398540kB, anon-rss:129324kB, file-rss:26880kB, shmem-rss:0kB, UID:65532 pgtables:440kB oom_score_adj:998

```

- After the fix
```sh
   PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                            
2272755 65532     20   0 1267076  39652  28032 S   0.3   0.1   0:02.86 bpfman-operator      
```