### PR TITLE
Revert automatic bpfman image loading into KIND cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,8 +354,8 @@ push-images: ## Push bpfman-agent and bpfman-operator images.
 	$(OCI_BIN) push ${BPFMAN_IMG}
 
 .PHONY: load-images-kind
-load-images-kind: ## Load bpfman, bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
-	./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG} ${BPFMAN_IMG}
+load-images-kind: ## Load bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
+	./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG}
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -354,29 +354,8 @@ push-images: ## Push bpfman-agent and bpfman-operator images.
 	$(OCI_BIN) push ${BPFMAN_IMG}
 
 .PHONY: load-images-kind
-# Function to check if an image exists locally using podman or docker.
-image_exists = \
-  if [ "$(OCI_BIN)" = "podman" ]; then \
-    podman image exists $(1); \
-  elif [ "$(OCI_BIN)" = "docker" ]; then \
-    docker image inspect $(1) > /dev/null 2>&1; \
-  else \
-    echo "Unsupported OCI_BIN value: $(OCI_BIN). Use 'podman' or 'docker'."; \
-    exit 1; \
-  fi
-
-.PHONY: load-images-kind
 load-images-kind: ## Load bpfman, bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
-	@set -e; \
-	images="$$BPFMAN_OPERATOR_IMG $$BPFMAN_AGENT_IMG $$BPFMAN_IMG"; \
-	for img in $$images; do \
-	  if $(call image_exists,$$img); then \
-	    echo "Loading image $$img into kind cluster ${KIND_CLUSTER_NAME}"; \
-	    ./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} $$img; \
-	  else \
-	    echo "Image $$img does not exist locally, skipping."; \
-	  fi; \
-	done
+	./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG} ${BPFMAN_IMG}
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.


### PR DESCRIPTION
Previously, the Makefile was modified to load the bpfman image
unconditionally into the KIND cluster. This commit reverts that
change. To load the bpfman image into the KIND cluster, use the
`./hack/kind-load-image.sh` script as a discrete step.

For example:
```sh

$ export BPFMAN_IMG=docker.io/library/bpfman:latest

$ cd bpfman
$ docker build -f Containerfile.bpfman.local -t $BPFMAN_IMG . 

$ cd bpfman-operator
$ make run-on-kind

# Note the current image.
$ echo "$(kubectl get -n bpfman daemonsets.apps bpfman-daemon -o jsonpath='{.spec.template.spec.containers[?(@.name=="bpfman")].image}')"
quay.io/bpfman/bpfman:latest

$ ./hack/kind-load-image.sh -v bpfman-deployment $BPFMAN_IMG
docker save  --output "/tmp/bpfman-5G4T1G/image-1.tar" "docker.io/library/bpfman:latest"
kind load image-archive --name "bpfman-deployment" "/tmp/bpfman-5G4T1G/image-1.tar"

$ kubectl set image -n bpfman daemonset/bpfman-daemon bpfman=$BPFMAN_IMG
daemonset.apps/bpfman-daemon image updated

$ kubectl rollout status -n bpfman daemonset/bpfman-daemon
daemon set "bpfman-daemon" successfully rolled out

# Verify that we are running the new image.
$ echo "$(kubectl get -n bpfman daemonsets.apps bpfman-daemon -o jsonpath='{.spec.template.spec.containers[?(@.name=="bpfman")].image}')"
docker.io/library/bpfman:latest

# Notice the two bpfman images we now have in the KIND cluster
$ docker exec -it bpfman-deployment-control-plane /bin/bash
root@bpfman-deployment-control-plane:/# crictl images | grep bpfman
docker.io/library/bpfman-agent                  latest               b61f99a39fca8       501MB
docker.io/library/bpfman-operator               latest               521c4ad502091       180MB
docker.io/library/bpfman                        latest               b16a909169931       405MB
quay.io/bpfman/bpfman                           latest               b13146c64b45f       56.2MB
quay.io/bpfman/csi-node-driver-registrar        v2.9.0               50013f94a28d1       10.6MB
```

This reverts:
- https://github.com/bpfman/bpfman-operator/pull/106
- https://github.com/bpfman/bpfman-operator/pull/111

