### PR TITLE
interface's based hooks don't allow more than one function per intf per direction

### DIFF
--- a/controllers/bpfman-agent/application-program.go
+++ b/controllers/bpfman-agent/application-program.go
@@ -78,7 +78,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		for j, p := range a.Spec.Programs {
 			switch p.Type {
 			case bpfmaniov1alpha1.ProgTypeFentry:
-				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Fentry.FunctionName))
+				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Fentry.FunctionName), p.Fentry.BpfFunctionName)
 				fentryProgram := bpfmaniov1alpha1.FentryProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -100,7 +100,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				complete, res, err = r.reconcileCommon(ctx, rec, fentryObjects)
 
 			case bpfmaniov1alpha1.ProgTypeFexit:
-				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Fexit.FunctionName))
+				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Fexit.FunctionName), p.Fexit.BpfFunctionName)
 				fexitProgram := bpfmaniov1alpha1.FexitProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -123,7 +123,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 			case bpfmaniov1alpha1.ProgTypeKprobe,
 				bpfmaniov1alpha1.ProgTypeKretprobe:
-				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Kprobe.FunctionName))
+				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Kprobe.FunctionName), p.Kprobe.BpfFunctionName)
 				kprobeProgram := bpfmaniov1alpha1.KprobeProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -146,7 +146,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 			case bpfmaniov1alpha1.ProgTypeUprobe,
 				bpfmaniov1alpha1.ProgTypeUretprobe:
-				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Uprobe.FunctionName))
+				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Uprobe.FunctionName), p.Uprobe.BpfFunctionName)
 				uprobeProgram := bpfmaniov1alpha1.UprobeProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -168,7 +168,7 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				complete, res, err = r.reconcileCommon(ctx, rec, uprobeObjects)
 
 			case bpfmaniov1alpha1.ProgTypeTracepoint:
-				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), sanitize(p.Tracepoint.Names[0]))
+				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), p.Tracepoint.BpfFunctionName)
 				tracepointProgram := bpfmaniov1alpha1.TracepointProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -190,13 +190,13 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				complete, res, err = r.reconcileCommon(ctx, rec, tracepointObjects)
 
 			case bpfmaniov1alpha1.ProgTypeTC:
-				interfaces, ifErr := getInterfaces(&p.TC.InterfaceSelector, r.ourNode)
+				_, ifErr := getInterfaces(&p.TC.InterfaceSelector, r.ourNode)
 				if ifErr != nil {
 					ctxLogger.Error(ifErr, "failed to get interfaces for TC Program",
 						"app program name", a.Name, "program index", j)
 					continue
 				}
-				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), p.TC.Direction, interfaces[0])
+				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), p.TC.Direction, p.TC.BpfFunctionName)
 				tcProgram := bpfmaniov1alpha1.TcProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -218,13 +218,13 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				complete, res, err = r.reconcileCommon(ctx, rec, tcObjects)
 
 			case bpfmaniov1alpha1.ProgTypeTCX:
-				interfaces, ifErr := getInterfaces(&p.TCX.InterfaceSelector, r.ourNode)
+				_, ifErr := getInterfaces(&p.TCX.InterfaceSelector, r.ourNode)
 				if ifErr != nil {
 					ctxLogger.Error(ifErr, "failed to get interfaces for TCX Program",
 						"app program name", a.Name, "program index", j)
 					continue
 				}
-				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), p.TCX.Direction, interfaces[0])
+				appProgramId := fmt.Sprintf("%s-%s-%s", strings.ToLower(string(p.Type)), p.TCX.Direction, p.TCX.BpfFunctionName)
 				tcxProgram := bpfmaniov1alpha1.TcxProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),
@@ -246,13 +246,13 @@ func (r *BpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				complete, res, err = r.reconcileCommon(ctx, rec, tcxObjects)
 
 			case bpfmaniov1alpha1.ProgTypeXDP:
-				interfaces, ifErr := getInterfaces(&p.XDP.InterfaceSelector, r.ourNode)
+				_, ifErr := getInterfaces(&p.XDP.InterfaceSelector, r.ourNode)
 				if ifErr != nil {
 					ctxLogger.Error(ifErr, "failed to get interfaces for XDP Program",
 						"app program name", a.Name, "program index", j)
 					continue
 				}
-				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), interfaces[0])
+				appProgramId := fmt.Sprintf("%s-%s", strings.ToLower(string(p.Type)), p.XDP.BpfFunctionName)
 				xdpProgram := bpfmaniov1alpha1.XdpProgram{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   buildProgramName(a, p),

--- a/controllers/bpfman-agent/application-program_test.go
+++ b/controllers/bpfman-agent/application-program_test.go
@@ -36,14 +36,14 @@ func TestBpfApplicationControllerCreate(t *testing.T) {
 		// fentry program config
 		bpfFentryFunctionName = "fentry_test"
 		fentryFunctionName    = "do_unlinkat"
-		fentryAppProgramId    = fmt.Sprintf("%s-%s", "fentry", sanitize(fentryFunctionName))
+		fentryAppProgramId    = fmt.Sprintf("%s-%s-%s", "fentry", sanitize(fentryFunctionName), bpfFentryFunctionName)
 		fentryAttachPoint     = sanitize(fentryFunctionName)
 		fentryBpfProg         = &bpfmaniov1alpha1.BpfProgram{}
 		fentryFakeUID         = "ef71d42c-aa21-48e8-a697-82391d801a81"
 		// kprobe program config
 		bpfKprobeFunctionName       = "kprobe_test"
 		kprobeFunctionName          = "try_to_wake_up"
-		kprobeAppProgramId          = fmt.Sprintf("%s-%s", "kprobe", sanitize(kprobeFunctionName))
+		kprobeAppProgramId          = fmt.Sprintf("%s-%s-%s", "kprobe", sanitize(kprobeFunctionName), bpfKprobeFunctionName)
 		kprobeAttachPoint           = sanitize(kprobeFunctionName)
 		kprobeBpfProg               = &bpfmaniov1alpha1.BpfProgram{}
 		kprobeFakeUID               = "ef71d42c-aa21-48e8-a697-82391d801a82"


### PR DESCRIPTION
bpfman agent operator go into loop loading/unreloading the program incorrectly when more than on hook is used on the same interface for the same direction
for example this yaml will cause the issue to happen

```yaml
apiVersion: bpfman.io/v1alpha1
kind: BpfApplication
metadata:
  labels:
    app: netobserv
  name: netobserv
spec:
  bytecode:
    image:
      url: quay.io/bpfman-bytecode/netobserv:latest
  globaldata:
    enable_dns_tracking: AQ==
    enable_network_events_monitoring: AQ==
    enable_rtt: AQ==
    sampling: AQAAAA==
  nodeselector: {}
  programs:
  - tcx:
      bpffunctionname: tcx_ingress_flow_parse
      direction: ingress
      interfaceselector:
        interfaces:
        - eth0
      priority: 0
    type: TCX
  - tcx:
      bpffunctionname: tcx_egress_flow_parse
      direction: egress
      interfaceselector:
        interfaces:
        - eth0
      priority: 0
    type: TCX
  - tcx:
      bpffunctionname: tcx_ingress_pca_parse
      direction: ingress
      interfaceselector:
        interfaces:
        - eth0
      priority: 0
    type: TCX
  - tcx:
      bpffunctionname: tcx_egress_pca_parse
      direction: egress
      interfaceselector:
        interfaces:
        - eth0
      priority: 0
    type: TCX
  - fentry:
      bpffunctionname: tcp_rcv_fentry
      func_name: tcp_rcv_established
    type: Fentry
  - kprobe:
      bpffunctionname: tcp_rcv_kprobe
      func_name: tcp_rcv_established
      offset: 0
      retprobe: false
    type: Kprobe
  - kprobe:
      bpffunctionname: rh_network_events_monitoring
      func_name: rh_psample_sample_packet
      offset: 0
      retprobe: false
    type: Kprobe
  - tracepoint:
      bpffunctionname: kfree_skb
      names:
      - skb/kfree_skb
    type: Tracepoint
```

with the fix
```bash
oc get bpfprograms 
NAME                            TYPE          STATUS            AGE
netobserv-fentry-907b363d       application   bpfmanLoaded      4m59s
netobserv-kprobe-2d90081d       application   bpfmanNotLoaded   4m50s
netobserv-kprobe-edd1a87c       application   bpfmanLoaded      4m55s
netobserv-tcx-0889f5a3          application   bpfmanLoaded      5m9s
netobserv-tcx-1043c6aa          application   bpfmanLoaded      5m2s
netobserv-tcx-3c193941          application   bpfmanLoaded      5m19s
netobserv-tcx-e8296a2e          application   bpfmanLoaded      5m6s
netobserv-tracepoint-0adc0447   application   bpfmanLoaded      4m43s
```