### PR TITLE
base clusterserviceversion updates

### DIFF
--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -295,8 +295,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: OpenShift Optional
-    containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
-    createdAt: "2024-10-10T19:42:33Z"
+    containerImage: quay.io/bpfman/bpfman-operator:latest
+    createdAt: "2024-10-15T17:00:13Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -399,8 +399,8 @@ spec:
     `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`:
     the log level for the bpfman-agent currently supports `info`, `debug`, and `trace`
     \n\nThe bpfman operator deploys eBPF programs via CRDs. The following CRDs are
-    currently available, \n\n- XdpProgram\n- TcProgram\n- TracepointProgram\n- KprobeProgram\n-
-    UprobeProgram\n- FentryProgram\n- FexitProgram\n\n## More information\n\nPlease
+    currently available, \n\n- BpfApplication\n- XdpProgram\n- TcProgram\n - TracepointProgram\n-
+    KprobeProgram\n- UprobeProgram\n- FentryProgram\n- FexitProgram\n\n ## More information\n\nPlease
     checkout the [bpfman community website](https://bpfman.io/) for more information."
   displayName: Bpfman Operator
   icon:

--- a/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: "[]"
     categories: OpenShift Optional
     capabilities: Basic Install
-    containerImage: quay.io/bpfman/bpfman-operator:v0.0.0
+    containerImage: quay.io/bpfman/bpfman-operator:latest
     repository: https://github.com/bpfman/bpfman
     operatorframework.io/suggested-namespace: bpfman
     operatorframework.io/suggested-namespace-template: |-
@@ -101,13 +101,15 @@ spec:
     Configuration\n\nThe `bpfman-config` configmap is automatically created in the `bpfman`
     namespace and used to configure the bpfman deployment.\n\nTo edit the config simply
     run\n\n```bash\nkubectl edit cm bpfman-config\n```\n\nThe following fields are adjustable\n\n-
-    `bpfman.agent.image`: The image used for the bpfman-agent`\n-
-    `bpfman.image`: The image used for bpfman`\n-
-    `bpfman.log.level`: the log level for bpfman, currently supports
-    `debug`, `info`, `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`: the log level for the bpfman-agent currently supports `info`, `debug`, and `trace` \n\nThe bpfman operator
-    deploys eBPF programs via CRDs. The following CRDs are currently available, \n\n-
-    XdpProgram\n- TcProgram\n- TracepointProgram\n- KprobeProgram\n- UprobeProgram\n- FentryProgram\n- FexitProgram\n\n## More information\n\nPlease
-    checkout the [bpfman community website](https://bpfman.io/) for more information."
+    `bpfman.agent.image`: The image used for the bpfman-agent`\n- `bpfman.image`: The 
+    image used for bpfman`\n- `bpfman.log.level`: the log level for bpfman, currently 
+    supports `debug`, `info`, `warn`, `error`, and `fatal`, defaults to `info`\n- 
+    `bpfman.agent.log.level`: the log level for the bpfman-agent currently supports 
+    `info`, `debug`, and `trace` \n\nThe bpfman operator deploys eBPF programs via CRDs. 
+    The following CRDs are currently available, \n\n- BpfApplication\n- XdpProgram\n- TcProgram\n
+    - TracepointProgram\n- KprobeProgram\n- UprobeProgram\n- FentryProgram\n- FexitProgram\n\n
+    ## More information\n\nPlease checkout the [bpfman community website](https://bpfman.io/) 
+    for more information."
   displayName: Bpfman Operator
   icon:
     - base64data: |


### PR DESCRIPTION
- Added BpfApplication to the list of CRDs in the operator description
- Changed default tag for containerImage: quay.io/bpfman/bpfman-operator from v0.0.0 to latest.
- Ran `make bundle`