### PR TITLE
Make sure changing bpfman configmap restart daemonset pods

### DIFF
--- a/controllers/bpfman-operator/configmap.go
+++ b/controllers/bpfman-operator/configmap.go
@@ -309,6 +309,7 @@ func LoadAndConfigureBpfmanDs(config *corev1.ConfigMap, path string) *appsv1.Dae
 	bpfmanAgentLogLevel := config.Data["bpfman.agent.log.level"]
 	bpfmanHealthProbeAddr := config.Data["bpfman.agent.healthprobe.addr"]
 	bpfmanMetricAddr := config.Data["bpfman.agent.metric.addr"]
+	bpfmanConfigs := config.Data["bpfman.toml"]
 
 	// Annotate the log level on the ds so we get automatic restarts on changes.
 	if staticBpfmanDeployment.Spec.Template.ObjectMeta.Annotations == nil {
@@ -319,6 +320,7 @@ func LoadAndConfigureBpfmanDs(config *corev1.ConfigMap, path string) *appsv1.Dae
 	staticBpfmanDeployment.Spec.Template.ObjectMeta.Annotations["bpfman.io.bpfman.agent.loglevel"] = bpfmanAgentLogLevel
 	staticBpfmanDeployment.Spec.Template.ObjectMeta.Annotations["bpfman.io.bpfman.agent.healthprobeaddr"] = bpfmanHealthProbeAddr
 	staticBpfmanDeployment.Spec.Template.ObjectMeta.Annotations["bpfman.io.bpfman.agent.metricaddr"] = bpfmanMetricAddr
+	staticBpfmanDeployment.Spec.Template.ObjectMeta.Annotations["bpfman.io.bpfman.toml"] = bpfmanConfigs
 	staticBpfmanDeployment.Name = internal.BpfmanDsName
 	staticBpfmanDeployment.Namespace = config.Namespace
 	staticBpfmanDeployment.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(true)


### PR DESCRIPTION
Editing bpfman configmap should restart daemonset pods for the configs to take effect

UT:
```sh

oc edit cm -n bpfman bpfman-config and change 
bpfman.toml: |
    [database]
    max_retries = 20 <<<
    millisec_delay = 10000
    
    
bpfman-operator-7d7559856-k8v2j   2/2     Running   0          23s
bpfman-daemon-vh4nb               3/3     Terminating   0          46s
bpfman-daemon-vh4nb               0/3     Terminating   0          46s
bpfman-daemon-vh4nb               0/3     Terminating   0          47s
bpfman-daemon-vh4nb               0/3     Terminating   0          47s
bpfman-daemon-29g6w               0/3     Pending       0          0s
bpfman-daemon-29g6w               0/3     Pending       0          0s
bpfman-daemon-29g6w               0/3     Init:0/1      0          0s
bpfman-daemon-29g6w               0/3     PodInitializing   0          1s
bpfman-daemon-29g6w               3/3     Running           0          2s
```