### PR TITLE
remove dependency on security-profiles-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,9 @@ bundle: operator-sdk generate kustomize manifests ## Generate bundle manifests a
 	      -e 's@bpfman\.agent\.image=.*@bpfman.agent.image=$(BPFMAN_AGENT_IMG)@' \
 		  kustomization.yaml.env > kustomization.yaml
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	cp config/manifests/dependencies.yaml bundle/metadata/
+	# Temporarily remove the dependency on security-profiles-operator until issue is fixed
+	# https://github.com/kubernetes-sigs/security-profiles-operator/issues/2699
+	# cp config/manifests/dependencies.yaml bundle/metadata/
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: build-release-yamls

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -1,6 +1,0 @@
-dependencies:
-  - type: olm.gvk
-    value:
-      group: security-profiles-operator.x-k8s.io
-      kind: SelinuxProfile
-      version: v1alpha2


### PR DESCRIPTION
After deploying the selinux profile, the status on the Selinux Profile is “Pending”. security-profiles-operator is currently deployed in OpenShift by making it a dependency of bpfman-operator. As a result, the security-profiles-operator is deployed in the bpfman namespace. security-profiles-operator encounters issues with this because there are other daemonsets in the namespace. Short term, remove the dependency. security-profiles-operator is still required, it just won't be auto-installed.

Related: #331
Related: https://github.com/kubernetes-sigs/security-profiles-operator/issues/2699