### PR TITLE
Enable Integration Tests to Use Podman-Built Images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ SHELL = /usr/bin/env bash -o pipefail
 # Image building tool (docker / podman) - docker is preferred in CI
 OCI_BIN_PATH := $(shell which docker 2>/dev/null || which podman)
 OCI_BIN ?= $(shell basename ${OCI_BIN_PATH})
+export OCI_BIN
 
 GOARCH ?= $(shell go env GOHOSTARCH)
 PLATFORM ?= $(shell go env GOHOSTOS)/$(shell go env GOHOSTARCH)
@@ -355,7 +356,7 @@ push-images: ## Push bpfman-agent and bpfman-operator images.
 
 .PHONY: load-images-kind
 load-images-kind: ## Load bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
-	kind load docker-image ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG} --name ${KIND_CLUSTER_NAME}
+	./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG}
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/hack/kind-load-image.sh
+++ b/hack/kind-load-image.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Load container images into a specified kind (Kubernetes IN Docker)
+# cluster. Save images from either Docker or Podman, depending on the
+# OCI_BIN environment variable. Defaults to Docker if OCI_BIN is not
+# set.
+#
+# Usage:
+#   ./kind-load-image.sh [-v] <KIND-CLUSTER-NAME> <IMAGE-REFERENCE> [<IMAGE-REFERENCE> ...]
+#
+# Arguments:
+#   -v                 Verbose mode; echo commands before executing them.
+#   KIND-CLUSTER-NAME  Specify the name of the kind cluster.
+#   IMAGE-REFERENCE    Specify one or more image references
+#                      (e.g., quay.io/bpfman/bpfman:latest).
+#
+# Example:
+#   ./kind-load-image.sh -v my-cluster quay.io/bpfman/bpfman:latest quay.io/bpfman/bpfman-operator:latest
+#
+# The script:
+#   1. Save each specified image as a tar file using the specified
+#      OCI_BIN (Docker or Podman).
+#   2. Load each tar file into the specified kind cluster.
+#   3. Clean up temporary files created during the process.
+#
+# Ensure that the specified kind cluster is already running before
+# executing the script.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Parse options
+verbose=0
+if [ "$1" = "-v" ]; then
+    verbose=1
+    shift
+fi
+
+if [ $# -lt 2 ]; then
+    echo "Usage: ${0##*/} [-v] <KIND_CLUSTER_NAME> <IMAGE REFERENCE> [<IMAGE REFERENCE> ...]"
+    exit 1
+fi
+
+kind_cluster_name="$1"
+shift
+
+: "${OCI_BIN:=docker}"
+
+tmp_dir=$(mktemp -d -t bpfman-XXXXXX)
+
+cleanup() {
+    rm -r "$tmp_dir"
+}
+
+trap cleanup EXIT
+
+save_args=""
+if [ "$OCI_BIN" = "podman" ]; then
+    save_args="--quiet"
+fi
+
+counter=1
+for image_reference in "$@"; do
+    tar_file="$tmp_dir/image-$counter.tar"
+
+    if [ $verbose -eq 1 ]; then
+        echo "$OCI_BIN save $save_args --output \"$tar_file\" \"$image_reference\""
+    fi
+    "$OCI_BIN" save $save_args --output "$tar_file" "$image_reference"
+
+    if [ $verbose -eq 1 ]; then
+        echo "kind load image-archive --name \"$kind_cluster_name\" \"$tar_file\""
+    fi
+    kind load image-archive --name "$kind_cluster_name" "$tar_file"
+
+    counter=$((counter + 1))
+done

--- a/test/integration/loadimagearchive/addon.go
+++ b/test/integration/loadimagearchive/addon.go
@@ -1,0 +1,81 @@
+//go:build integration_tests
+// +build integration_tests
+
+package loadimagearchive
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
+)
+
+// -----------------------------------------------------------------------------
+// LoadImageArchive Addon
+// -----------------------------------------------------------------------------
+
+const (
+	// AddonName indicates the unique name of this addon.
+	AddonName clusters.AddonName = "loadimagearchive"
+)
+
+type Addon struct {
+	images []string
+	ociBin string
+	loaded bool
+}
+
+func New(ociBin string) clusters.Addon {
+	return &Addon{ociBin: ociBin}
+}
+
+// -----------------------------------------------------------------------------
+// LoadImageArchive Addon - Addon Implementation
+// -----------------------------------------------------------------------------
+
+func (a *Addon) Name() clusters.AddonName {
+	return AddonName
+}
+
+func (a *Addon) Dependencies(_ context.Context, _ clusters.Cluster) []clusters.AddonName {
+	return nil
+}
+
+func (a *Addon) Deploy(ctx context.Context, cluster clusters.Cluster) error {
+	switch ctype := cluster.Type(); ctype {
+	case kind.KindClusterType:
+		if err := a.loadIntoKind(ctx, cluster); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("loadimagearchive addon is not supported by cluster type '%v'", cluster.Type())
+	}
+
+	return nil
+}
+
+func (a *Addon) Delete(_ context.Context, cluster clusters.Cluster) error {
+	switch ctype := cluster.Type(); ctype {
+	case kind.KindClusterType:
+		// per https://github.com/kubernetes-sigs/kind/issues/658 this is basically impossible
+		// we lie here, because we want to mask this error. not deleting an image from KIND is benign:
+		// you either don't use it after (in which case you shouldn't care that it's still present) or
+		// load another image with the same name (in which case the name will point to the new image)
+		return nil
+	default:
+		return fmt.Errorf("loadimagearchive addon is not supported by cluster type '%v'", cluster.Type())
+	}
+}
+
+func (a *Addon) Ready(context.Context, clusters.Cluster) ([]runtime.Object, bool, error) {
+	// no way to verify this, we rely on Deploy's cmd.Run() not failing
+	return nil, a.loaded, nil
+}
+
+func (a *Addon) DumpDiagnostics(context.Context, clusters.Cluster) (map[string][]byte, error) {
+	diagnostics := make(map[string][]byte)
+	return diagnostics, nil
+}

--- a/test/integration/loadimagearchive/builder.go
+++ b/test/integration/loadimagearchive/builder.go
@@ -1,0 +1,35 @@
+//go:build integration_tests
+// +build integration_tests
+
+package loadimagearchive
+
+import "errors"
+
+// -----------------------------------------------------------------------------
+// LoadImageArchive Addon - Builder
+// -----------------------------------------------------------------------------
+
+type Builder struct {
+	images []string
+	ociBin string
+}
+
+func NewBuilder(ociBin string) *Builder {
+	return &Builder{ociBin: ociBin}
+}
+
+func (b *Builder) WithImage(image string) (*Builder, error) {
+	if len(image) == 0 {
+		return nil, errors.New("no image provided")
+	}
+	b.images = append(b.images, image)
+	return b, nil
+}
+
+func (b *Builder) Build() *Addon {
+	return &Addon{
+		images: b.images,
+		ociBin: b.ociBin,
+		loaded: false,
+	}
+}

--- a/test/integration/loadimagearchive/cluster_implementations.go
+++ b/test/integration/loadimagearchive/cluster_implementations.go
@@ -1,0 +1,78 @@
+//go:build integration_tests
+// +build integration_tests
+
+// Package loadimagearchive extends the functionality of kind clusters
+// to load OCI images using either Podman or Docker. Unlike the
+// standard kind command which is limited to Docker through `kind load
+// docker-image`, this add-on supports both systems by saving images
+// as tarballs and then using the `kind load image-archive` command.
+package loadimagearchive
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+)
+
+// loadIntoKind orchestrates the loading of OCI images into a Kind
+// cluster by creating temporary tarballs and loading them.
+func (a *Addon) loadIntoKind(ctx context.Context, cluster clusters.Cluster) error {
+	if len(a.images) == 0 {
+		return fmt.Errorf("no images provided")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "kind-image-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	for i, image := range a.images {
+		tarballPath := filepath.Join(tmpDir, fmt.Sprintf("image%d.tar", i+1))
+		if err := saveImage(a.ociBin, image, tarballPath); err != nil {
+			return err
+		}
+		if err := loadImageToKind(ctx, cluster, tarballPath); err != nil {
+			return err
+		}
+		a.loaded = true
+	}
+
+	return nil
+}
+
+// loadImageToKind loads a single image tarball into the Kind cluster.
+func loadImageToKind(ctx context.Context, cluster clusters.Cluster, tarballPath string) error {
+	loadArgs := []string{"load", "image-archive", "--name", cluster.Name(), tarballPath}
+	cmd := exec.CommandContext(ctx, "kind", loadArgs...)
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", stderr.String(), err)
+	}
+
+	return nil
+}
+
+// saveImage saves a specified OCI image as a tarball at the given
+// path.
+func saveImage(ociBin, imageName, tarballPath string) error {
+	saveCmd := exec.Command(ociBin, "save", "-o", tarballPath, imageName)
+	stderr := &bytes.Buffer{}
+	saveCmd.Stdout = io.Discard
+	saveCmd.Stderr = stderr
+
+	if err := saveCmd.Run(); err != nil {
+		return fmt.Errorf("'%v save -o %v %v': %s: %w", ociBin, tarballPath, imageName, stderr.String(), err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/bpfman/bpfman-operator/issues/96.

#### Summary

This PR ensures that the value of `OCI_BIN` now determines whether images are loaded from Podman or Docker during integration tests, addressing the issue detailed in [Integration Tests Not Using Podman-Built Images](#96). The key updates include:

- **Addition of the `loadimagearchive` Addon**: A new addon, `loadimagearchive`, has been created by adapting the existing [github.com/kong/kubernetes-testing-framework/pkg/clusters/addons/loadimage addon.](https://github.com/Kong/kubernetes-testing-framework/tree/main/pkg/clusters/addons/loadimage) This new addon supports both Docker and Podman by saving images as tarballs and loading them into kind clusters using the `kind load image-archive` command. The addon determines which container engine to use based on the value of the `OCI_BIN` environment variable, ensuring that the correct images are loaded into the cluster.

- **Makefile Updates**: The `load-images-kind` target now respects the value of `OCI_BIN` and has been reworked to load images via `kind load image-archive`, similar to the new addon. This change ensures that images corresponding to the specified `OCI_BIN` (either Docker or Podman) are correctly loaded into the kind cluster.

- **Integration Test Suite**: The test suite has been updated to use the new `loadimagearchive` addon.