### PR TITLE
Update TestBpfmanConfigReconcileAndDelete unit test to verify that the OpenShift SCC is deployed

### DIFF
--- a/controllers/bpfman-operator/configmap_test.go
+++ b/controllers/bpfman-operator/configmap_test.go
@@ -18,9 +18,12 @@ package bpfmanoperator
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	osv1 "github.com/openshift/api/security/v1"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,13 +33,132 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/bpfman/bpfman-operator/internal"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+// setupTestEnvironment sets up the testing environment for the
+// BpfmanConfigReconciler. It initialises a fake client with a
+// ConfigMap, registers necessary types with the runtime scheme, and
+// configures the reconciler with the fake client and scheme. The
+// function will set the RestrictedSCC field on the reconciler object
+// if the isOpenShift parameter is set to true, which is required for
+// OpenShift-specific tests.
+//
+// Parameters:
+//   - isOpenShift (bool):
+//     A flag indicating whether to set up the test environment for
+//     OpenShift, which includes setting the RestrictedSCC field on the
+//     reconciler object.
+//
+// Returns:
+// - *BpfmanConfigReconciler: The configured reconciler.
+// - *corev1.ConfigMap: The test ConfigMap object.
+// - reconcile.Request: The reconcile request object.
+// - context.Context: The context for the reconcile functio
+func setupTestEnvironment(isOpenShift bool) (*BpfmanConfigReconciler, *corev1.ConfigMap, reconcile.Request, context.Context, client.Client) {
+	// A configMap for bpfman with metadata and spec.
+	bpfmanConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      internal.BpfmanConfigName,
+			Namespace: internal.BpfmanNs,
+		},
+		Data: map[string]string{
+			"bpfman.agent.image":     "BPFMAN_AGENT_IS_SCARY",
+			"bpfman.image":           "FAKE-IMAGE",
+			"bpfman.agent.log.level": "FAKE",
+		},
+	}
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{bpfmanConfig}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{})
+	s.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DaemonSet{})
+	s.AddKnownTypes(storagev1.SchemeGroupVersion, &storagev1.CSIDriver{})
+	s.AddKnownTypes(osv1.GroupVersion, &osv1.SecurityContextConstraints{})
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+
+	// Set development Logger so we can see all logs in tests.
+	logf.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+
+	// Create a BpfmanConfigReconciler object with the scheme and
+	// fake client.
+	r := &BpfmanConfigReconciler{
+		ReconcilerCommon:         ReconcilerCommon{Client: cl, Scheme: s},
+		BpfmanStandardDeployment: resolveConfigPath(internal.BpfmanDaemonManifestPath),
+		CsiDriverDeployment:      resolveConfigPath(internal.BpfmanCsiDriverPath),
+		IsOpenshift:              isOpenShift,
+	}
+	if isOpenShift {
+		r.RestrictedSCC = resolveConfigPath(internal.BpfmanRestrictedSCCPath)
+	}
+
+	// Mock request object to simulate Reconcile() being called on
+	// an event for a watched resource.
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      internal.BpfmanConfigName,
+			Namespace: internal.BpfmanNs,
+		},
+	}
+
+	return r, bpfmanConfig, req, context.TODO(), cl
+}
+
+// resolveConfigPath adjusts the path for configuration files so that
+// lookup of path resolves from the perspective of the calling test.
+func resolveConfigPath(path string) string {
+	testDir, _ := os.Getwd()
+	return filepath.Clean(filepath.Join(testDir, getRelativePathToRoot(testDir), path))
+}
+
+// getRelativePathToRoot calculates the relative path from the current
+// directory to the project root.
+func getRelativePathToRoot(currentDir string) string {
+	projectRoot := mustFindProjectRoot(currentDir, projectRootPredicate)
+	relPath, _ := filepath.Rel(currentDir, projectRoot)
+	return relPath
+}
+
+// mustFindProjectRoot traverses up the directory tree to find the
+// project root. The project root is identified by the provided
+// closure. This function panics if, after walking the tree and
+// reaching the root of the filesystem, the project root is not found.
+func mustFindProjectRoot(currentDir string, isProjectRoot func(string) bool) string {
+	for {
+		if isProjectRoot(currentDir) {
+			return currentDir
+		}
+		if currentDir == filepath.Dir(currentDir) {
+			panic("project root not found")
+		}
+		// Move up to the parent directory.
+		currentDir = filepath.Dir(currentDir)
+	}
+}
+
+// projectRootPredicate checks if the given directory is the project
+// root by looking for the presence of a `go.mod` file and a `config`
+// directory. Returns true if both are found, otherwise returns false.
+func projectRootPredicate(dir string) bool {
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config")); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
 
 func TestBpfmanConfigReconcileAndDelete(t *testing.T) {
 	var (


### PR DESCRIPTION
Fixes #27.

This pull request refactors the existing `TestBpfmanConfigReconcileAndDelete` function to verify that the OpenShift Security Context Constraints (SCC) resource is created and deleted during reconciliation. The previous implementation did not test the OpenShift case.

#### Summary

- Introduce `setupTestEnvironment` helper function.
- Refactor `TestBpfmanConfigReconcileAndDelete` to use a table-driven approach.
- Verify creation and configuration of Restricted SCC in OpenShift.
- Update reconciler function to ensure proper cleanup of Restricted SCC in OpenShift case.

These are the key changes:

1. **Introduce `setupTestEnvironment` Helper Function**:
    - Standardise the setup process for `TestBpfmanConfigReconcileAndDelete` tests.
    - Handle the initialisation of the fake client, the registration of necessary types with the runtime scheme, and the configuration of the reconciler.
    - Enable specific OpenShift testing by conditionally setting the `RestrictedSCC` field on the reconciler object.
    - Eliminate duplicated path references to various YAML files by using constants declared in the internal package and resolving the paths relative to the test directory at runtime. This ensures that if filenames change, the test code doesn't need to be updated.

2. **Refactor `TestBpfmanConfigReconcileAndDelete`**:
    - Convert the test to a table-driven approach, enabling testing for both standard and OpenShift scenarios.
    - Verify that the Restricted Security Context Constraints (SCC) is created and configured correctly when the `isOpenShift` flag is true.
    - Identify that the Restricted SCC was not being deleted during the reconciliation process. Update the reconciler function to address this omission, ensuring proper cleanup of resources in the OpenShift case.
    - Use the new `setupTestEnvironment` helper function to standardise the setup process.