### PR TITLE
revert back to go1.23 and pin cri-tool to v1.32.0

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go: ["1.24"]
+        go: ["1.23"]
         oci_bin: ["docker", "podman"]
     env:
       BPFMAN_AGENT_IMG: quay.io/bpfman/bpfman-agent:int-test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.24"]
+        go: ["1.23"]
         arch:
           - arch: amd64
             filename: linux-x86_64
@@ -59,7 +59,7 @@ jobs:
         run: make test
 
       - name: Archive Go code coverage results
-        if: ${{ matrix.arch.arch == 'amd64' && matrix.go == '1.24' }}
+        if: ${{ matrix.arch.arch == 'amd64' && matrix.go == '1.23' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-go

--- a/Containerfile.bpfman-agent
+++ b/Containerfile.bpfman-agent
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24 AS bpfman-agent-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS bpfman-agent-build
 
 # The following ARGs are set internally by docker/build-push-action in github actions
 ARG TARGETOS
@@ -25,7 +25,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-agent ./cmd/bpfman-agent/main.go
 
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24 AS cri-tools-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS cri-tools-build
 # The following ARGs are set internally by docker/build-push-action in github actions
 ARG TARGETOS
 ARG TARGETARCH
@@ -37,12 +37,12 @@ RUN echo "TARGETOS=${TARGETOS}  TARGETARCH=${TARGETARCH}  BUILDPLATFORM=${BUILDP
 
 WORKDIR /usr/src/cri-tools
 ARG CRI_REPO_URL=https://github.com/kubernetes-sigs/cri-tools
-ARG CRI_REPO_BRANCH=master
+ARG CRI_REPO_TAG=v1.32.0
 
-RUN git clone --depth 1 --branch $CRI_REPO_BRANCH $CRI_REPO_URL .
+RUN git clone --depth 1 --branch $CRI_REPO_TAG $CRI_REPO_URL .
 
 # Build
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} VERSION="latest" make
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} VERSION=$CRI_REPO_TAG make
 RUN cp ./build/bin/${TARGETOS}/${TARGETARCH}/crictl .
 
 # Use the fedora minimal image to reduce the size of the final image but still

--- a/Containerfile.bpfman-operator
+++ b/Containerfile.bpfman-operator
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24 AS bpfman-operator-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS bpfman-operator-build
 
 ARG BUILDPLATFORM
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/bpfman/bpfman-operator
 
-go 1.24.0
+go 1.23.0
+
+toolchain go1.23.5
 
 require (
 	github.com/bpfman/bpfman v0.5.7-0.20250305151919-a74c631c3643
@@ -16,7 +18,6 @@ require (
 	k8s.io/client-go v0.32.2
 	k8s.io/code-generator v0.32.2
 	sigs.k8s.io/controller-runtime v0.20.2
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -32,6 +33,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 require (


### PR DESCRIPTION
this PR we have to pin cri-tool to version `v1.32.0` to avoid bump to go1.24