### PR TITLE
ci: run image-build.yaml when Containerfiles are updated

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -1,4 +1,4 @@
-name: bpfman-image-build
+name: operator-image-build
 
 on: # yamllint disable-line rule:truthy
   push:
@@ -7,7 +7,10 @@ on: # yamllint disable-line rule:truthy
       - v*
 
   pull_request:
-    paths: [.github/workflows/image-build.yaml]
+    paths:
+      - .github/workflows/image-build.yaml
+      - Containerfile.bpfman-agent
+      - Containerfile.bpfman-operator
 
 jobs:
   build-and-push-images:


### PR DESCRIPTION
Currently, image-build.yaml, which is used to build and push all related container images to quay.io, is run when PR is merged or a PR is updated and image-build.yaml file itself is modified. A new rule needs to be added such that image-build.yaml is run when a PR is updated and one of the Containerfile files is modified.