### PR TITLE
Makefile: Ensure ${BPFMAN_IMG} is loaded into KIND cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,8 +354,8 @@ push-images: ## Push bpfman-agent and bpfman-operator images.
 	$(OCI_BIN) push ${BPFMAN_IMG}
 
 .PHONY: load-images-kind
-load-images-kind: ## Load bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
-	./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG}
+load-images-kind: ## Load bpfman, bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
+	./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG} ${BPFMAN_IMG}
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.


### PR DESCRIPTION
Fix an issue where the bpfman image referenced by `${BPFMAN_IMG}` is not
loaded into the Kind cluster when using `make run-on-kind`. This
resulted in Kubernetes pulling the image from quay.io, even if a locally
built version with the same tag exists.

Fixes: https://github.com/bpfman/bpfman-operator/issues/105.
