### PR TITLE
Change Andrew's email back to redhat

### DIFF
--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -1146,7 +1146,7 @@ spec:
   - name: bpfman website
     url: https://bpfman.io/
   maintainers:
-  - email: astoycos@gmail.com
+  - email: astoycos@redhat.com
     name: Andrew Stoycos
   - email: afredette@redhat.com
     name: Andre Fredette

--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -482,7 +482,7 @@ properties:
     - name: bpfman website
       url: https://bpfman.io/
     maintainers:
-    - email: astoycos@gmail.com
+    - email: astoycos@redhat.com
       name: Andrew Stoycos
     - email: afredette@redhat.com
       name: Andre Fredette

--- a/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -429,7 +429,7 @@ spec:
     - name: bpfman website
       url: https://bpfman.io/
   maintainers:
-    - email: astoycos@gmail.com
+    - email: astoycos@redhat.com
       name: Andrew Stoycos
     - email: afredette@redhat.com
       name: Andre Fredette


### PR DESCRIPTION
This is a temporary fix to work around the following Konflux error:

"The optional \\\"maintainer\\\" label is missing. Label description: The name and email of the maintainer (usually the submitter). Should contain `@redhat.com` or `Red Hat`.\"