### PR TITLE
add xdp & tc image configuration example

### DIFF
--- a/config/bpfman-deployment/config.yaml
+++ b/config/bpfman-deployment/config.yaml
@@ -18,3 +18,6 @@ data:
     [database]
     max_retries = 30
     millisec_delay = 10000
+    [registry]
+    xdp_dispatcher_image = "quay.io/bpfman/xdp-dispatcher:latest"
+    tc_dispatcher_image = "quay.io/bpfman/tc-dispatcher:latest"


### PR DESCRIPTION
Requested in https://github.com/bpfman/bpfman-operator/issues/104

Tested via `make run-on-kind` with the following jq, yq, tomlq validation

```bash 
bpfman-operator git:(main) ✗ kubectl get cm -n bpfman bpfman-config -o json | jq '.data.["bpfman.toml"]' -r | tomlq . 
{
  "database": {
    "max_retries": 30,
    "millisec_delay": 10000
  },
  "registry": {
    "xdp_dispatcher_image": "quay.io/bpfman/xdp-dispatcher:latest",
    "tc_dispatcher_image": "quay.io/bpfman/tc-dispatcher:latest"
  }
}
```