### PR TITLE
update csi-node-driver-registrar container for multiarch

### DIFF
--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -140,7 +140,7 @@ spec:
             - mountPath: /etc/crictl.yaml
               name: host-crictl-config
         - name: node-driver-registrar
-          image: quay.io/bpfman/csi-node-driver-registrar:v2.9.0
+          image: quay.io/bpfman/csi-node-driver-registrar:v2.13.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:


### PR DESCRIPTION
The current quay.io/bpfman/csi-node-driver-registrar:v2.9.0 container image does not support multiarch. Update to v2.13.0, which is the latest and is a multiarch image.