### PR TITLE
feat: add slack notification on failed integration tests

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -80,3 +80,10 @@ jobs:
           name: kubernetes-integration-test-diag
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
+
+      - name: Notify Slack on Test Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: "Nightly Kubernetes BPFMan Operator integration tests failed! Go version: ${{ matrix.go }} and OCI runtime: ${{ matrix.oci_bin }}"

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check disk space
         run: df -h
 
-      ## Upload diagnostics if integration test step failed.
+      # Upload diagnostics if integration test step failed.
       - name: Upload diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -81,9 +81,12 @@ jobs:
           path: /tmp/ktf-diag*
           if-no-files-found: ignore
 
+      # Push Notifications to Slack if integration test step failed 
       - name: Notify Slack on Test Failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: "Nightly Kubernetes BPFMan Operator integration tests failed! Go version: ${{ matrix.go }} and OCI runtime: ${{ matrix.oci_bin }}"
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            "Nightly Kubernetes bpfman Operator integration tests failed! Go version: ${{ matrix.go }} and OCI runtime: ${{ matrix.oci_bin }}"


### PR DESCRIPTION
Fixes #332 
Closes #332 

### Description
This PR adds the feature to give alerts on slack when the integration tests fails.

### TODO
@anfredette , we need to add a Github secret named `SLACK_WEBHOOK_URL` to enable the alerts.