### PR TITLE
ci: make sure BUILDPLATFORM is set in github actions

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -94,7 +94,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ matrix.image.dockerfile }}
-          build-args: ${{ matrix.image.build_args }}
+          build-args: BUILDPLATFORM=linux/amd64
           context: ${{ matrix.image.context }}
 
       - name: Sign the images with GitHub OIDC Token
@@ -160,7 +160,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           containerfiles: ${{ matrix.image.dockerfile }}
-          build-args: ${{ matrix.image.build_args }}
+          build-args: BUILDPLATFORM=linux/amd64
           context: ${{ matrix.image.context }}
 
       - name: Push to registry


### PR DESCRIPTION
#121 removed the BUILDPLATFORM initialization from the Containerfiles.* (ARG BUILDPLATFORM=linux/amd64 -> ARG BUILDPLATFORM). The bpfman-operator Makefile sets that ARG manually, but it wasn't being set in the github actions. This PR adds BUILDPLATFORM to build-arg parameter passed to the docker github action.