### PR TITLE
Makefile: Disable test caching by using go test -count=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,12 +285,11 @@ test: fmt envtest ## Run Unit tests.
 
 .PHONY: test-integration
 test-integration: ## Run Integration tests.
-	go clean -testcache
 	cd config/bpfman-deployment && \
 	  $(SED) -e 's@bpfman\.image=.*@bpfman.image=$(BPFMAN_IMG)@' \
 	      -e 's@bpfman\.agent\.image=.*@bpfman.agent.image=$(BPFMAN_AGENT_IMG)@' \
 		  kustomization.yaml.env > kustomization.yaml
-	GOFLAGS="-tags=integration_tests" go test -race -v ./test/integration/...
+	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration/...
 
 ## The physical bundle is no longer tracked in git since it should be considered
 ## and treated as a release artifact, rather than something that's updated


### PR DESCRIPTION
The test-integration Make target clears the entire Go test cache, which is overly aggressive, especially when running `go test ./...` in other projects, causing all tests to re-run in those other projects after running the integration tests.

Instead, use the idiomatic -count=1 flag to explicitly disable test caching.

This idiom is mentioned in the documentation [1]: "The idiomatic way to disable test caching explicitly is to use -count=1."

[1] https://pkg.go.dev/cmd/go#hdr-Test_packages