### PR TITLE
ci: add Podman validation to the build-images step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -78,11 +78,12 @@ jobs:
         git diff --exit-code -I'^    createdAt: ' bundle
 
   kubernetes-integration-tests:
-    name: Kubernetes Integration Tests (Go ${{ matrix.go }} - amd64)
+    name: Kubernetes Integration Tests (Go ${{ matrix.go }} - amd64 - ${{ matrix.oci_bin }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go: ['1.22']
+        oci_bin: ['docker', 'podman']
     env:
       BPFMAN_AGENT_IMG: quay.io/bpfman/bpfman-agent:int-test
       BPFMAN_OPERATOR_IMG: quay.io/bpfman/bpfman-operator:int-test
@@ -120,11 +121,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build Operator and Agent images
+      - name: Install OCI runtime (Docker or Podman)
         run: |
-          make build-images
+          if [ "${{ matrix.oci_bin }}" = "podman" ]; then
+            sudo apt-get update && sudo apt-get install -y podman
+          fi
 
+      - name: Build Operator and Agent images with ${{ matrix.oci_bin }}
+        run: |
+          make OCI_BIN=${{ matrix.oci_bin }} build-images
+
+      # Run integration tests only if OCI_BIN is Docker.
       - name: Run integration tests
+        if: ${{ matrix.oci_bin == 'docker' }}
         run: |
           make test-integration
 


### PR DESCRIPTION
Introduce a matrix in the Kubernetes integration tests job to support both Docker and Podman for image builds. Add `oci_bin` as a matrix entry to control which container runtime is used. Conditionally install Podman when required and build images using the appropriate runtime.

Ensure that integration tests only run with Docker by skipping them when Podman is used, avoiding unnecessary test runs. This change ensures Podman compatibility for image builds while keeping the test process the same for Docker.
