### PR TITLE
OCPBUGS-42593: hardening service account automount

### DIFF
--- a/controllers/bpfman-operator/configmap.go
+++ b/controllers/bpfman-operator/configmap.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -321,6 +322,7 @@ func LoadAndConfigureBpfmanDs(config *corev1.ConfigMap, path string) *appsv1.Dae
 	staticBpfmanDeployment.Spec.Template.ObjectMeta.Annotations["bpfman.io.bpfman.agent.metricaddr"] = bpfmanMetricAddr
 	staticBpfmanDeployment.Name = internal.BpfmanDsName
 	staticBpfmanDeployment.Namespace = config.Namespace
+	staticBpfmanDeployment.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(true)
 	for cindex, container := range staticBpfmanDeployment.Spec.Template.Spec.Containers {
 		if container.Name == internal.BpfmanContainerName {
 			staticBpfmanDeployment.Spec.Template.Spec.Containers[cindex].Image = bpfmanImage


### PR DESCRIPTION
Address security warning about `automount service account token – set to FALSE`