### PR TITLE
ci: upgrade upload-artifact action to v4 in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -60,7 +60,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Fixes: https://github.com/bpfman/bpfman-operator/issues/348.

Upgrade from actions/upload-artifact@v3-node20 (previously referenced as "v3.pre.node20" in the existing comment) to v4.

Determine the previous and v4 commit SHAs:
```sh
  $ git tag --contains 97a0fba1372883ab732affbe8f94b823f91727db
  v3-node20
  v3.2.0-node20
  v3.2.1-node20

  $ git ls-remote https://github.com/actions/upload-artifact.git refs/tags/v4
  65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08	refs/tags/v4
  $ git tag --contains 65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
  v4
  v4.6.0
```

Bump straight to v4 after reviewing the [migration documentation](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) because:

- The workflow uploads a single artefact once, so v4’s restriction on multiple uploads to the same name and its new merging behaviour do not affect our usage.

- The retention-days input remains unchanged in v4. While neither v3 nor v4 explicitly define a default in their action.yml, [GitHub’s documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) states that artifacts default to 90 days unless overridden in repository settings. Since v4 does not specify a new default, it continues using GitHub’s 90-day retention policy, as before.

- Hidden files are not relevant to this artefact, so their exclusion (introduced in v4.4) has no impact. Since v4.6.0 maintains this behaviour, upgrading does not introduce any changes affecting this workflow.

