### PR TITLE
Fix FromAsCasing warnings in container files

### DIFF
--- a/Containerfile.bpfman-agent
+++ b/Containerfile.bpfman-agent
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 as bpfman-agent-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-agent-build
 
 # The following ARGs are set internally by docker/build-push-action in github actions
 ARG TARGETOS

--- a/Containerfile.bpfman-operator
+++ b/Containerfile.bpfman-operator
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 as bpfman-operator-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-operator-build
 
 ARG BUILDPLATFORM
 


### PR DESCRIPTION
This commit addresses the FromAsCasing warnings issued by Docker during the build process by ensuring that 'as' is converted to 'AS' in the FROM directives.

Warnings observed:
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)

Reference: https://docs.docker.com/reference/build-checks/from-as-casing/