### PR TITLE
Fix BUILDPLATFORM redefinition issue in some Containerfiles

### DIFF
--- a/Containerfile.bpfman-agent
+++ b/Containerfile.bpfman-agent
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG BUILDPLATFORM=linux/amd64
+ARG BUILDPLATFORM
 
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-agent-build
 
@@ -7,6 +7,8 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-agent-bui
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
+
+ARG BUILDPLATFORM
 
 RUN echo "TARGETOS=${TARGETOS}  TARGETARCH=${TARGETARCH}  BUILDPLATFORM=${BUILDPLATFORM}  TARGETPLATFORM=${TARGETPLATFORM}"
 

--- a/Containerfile.bpfman-agent.openshift
+++ b/Containerfile.bpfman-agent.openshift
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG BUILDPLATFORM=linux/amd64
+ARG BUILDPLATFORM
 
 FROM --platform=$BUILDPLATFORM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22.5-202407301806.g4c8b32d.el9 AS bpfman-agent-build
 
@@ -7,6 +7,8 @@ FROM --platform=$BUILDPLATFORM brew.registry.redhat.io/rh-osbs/openshift-golang-
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
+
+ARG BUILDPLATFORM
 
 RUN echo "TARGETOS=${TARGETOS}  TARGETARCH=${TARGETARCH}  BUILDPLATFORM=${BUILDPLATFORM}  TARGETPLATFORM=${TARGETPLATFORM}"
 

--- a/Containerfile.bpfman-operator
+++ b/Containerfile.bpfman-operator
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG BUILDPLATFORM=linux/amd64
+ARG BUILDPLATFORM
 
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-operator-build
 

--- a/Containerfile.bpfman-operator.openshift
+++ b/Containerfile.bpfman-operator.openshift
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG BUILDPLATFORM=linux/amd64
+ARG BUILDPLATFORM
 
 FROM --platform=$BUILDPLATFORM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22.5-202407301806.g4c8b32d.el9 AS bpfman-operator-build
 


### PR DESCRIPTION
Removed the hardcoded `ARG BUILDPLATFORM=linux/amd64` from
`Containerfile.bpfman-agent{.openshift}` and `Containerfile.bpfman-operator{.openshift}`.

This change addresses an issue where Podman fails to build the images if
`BUILDPLATFORM` is redefined. By removing the redefinition, the build
process is made compatible with Podman.

This change remains compatible with Docker, which is more lenient with
ARG redefinitions.

I didn't bisect which version of Podman made this a failure; it doesn't occur with:

```sh
% podman version
Client:       Podman Engine
Version:      5.0.3
API Version:  5.0.3
Go Version:   go1.22.5
Built:        Tue Jan  1 00:00:00 1980
OS/Arch:      linux/amd64
```

but does with:

```sh
% podman version
Client:       Podman Engine
Version:      5.2.2
API Version:  5.2.2
Go Version:   go1.22.6
Built:        Wed Aug 21 01:00:00 2024
OS/Arch:      linux/amd64
```

Fixes: https://github.com/bpfman/bpfman-operator/issues/120

