### PR TITLE
update golang to 1.23 and build crictl from source

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ['1.22']
+        go: ['1.23']
         oci_bin: ['docker', 'podman']
     env:
       BPFMAN_AGENT_IMG: quay.io/bpfman/bpfman-agent:int-test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.22']
+        go: ['1.23']
         arch:
           - arch: amd64
             filename: linux-x86_64
@@ -60,7 +60,7 @@ jobs:
       run: make test
 
     - name: Archive Go code coverage results
-      if: ${{ matrix.arch.arch == 'amd64' && matrix.go == '1.22' }}
+      if: ${{ matrix.arch.arch == 'amd64' && matrix.go == '1.23' }}
       uses: actions/upload-artifact@v4
       with:
         name: coverage-go

--- a/Containerfile.bpfman-agent
+++ b/Containerfile.bpfman-agent
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-agent-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS bpfman-agent-build
 
 # The following ARGs are set internally by docker/build-push-action in github actions
 ARG TARGETOS
@@ -24,10 +24,30 @@ COPY . .
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-agent ./cmd/bpfman-agent/main.go
 
+
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS cri-tools-build
+# The following ARGs are set internally by docker/build-push-action in github actions
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETPLATFORM
+
+ARG BUILDPLATFORM
+
+RUN echo "TARGETOS=${TARGETOS}  TARGETARCH=${TARGETARCH}  BUILDPLATFORM=${BUILDPLATFORM}  TARGETPLATFORM=${TARGETPLATFORM}"
+
+WORKDIR /usr/src/cri-tools
+ARG CRI_REPO_URL=https://github.com/kubernetes-sigs/cri-tools
+ARG CRI_REPO_BRANCH=master
+
+RUN git clone --depth 1 --branch $CRI_REPO_BRANCH $CRI_REPO_URL .
+
+# Build
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} VERSION="latest" make
+RUN cp ./build/bin/${TARGETOS}/${TARGETARCH}/crictl .
+
 # Use the fedora minimal image to reduce the size of the final image but still
 # be able to easily install extra packages.
 FROM --platform=$TARGETPLATFORM quay.io/fedora/fedora-minimal
-ARG DNF_CMD="microdnf"
 
 # The full fedora image can be used for debugging purposes.  To use it, comment
 # out the FROM and ARG lines above and uncomment the FROM and ARG lines below.
@@ -41,11 +61,7 @@ WORKDIR /
 COPY --from=bpfman-agent-build /usr/src/bpfman-operator/bpfman-agent .
 
 # Install crictl
-RUN ${DNF_CMD} -y install wget tar gzip ca-certificates
-ARG VERSION="v1.31.0"
-RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${VERSION}/crictl-${VERSION}-linux-${TARGETARCH}.tar.gz
-RUN tar zxvf crictl-${VERSION}-linux-${TARGETARCH}.tar.gz -C /usr/local/bin
-RUN rm -f crictl-${VERSION}-linux-${TARGETARCH}.tar.gz
-RUN ${DNF_CMD} -y clean all
+COPY --from=cri-tools-build /usr/src/cri-tools/crictl /usr/local/bin
+RUN chmod +x /usr/local/bin/crictl
 
 ENTRYPOINT ["/bpfman-agent"]

--- a/Containerfile.bpfman-operator
+++ b/Containerfile.bpfman-operator
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 AS bpfman-operator-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS bpfman-operator-build
 
 ARG BUILDPLATFORM
 

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 OPERATOR_SDK_VERSION ?= v1.27.0
-GOLANGCI_LINT_VERSION = v1.53.3
+GOLANGCI_LINT_VERSION = v1.61.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize


### PR DESCRIPTION
bump go to 1.23 to reenable dependabot latest updates and cves fixes
and build crictl from source 