### PR TITLE
logs: simplify the bpfman-agent logs

### DIFF
--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -307,7 +307,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:latest
-    createdAt: "2024-10-21T11:51:40Z"
+    createdAt: "2024-11-01T20:38:03Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -1102,7 +1102,7 @@ spec:
                 - /bpfman-operator
                 env:
                 - name: GO_LOG
-                  value: debug
+                  value: info
                 image: quay.io/bpfman/bpfman-operator:latest
                 imagePullPolicy: IfNotPresent
                 livenessProbe:

--- a/config/bpfman-operator-deployment/deployment.yaml
+++ b/config/bpfman-operator-deployment/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: GO_LOG
-              value: debug
+              value: info
           name: bpfman-operator
           securityContext:
             allowPrivilegeEscalation: false

--- a/controllers/bpfman-agent/fentry-program.go
+++ b/controllers/bpfman-agent/fentry-program.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -149,8 +148,7 @@ func (r *FentryProgramReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("fentry")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile Fentry: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: fentry", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/fexit-program.go
+++ b/controllers/bpfman-agent/fexit-program.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -149,8 +148,7 @@ func (r *FexitProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("fexit")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile Fexit: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: fexit", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/kprobe-program.go
+++ b/controllers/bpfman-agent/kprobe-program.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -149,8 +148,7 @@ func (r *KprobeProgramReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("kprobe")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile Kprobe: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: kprobe", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/tc-program.go
+++ b/controllers/bpfman-agent/tc-program.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -195,8 +194,7 @@ func (r *TcProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("tc")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile TC: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: TC", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/tcx-program.go
+++ b/controllers/bpfman-agent/tcx-program.go
@@ -19,6 +19,7 @@ package bpfmanagent
 import (
 	"context"
 	"fmt"
+
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	bpfmanagentinternal "github.com/bpfman/bpfman-operator/controllers/bpfman-agent/internal"
 	"github.com/bpfman/bpfman-operator/internal"
@@ -31,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -160,8 +160,7 @@ func (r *TcxProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("tcx")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile TCX: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: tcx", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/tracepoint-program.go
+++ b/controllers/bpfman-agent/tracepoint-program.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -150,8 +149,7 @@ func (r *TracepointProgramReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("tracept")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile Tracepoint: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: tracepoint", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/uprobe-program.go
+++ b/controllers/bpfman-agent/uprobe-program.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -233,8 +232,7 @@ func (r *UprobeProgramReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("uprobe")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile Uprobe: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: uprobe", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/xdp-program.go
+++ b/controllers/bpfman-agent/xdp-program.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -181,8 +180,7 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	r.ourNode = &v1.Node{}
 	r.Logger = ctrl.Log.WithName("xdp")
 
-	ctxLogger := log.FromContext(ctx)
-	ctxLogger.Info("Reconcile XDP: Enter", "ReconcileKey", req)
+	r.Logger.Info("bpfman-agent enter: XDP", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-operator/application-programs.go
+++ b/controllers/bpfman-operator/application-programs.go
@@ -28,7 +28,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
@@ -66,7 +65,8 @@ func (r *BpfApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("application")
+	r.Logger.Info("bpfman-operator enter: application", "Name", req.NamespacedName.Name)
 
 	appProgram := &bpfmaniov1alpha1.BpfApplication{}
 	if err := r.Get(ctx, req.NamespacedName, appProgram); err != nil {

--- a/controllers/bpfman-operator/configmap.go
+++ b/controllers/bpfman-operator/configmap.go
@@ -37,7 +37,6 @@ import (
 	osv1 "github.com/openshift/api/security/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/bpfman/bpfman-operator/internal"
 )
@@ -73,7 +72,7 @@ func (r *BpfmanConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *BpfmanConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("configMap")
 
 	bpfmanConfig := &corev1.ConfigMap{}
 	if err := r.Get(ctx, req.NamespacedName, bpfmanConfig); err != nil {

--- a/controllers/bpfman-operator/fentry-program.go
+++ b/controllers/bpfman-operator/fentry-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *FentryProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *FentryProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("fentry")
+	r.Logger.Info("bpfman-operator enter: fentry", "Name", req.NamespacedName.Name)
 
 	fentryProgram := &bpfmaniov1alpha1.FentryProgram{}
 	if err := r.Get(ctx, req.NamespacedName, fentryProgram); err != nil {

--- a/controllers/bpfman-operator/fexit-program.go
+++ b/controllers/bpfman-operator/fexit-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *FexitProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *FexitProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("fexit")
+	r.Logger.Info("bpfman-operator enter: fexit", "Name", req.NamespacedName.Name)
 
 	fexitProgram := &bpfmaniov1alpha1.FexitProgram{}
 	if err := r.Get(ctx, req.NamespacedName, fexitProgram); err != nil {

--- a/controllers/bpfman-operator/kprobe-program.go
+++ b/controllers/bpfman-operator/kprobe-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *KprobeProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *KprobeProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("kprobe")
+	r.Logger.Info("bpfman-operator enter: kprobe", "Name", req.NamespacedName.Name)
 
 	kprobeProgram := &bpfmaniov1alpha1.KprobeProgram{}
 	if err := r.Get(ctx, req.NamespacedName, kprobeProgram); err != nil {

--- a/controllers/bpfman-operator/tc-program.go
+++ b/controllers/bpfman-operator/tc-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *TcProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=bpfman.io,resources=tcprograms/finalizers,verbs=update
 
 func (r *TcProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("tc")
+	r.Logger.Info("bpfman-operator enter: tc", "Name", req.NamespacedName.Name)
 
 	tcProgram := &bpfmaniov1alpha1.TcProgram{}
 	if err := r.Get(ctx, req.NamespacedName, tcProgram); err != nil {

--- a/controllers/bpfman-operator/tcx-program.go
+++ b/controllers/bpfman-operator/tcx-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *TcxProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups=bpfman.io,resources=tcxprograms/finalizers,verbs=update
 
 func (r *TcxProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("tcx")
+	r.Logger.Info("bpfman-operator enter: tcx", "Name", req.NamespacedName.Name)
 
 	tcxProgram := &bpfmaniov1alpha1.TcxProgram{}
 	if err := r.Get(ctx, req.NamespacedName, tcxProgram); err != nil {

--- a/controllers/bpfman-operator/tracepoint-program.go
+++ b/controllers/bpfman-operator/tracepoint-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *TracepointProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *TracepointProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("tracepoint")
+	r.Logger.Info("bpfman-operator enter: tracepoint", "Name", req.NamespacedName.Name)
 
 	tracepointProgram := &bpfmaniov1alpha1.TracepointProgram{}
 	if err := r.Get(ctx, req.NamespacedName, tracepointProgram); err != nil {

--- a/controllers/bpfman-operator/uprobe-program.go
+++ b/controllers/bpfman-operator/uprobe-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *UprobeProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *UprobeProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("uprobe")
+	r.Logger.Info("bpfman-operator enter: uprobe", "Name", req.NamespacedName.Name)
 
 	uprobeProgram := &bpfmaniov1alpha1.UprobeProgram{}
 	if err := r.Get(ctx, req.NamespacedName, uprobeProgram); err != nil {

--- a/controllers/bpfman-operator/xdp-program.go
+++ b/controllers/bpfman-operator/xdp-program.go
@@ -27,7 +27,6 @@ import (
 	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
 	"github.com/bpfman/bpfman-operator/internal"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -61,7 +60,8 @@ func (r *XdpProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Logger = log.FromContext(ctx)
+	r.Logger = ctrl.Log.WithName("xdp")
+	r.Logger.Info("bpfman-operator enter: xdp", "Name", req.NamespacedName.Name)
 
 	xdpProgram := &bpfmaniov1alpha1.XdpProgram{}
 	if err := r.Get(ctx, req.NamespacedName, xdpProgram); err != nil {


### PR DESCRIPTION
As part of a security review which required extend logging behavior, investigated improving the logs. Moved the logs from using context, which prints a lot if useless info, to just using regular logs. Also changed the logging default from debug to info, and changed the level of some of the existing logs.