### PR TITLE
Makefile: Export BPFMAN_AGENT_IMG and BPFMAN_OPERATOR_IMG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ BPFMAN_AGENT_IMG ?= quay.io/bpfman/bpfman-agent:$(IMAGE_TAG)
 BPFMAN_OPERATOR_IMG ?= quay.io/bpfman/bpfman-operator:$(IMAGE_TAG)
 KIND_CLUSTER_NAME ?= bpfman-deployment
 
+# These environment variable keys need to be exported as the
+# integration tests expect them to be defined.
+export BPFMAN_AGENT_IMG
+export BPFMAN_OPERATOR_IMG
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 K8S_CODEGEN_VERSION = v0.30.1


### PR DESCRIPTION
Ensure BPFMAN_AGENT_IMG and BPFMAN_OPERATOR_IMG are exported so that they are available to child processes invoked by make. The Makefile provides helpful default values for these variables if not specified. However, without exporting them, you must either specify the values on the make invocation line or export them from your shell. This change resolves issues where integration tests fail due to these variables being missing from the environment.

Without these values being exported, we observe the following:

```console
% make test-integration
go clean -testcache
cd config/bpfman-deployment && \
  sed -e 's@bpfman\.image=.*@bpfman.image=quay.io/bpfman/bpfman:latest@' \
      -e 's@bpfman\.agent\.image=.*@bpfman.agent.image=quay.io/bpfman/bpfman-agent:latest@' \
	  kustomization.yaml.env > kustomization.yaml
GOFLAGS="-tags=integration_tests" go test -race -v ./test/integration/...
BPFMAN_AGENT_IMG, and BPFMAN_OPERATOR_IMG must be provided
FAIL	github.com/bpfman/bpfman-operator/test/integration	0.075s
FAIL
make: *** [Makefile:290: test-integration] Error 1
```

And when they are exported, we observe the following:

```console
% make test-integration
go clean -testcache
cd config/bpfman-deployment && \
  sed -e 's@bpfman\.image=.*@bpfman.image=quay.io/bpfman/bpfman:latest@' \
      -e 's@bpfman\.agent\.image=.*@bpfman.agent.image=quay.io/bpfman/bpfman-agent:latest@' \
	  kustomization.yaml.env > kustomization.yaml
GOFLAGS="-tags=integration_tests" go test -race -v ./test/integration/...
INFO: using bpfmanAgentImage=quay.io/bpfman/bpfman-agent:latest and bpfmanOperatorImage=quay.io/bpfman/bpfman-operator:latest
INFO: creating a new kind cluster
...
```