### PR TITLE
Add missing summary label to agent to avoid release violation

### DIFF
--- a/Containerfile.bpfman-agent.openshift
+++ b/Containerfile.bpfman-agent.openshift
@@ -44,6 +44,7 @@ RUN ${DNF_CMD} -y clean all
 LABEL name="bpfman/bpfman-agent" \
       com.redhat.component="bpfman-agent" \
       io.k8s.display-name="Bpfman Agent" \
+      summary="Bpfman agent manages the eBPF programs lifecycle." \
       description="The bpfman-agent manage bpfman ebpf programs on every node." \
       io.k8s.description="The bpfman-agent manage bpfman programs on every node. ." \
       io.openshift.tags="bpfman-agent" \


### PR DESCRIPTION
```sh
[Violation] labels.disallowed_inherited_labels
  ImageRef: quay.io/redhat-user-workloads/ocp-bpfman-tenant/bpfman-operator/bpfman-agent@sha256:6cb0b82fab5ef68da54a52a7a4f35e228a364e387a7a7f8dbb6b2ce79ab14d01
  Reason: The "summary" label should not be inherited from the parent image
  Title: Disallowed inherited labels
  Description: Check that certain labels on the image have different values than the labels from the parent image. If the label is
  inherited from the parent image but not redefined for the image, it will contain an incorrect value for the image. Use the rule
  data `disallowed_inherited_labels` key to set the list of labels to check, or the `fbc_disallowed_inherited_labels` key for fbc
  images. To exclude this rule add "labels.disallowed_inherited_labels:summary" to the `exclude` section of the policy
  configuration.
  Solution: Update the image build process to overwrite the inherited labels.
```