### PR TITLE
fix some warnings in community-operators-prod

### DIFF
--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -619,7 +619,8 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:latest
-    createdAt: "2025-02-17T19:04:19Z"
+    createdAt: "2025-02-19T20:12:43Z"
+    description: The bpfman Operator is designed to manage eBPF programs for applications.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -653,6 +654,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/bpfman/bpfman
+    support: bpfman Community
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -1807,11 +1809,12 @@ spec:
   - name: bpfman website
     url: https://bpfman.io/
   maintainers:
-  - email: astoycos@redhat.com
-    name: Andrew Stoycos
   - email: afredette@redhat.com
     name: Andre Fredette
+  - email: mmahmoud@redhat.com
+    name: Mohamed Mahmoud
   maturity: alpha
+  minKubeVersion: 1.26.0
   provider:
     name: The bpfman Community
     url: https://bpfman.io/

--- a/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -6,7 +6,9 @@ metadata:
     categories: OpenShift Optional
     capabilities: Basic Install
     containerImage: quay.io/bpfman/bpfman-operator:latest
+    description: The bpfman Operator is designed to manage eBPF programs for applications.
     repository: https://github.com/bpfman/bpfman
+    support: bpfman Community
     operatorframework.io/suggested-namespace: bpfman
     operatorframework.io/suggested-namespace-template: |-
       {
@@ -468,11 +470,12 @@ spec:
     - name: bpfman website
       url: https://bpfman.io/
   maintainers:
-    - email: astoycos@redhat.com
-      name: Andrew Stoycos
     - email: afredette@redhat.com
       name: Andre Fredette
+    - email: mmahmoud@redhat.com
+      name: Mohamed Mahmoud
   maturity: alpha
+  minKubeVersion: 1.26.0
   provider:
     name: The bpfman Community
     url: https://bpfman.io/


### PR DESCRIPTION
Part of the release process includes pushing the bundle to community-operators-prod. There are several warnings that are generated during CI. This PR addresses some of the trivial fixes. There are still a few warnings not addressed.

See: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/6019