### PR TITLE
api review: update field descriptions

### DIFF
--- a/apis/v1alpha1/bpf_application_state_types.go
+++ b/apis/v1alpha1/bpf_application_state_types.go
@@ -83,31 +83,33 @@ type BpfApplicationProgramState struct {
 }
 
 type BpfApplicationStateStatus struct {
-	// updateCount is the number of times the BpfApplicationState has been updated.
-	// Set to 1 when the object is created, then it is incremented prior to each
-	// update. This is used to verify that the API server has the updated object
-	// prior to starting a new Reconcile operation.
+	// UpdateCount tracks the number of times the BpfApplicationState object has
+	// been updated. The bpfman agent initializes it to 1 when it creates the
+	// object, and then increments it before each subsequent update. It serves
+	// as a lightweight sequence number to verify that the API server is serving
+	// the most recent version of the object before beginning a new Reconcile
+	// operation.
 	UpdateCount int64 `json:"updateCount"`
 	// node is the name of the Kubernets node for this BpfApplicationState.
 	Node string `json:"node"`
 	// appLoadStatus reflects the status of loading the eBPF application on the
-	// given node. Whether or not the eBPF program is attached to an attachment
-	// point is tracked by the linkStatus field, which is under of each link of
-	// each program.
+	// given node.
 	//
 	// NotLoaded is a temporary state that is assigned when a
 	// ClusterBpfApplicationState is created and the initial reconcile is being
 	// processed.
 	//
-	// LoadSuccess is returned if all the programs have been loaded with no errors.
+	// LoadSuccess is returned if all the programs have been loaded with no
+	// errors.
 	//
-	// LoadError is returned if one or more programs encountered an error and were
-	// not loaded.
+	// LoadError is returned if one or more programs encountered an error and
+	// were not loaded.
 	//
 	// NotSelected is returned if this application did not select to run on this
 	// Kubernetes node.
 	//
-	// UnloadSuccess is returned when all the programs were successfully unloaded.
+	// UnloadSuccess is returned when all the programs were successfully
+	// unloaded.
 	//
 	// UnloadError is returned if one or more programs encountered an error when
 	// being unloaded.

--- a/apis/v1alpha1/bpf_application_state_types.go
+++ b/apis/v1alpha1/bpf_application_state_types.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// BpfApplicationProgramState defines the desired state of BpfApplication
 // +union
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'XDP' ?  has(self.xdp) : !has(self.xdp)",message="xdp configuration is required when type is xdp, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'TC' ?  has(self.tc) : !has(self.tc)",message="tc configuration is required when type is tc, and forbidden otherwise"
@@ -32,54 +31,96 @@ import (
 type BpfApplicationProgramState struct {
 	BpfProgramStateCommon `json:",inline"`
 
-	// type specifies the bpf program type
+	// type specifies the provisioned eBPF program type for this program entry.
+	// Type will be one of:
+	//   TC, TCX, UProbe, URetProbe, XDP
+	//
+	// When set to TC, the tc object will be populated with the eBPF program data
+	// associated with a TC program.
+	//
+	// When set to TCX, the tcx object will be populated with the eBPF program
+	// data associated with a TCX program.
+	//
+	// When set to UProbe, the uprobe object will be populated with the eBPF
+	// program data associated with a UProbe program.
+	//
+	// When set to URetProbe, the uretprobe object will be populated with the eBPF
+	// program data associated with a URetProbe program.
+	//
+	// When set to XDP, the xdp object will be populated with the eBPF program data
+	// associated with a URetProbe program.
 	// +unionDiscriminator
 	// +required
 	// +kubebuilder:validation:Enum:="XDP";"TC";"TCX";"UProbe";"URetProbe"
 	Type EBPFProgType `json:"type"`
 
-	// xdp defines the desired state of the application's XdpPrograms.
+	// xdp contains the attachment data for an XDP program when type is set to XDP.
 	// +unionMember
 	// +optional
 	XDP *XdpProgramInfoState `json:"xdp,omitempty"`
 
-	// tc defines the desired state of the application's TcPrograms.
+	// tc contains the attachment data for a TC program when type is set to TC.
 	// +unionMember
 	// +optional
 	TC *TcProgramInfoState `json:"tc,omitempty"`
 
-	// tcx defines the desired state of the application's TcxPrograms.
+	// tcx contains the attachment data for a TCX program when type is set to TCX.
 	// +unionMember
 	// +optional
 	TCX *TcxProgramInfoState `json:"tcx,omitempty"`
 
-	// uprobe defines the desired state of the application's UprobePrograms.
+	// uprobe contains the attachment data for a UProbe program when type is set to
+	// UProbe.
 	// +unionMember
 	// +optional
 	UProbe *UprobeProgramInfoState `json:"uprobe,omitempty"`
 
-	// uretprobe defines the desired state of the application's UretprobePrograms.
+	// uretprobe contains the attachment data for a URetProbe program when type is
+	// set to URetProbe.
 	// +unionMember
 	// +optional
 	URetProbe *UprobeProgramInfoState `json:"uretprobe,omitempty"`
 }
 
-// BpfApplicationStateStatus reflects the status of the BpfApplication on the given node
 type BpfApplicationStateStatus struct {
-	// updateCount is the number of times the BpfApplicationState has been updated. Set to 1
-	// when the object is created, then it is incremented prior to each update.
-	// This allows us to verify that the API server has the updated object prior
-	// to starting a new Reconcile operation.
+	// updateCount is the number of times the BpfApplicationState has been updated.
+	// Set to 1 when the object is created, then it is incremented prior to each
+	// update. This is used to verify that the API server has the updated object
+	// prior to starting a new Reconcile operation.
 	UpdateCount int64 `json:"updateCount"`
-	// node is the name of the node for this BpfApplicationStateSpec.
+	// node is the name of the Kubernets node for this BpfApplicationState.
 	Node string `json:"node"`
-	// appLoadStatus reflects the status of loading the bpf application on the
-	// given node.
+	// appLoadStatus reflects the status of loading the eBPF application on the
+	// given node. Whether or not the eBPF program is attached to an attachment
+	// point is tracked by the linkStatus field, which is under of each link of
+	// each program.
+	//
+	// NotLoaded is a temporary state that is assigned when a
+	// ClusterBpfApplicationState is created and the initial reconcile is being
+	// processed.
+	//
+	// LoadSuccess is returned if all the programs have been loaded with no errors.
+	//
+	// LoadError is returned if one or more programs encountered an error and were
+	// not loaded.
+	//
+	// NotSelected is returned if this application did not select to run on this
+	// Kubernetes node.
+	//
+	// UnloadSuccess is returned when all the programs were successfully unloaded.
+	//
+	// UnloadError is returned if one or more programs encountered an error when
+	// being unloaded.
 	AppLoadStatus AppLoadStatus `json:"appLoadStatus"`
-	// programs is a list of bpf programs contained in the parent application.
+	// programs is a list of eBPF programs contained in the parent BpfApplication
+	// instance. Each entry in the list contains the derived program attributes as
+	// well as the attach status for each program on the given Kubernetes node.
 	Programs []BpfApplicationProgramState `json:"programs,omitempty"`
-	// Conditions contains the overall status of the BpfApplicationState object
-	// on the given node.
+	// conditions contains the summary state of the BpfApplication for the given
+	// Kubernetes node. If one or more programs failed to load or attach to the
+	// designated attachment point, the condition will report the error. If more
+	// than one error has occurred, condition will contain the first error
+	// encountered.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -92,7 +133,10 @@ type BpfApplicationStateStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
 
-// BpfApplicationState contains the per-node state of a BpfApplication.
+// BpfApplicationState contains the state of a BpfApplication instance for a
+// given Kubernetes node. When a user creates a BpfApplication instance, bpfman
+// creates a BpfApplicationState instance for each node in a Kubernetes
+// cluster.
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=".status.node"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
@@ -100,6 +144,10 @@ type BpfApplicationState struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// status reflects the status of a BpfApplication instance for the given node.
+	// appLoadStatus and conditions provide an overall status for the given node,
+	// while each item in the programs list provides a per eBPF program status for
+	// the given node.
 	Status BpfApplicationStateStatus `json:"status,omitempty"`
 }
 

--- a/apis/v1alpha1/bpf_application_types.go
+++ b/apis/v1alpha1/bpf_application_types.go
@@ -38,9 +38,7 @@ type BpfApplicationProgram struct {
 	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
-	// type is a required field used to specify the type of the eBPF program. The
-	// type dictates which eBPF attachment point to use. This is where the eBPF
-	// program is executed.
+	// type is a required field used to specify the type of the eBPF program.
 	//
 	// Allowed values are:
 	//   TC, TCX, UProbe, URetProbe, XDP
@@ -175,8 +173,8 @@ type BpfApplicationSpec struct {
 // +kubebuilder:resource:scope=Namespaced
 
 // BpfApplication is the schema for the namespace scoped BPF Applications API.
-// Using this API allows applications to load one or more eBPF programs on a
-// Kubernetes cluster using bpfman to load the programs.
+// This API allows applications to use bpfman to load and attach one or more
+// eBPF programs on a Kubernetes cluster.
 //
 // The bpfApplication.status field reports the overall status of the
 // BpfApplication CRD. A given BpfApplication CRD can result in loading and

--- a/apis/v1alpha1/bpf_application_types.go
+++ b/apis/v1alpha1/bpf_application_types.go
@@ -28,52 +28,143 @@ import (
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'UProbe' ?  has(self.uprobe) : !has(self.uprobe)",message="uprobe configuration is required when type is uprobe, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'URetProbe' ?  has(self.uretprobe) : !has(self.uretprobe)",message="uretprobe configuration is required when type is uretprobe, and forbidden otherwise"
 type BpfApplicationProgram struct {
-	// name is the name of the function that is the entry point for the BPF
-	// program
+	// name is a required field and is the name of the function that is the entry
+	// point for the eBPF program. name must not be an empty string, must not
+	// exceed 64 characters in length, must start with alpha characters and must
+	// only contain alphanumeric characters.
+	// +required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
-	// type specifies the bpf program type
+	// type is a required field used to specify the type of the eBPF program. The
+	// type dictates which eBPF attachment point to use. This is where the eBPF
+	// program is executed.
+	//
+	// Allowed values are:
+	//   TC, TCX, UProbe, URetProbe, XDP
+	//
+	// When set to TC, the eBPF program can attach to network devices (interfaces).
+	// The program can be attached on either packet ingress or egress, so the
+	// program will be called on every incoming or outgoing packet seen by the
+	// network device. When using the TC program type, the tc field is required.
+	// See tc for more details on TC programs.
+	//
+	// When set to TCX, the eBPF program can attach to network devices
+	// (interfaces). The program can be attached on either packet ingress or
+	// egress, so the program will be called on every incoming or outgoing packet
+	// seen by the network device. When using the TCX program type, the tcx field
+	// is required. See tcx for more details on TCX programs.
+	//
+	// When set to UProbe, the program can attach in user-space. The UProbe is
+	// attached to a binary, library or function name, and optionally an offset in
+	// the code. When using the UProbe program type, the uprobe field is required.
+	// See uprobe for more details on UProbe programs.
+	//
+	// When set to URetProbe, the program can attach in user-space.
+	// The URetProbe is attached to the return of a binary, library or function
+	// name, and optionally an offset in the code.  When using the URetProbe
+	// program type, the uretprobe field is required. See uretprobe for more
+	// details on URetProbe programs.
+	//
+	// When set to XDP, the eBPF program can attach to network devices (interfaces)
+	// and will be called on every incoming packet received by the network device.
+	// When using the XDP program type, the xdp field is required. See xdp for more
+	// details on XDP programs.
 	// +unionDiscriminator
 	// +required
 	// +kubebuilder:validation:Enum:="XDP";"TC";"TCX";"UProbe";"URetProbe"
 	Type EBPFProgType `json:"type"`
 
-	// xdp defines the desired state of the application's XdpPrograms.
+	// xdp is an optional field, but required when the type field is set to XDP.
+	// xdp defines the desired state of the application's XDP programs. XDP program
+	// can be attached to network devices (interfaces) and will be called on every
+	// incoming packet received by the network device. The XDP attachment point is
+	// just after the packet has been received off the wire, but before the Linux
+	// kernel has allocated an sk_buff, which is used to pass the packet through
+	// the kernel networking stack.
 	// +unionMember
 	// +optional
 	XDP *XdpProgramInfo `json:"xdp,omitempty"`
 
-	// tc defines the desired state of the application's TcPrograms.
+	// tc is an optional field, but required when the type field is set to TC. tc
+	// defines the desired state of the application's TC programs. TC programs are
+	// attached to network devices (interfaces). The program can be attached on
+	// either packet ingress or egress, so the program will be called on every
+	// incoming or outgoing packet seen by the network device. The TC attachment
+	// point is in Linux's Traffic Control (tc) subsystem, which is after the
+	// Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+	// with enhanced performance and better support for running multiple programs
+	// on a given network device. This makes TC useful for packet classification
+	// actions.
 	// +unionMember
 	// +optional
 	TC *TcProgramInfo `json:"tc,omitempty"`
 
-	// tcx defines the desired state of the application's TcxPrograms.
+	// tcx is an optional field, but required when the type field is set to TCX.
+	// tcx defines the desired state of the application's TCX programs. TCX
+	// programs are attached to network devices (interfaces). The program can be
+	// attached on either packet ingress or egress, so the program will be called
+	// on every incoming or outgoing packet seen by the network device. The TCX
+	// attachment point is in Linux's Traffic Control (tc) subsystem, which is
+	// after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+	// packet classification actions. TCX is a newer implementation of TC with
+	// enhanced performance and better support for running multiple programs on a
+	// given network device.
 	// +unionMember
 	// +optional
 	TCX *TcxProgramInfo `json:"tcx,omitempty"`
 
-	// uprobe defines the desired state of the application's UprobePrograms.
+	// uprobe is an optional field, but required when the type field is set to
+	// UProbe. uprobe defines the desired state of the application's UProbe
+	// programs. UProbe programs are user-space probes. A target must be provided,
+	// which is the library name or absolute path to a binary or library where the
+	// probe is attached. Optionally, a function name can also be provided to
+	// provide finer granularity on where the probe is attached. They can be
+	// attached at any point in the binary, library or function using the optional
+	// offset field. However, caution must be taken when using the offset, ensuring
+	// the offset is still in the desired bytecode.
 	// +unionMember
 	// +optional
 	UProbe *UprobeProgramInfo `json:"uprobe,omitempty"`
 
-	// uretprobe defines the desired state of the application's UretprobePrograms.
+	// uretprobe is an optional field, but required when the type field is set to
+	// URetProbe. uretprobe defines the desired state of the application's
+	// URetProbe programs. URetProbe programs are user-space probes. A target must
+	// be provided, which is the library name or absolute path to a binary or
+	// library where the probe is attached. Optionally, a function name can also be
+	// provided to provide finer granularity on where the probe is attached. They
+	// are attached to the return point of the binary, library or function, but can
+	// be set anywhere using the optional offset field. However, caution must be
+	// taken when using the offset, ensuring the offset is still in the desired
+	// bytecode.
 	// +unionMember
 	// +optional
 	URetProbe *UprobeProgramInfo `json:"uretprobe,omitempty"`
 }
 
-// BpfApplicationSpec defines the desired state of BpfApplication
+// spec defines the desired state of the BpfApplication. The BpfApplication
+// describes the set of one or more namespace scoped eBPF programs that should
+// be loaded for a given application and attributes for how they should be
+// loaded. eBPF programs that are grouped together under the same
+// BpfApplication instance can share maps and global data between the eBPF
+// programs loaded on the same Kubernetes Node.
 type BpfApplicationSpec struct {
 	BpfAppCommon `json:",inline"`
 
-	// programs is the list of bpf programs in the BpfApplication that should be
-	// loaded. The application can selectively choose which program(s) to run
-	// from this list based on the optional attach points provided.
+	// programs is a required field and is the list of eBPF programs in a BPF
+	// Application CRD that should be loaded in kernel memory. At least one entry
+	// is required. eBPF programs in this list will be loaded on the system based
+	// the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+	// cannot be triggered until an attachment point is provided. The different
+	// program types have different ways of attaching. The attachment points can be
+	// added at creation time or modified (added or removed) at a later time to
+	// activate or deactivate the eBPF program as desired.
+	// CAUTION: When programs are added or removed from the list, that requires all
+	// programs in the list to be reloaded, which could be temporarily service
+	// effecting. For this reason, modifying the list is currently not allowed.
+	// +required
 	// +kubebuilder:validation:MinItems:=1
 	Programs []BpfApplicationProgram `json:"programs,omitempty"`
 }
@@ -83,7 +174,15 @@ type BpfApplicationSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
 
-// BpfApplication is the Schema for the bpfapplications API
+// BpfApplication is the schema for the namespace scoped BPF Applications API.
+// Using this API allows applications to load one or more eBPF programs on a
+// Kubernetes cluster using bpfman to load the programs.
+//
+// The bpfApplication.status field reports the overall status of the
+// BpfApplication CRD. A given BpfApplication CRD can result in loading and
+// attaching multiple eBPF programs on multiple nodes, so this status is just a
+// summary. More granular per-node status details can be found in the
+// corresponding BpfApplicationState CRD that bpfman creates for each node.
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/apis/v1alpha1/cluster_bpf_application_state_types.go
+++ b/apis/v1alpha1/cluster_bpf_application_state_types.go
@@ -134,17 +134,17 @@ type ClBpfApplicationProgramState struct {
 }
 
 type ClBpfApplicationStateStatus struct {
-	// updateCount is the number of times the ClusterBpfApplicationState has been
-	// updated. Set to 1 when the object is created, then it is incremented prior
-	// to each update. This is used to verify that the API server has the updated
-	// object prior to starting a new Reconcile operation.
+	// UpdateCount tracks the number of times the BpfApplicationState object has
+	// been updated. The bpfman agent initializes it to 1 when it creates the
+	// object, and then increments it before each subsequent update. It serves
+	// as a lightweight sequence number to verify that the API server is serving
+	// the most recent version of the object before beginning a new Reconcile
+	// operation.
 	UpdateCount int64 `json:"updateCount"`
 	// node is the name of the Kubernetes node for this ClusterBpfApplicationState.
 	Node string `json:"node"`
 	// appLoadStatus reflects the status of loading the eBPF application on the
-	// given node. Whether or not the eBPF program is attached to an attachment
-	// point is tracked by the linkStatus field, which is under of each link of
-	// each program.
+	// given node.
 	//
 	// NotLoaded is a temporary state that is assigned when a
 	// ClusterBpfApplicationState is created and the initial reconcile is being

--- a/apis/v1alpha1/cluster_bpf_application_state_types.go
+++ b/apis/v1alpha1/cluster_bpf_application_state_types.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ClBpfApplicationProgramState defines the desired state of BpfApplication
 // +union
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'XDP' ?  has(self.xdp) : !has(self.xdp)",message="xdp configuration is required when type is xdp, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'TC' ?  has(self.tc) : !has(self.tc)",message="tc configuration is required when type is tc, and forbidden otherwise"
@@ -37,79 +36,143 @@ import (
 type ClBpfApplicationProgramState struct {
 	BpfProgramStateCommon `json:",inline"`
 
-	// type specifies the bpf program type
+	// type specifies the provisioned eBPF program type for this program entry.
+	// Type will be one of:
+	//   FEntry, FExit, KProbe, KRetProbe, TC, TCX, Tracepoint, UProbe,
+	//   URetProbe, XDP
+	//
+	// When set to FEntry, the fentry object will be populated with the eBPF
+	// program data associated with an FEntry program.
+	//
+	// When set to FExit, the fexit object will be populated with the eBPF program
+	// data associated with an FExit program.
+	//
+	// When set to KProbe, the kprobe object will be populated with the eBPF
+	// program data associated with a KProbe program.
+	//
+	// When set to KRetProbe, the kretprobe object will be populated with the
+	// eBPF program data associated with a KRetProbe program.
+	//
+	// When set to TC, the tc object will be populated with the eBPF program data
+	// associated with a TC program.
+	//
+	// When set to TCX, the tcx object will be populated with the eBPF program
+	// data associated with a TCX program.
+	//
+	// When set to Tracepoint, the tracepoint object will be populated with the
+	// eBPF program data associated with a Tracepoint program.
+	//
+	// When set to UProbe, the uprobe object will be populated with the eBPF
+	// program data associated with a UProbe program.
+	//
+	// When set to URetProbe, the uretprobe object will be populated with the eBPF
+	// program data associated with a URetProbe program.
+	//
+	// When set to XDP, the xdp object will be populated with the eBPF program data
+	// associated with a URetProbe program.
 	// +unionDiscriminator
 	// +required
-	// +kubebuilder:validation:Enum:="XDP";"TC";"TCX";"FEntry";"FExit";"KProbe";"KRetProbe";"UProbe";"URetProbe";"TracePoint"
+	// +kubebuilder:validation:Enum:="FEntry";"FExit";"KProbe";"KRetProbe";"TC";"TCX";"TracePoint";"UProbe";"URetProbe";"XDP"
 	Type EBPFProgType `json:"type"`
 
-	// xdp defines the desired state of the application's XdpPrograms.
+	// xdp contains the attachment data for an XDP program when type is set to XDP.
 	// +unionMember
 	// +optional
 	XDP *ClXdpProgramInfoState `json:"xdp,omitempty"`
 
-	// tc defines the desired state of the application's TcPrograms.
+	// tc contains the attachment data for a TC program when type is set to TC.
 	// +unionMember
 	// +optional
 	TC *ClTcProgramInfoState `json:"tc,omitempty"`
 
-	// tcx defines the desired state of the application's TcxPrograms.
+	// tcx contains the attachment data for a TCX program when type is set to TCX.
 	// +unionMember
 	// +optional
 	TCX *ClTcxProgramInfoState `json:"tcx,omitempty"`
 
-	// fentry defines the desired state of the application's FentryPrograms.
+	// fentry contains the attachment data for an FEntry program when type is set
+	// to FEntry.
 	// +unionMember
 	// +optional
 	FEntry *ClFentryProgramInfoState `json:"fentry,omitempty"`
 
-	// fexit defines the desired state of the application's FexitPrograms.
+	// fexit contains the attachment data for an FExit program when type is set to
+	// FExit.
 	// +unionMember
 	// +optional
 	FExit *ClFexitProgramInfoState `json:"fexit,omitempty"`
 
-	// kprobe defines the desired state of the application's KprobePrograms.
+	// kprobe contains the attachment data for a KProbe program when type is set to
+	// KProbe.
 	// +unionMember
 	// +optional
 	KProbe *ClKprobeProgramInfoState `json:"kprobe,omitempty"`
 
-	// kretprobe defines the desired state of the application's KprobePrograms.
+	// kretprobe contains the attachment data for a KRetProbe program when type is
+	// set to KRetProbe.
 	// +unionMember
 	// +optional
 	KRetProbe *ClKretprobeProgramInfoState `json:"kretprobe,omitempty"`
 
-	// uprobe defines the desired state of the application's UprobePrograms.
+	// uprobe contains the attachment data for a UProbe program when type is set to
+	// UProbe.
 	// +unionMember
 	// +optional
 	UProbe *ClUprobeProgramInfoState `json:"uprobe,omitempty"`
 
-	// uretprobe defines the desired state of the application's UretprobePrograms.
+	// uretprobe contains the attachment data for a URetProbe program when type is
+	// set to URetProbe.
 	// +unionMember
 	// +optional
 	URetProbe *ClUprobeProgramInfoState `json:"uretprobe,omitempty"`
 
-	// tracepoint defines the desired state of the application's TracepointPrograms.
+	// tracepoint contains the attachment data for a Tracepoint program when type
+	// is set to Tracepoint.
 	// +unionMember
 	// +optional
 	TracePoint *ClTracepointProgramInfoState `json:"tracepoint,omitempty"`
 }
 
-// ClBpfApplicationStateStatus reflects the status of the ClusterBpfApplicationState on the given node
 type ClBpfApplicationStateStatus struct {
-	// updateCount is the number of times the BpfApplicationState has been updated. Set to 1
-	// when the object is created, then it is incremented prior to each update.
-	// This allows us to verify that the API server has the updated object prior
-	// to starting a new Reconcile operation.
+	// updateCount is the number of times the ClusterBpfApplicationState has been
+	// updated. Set to 1 when the object is created, then it is incremented prior
+	// to each update. This is used to verify that the API server has the updated
+	// object prior to starting a new Reconcile operation.
 	UpdateCount int64 `json:"updateCount"`
-	// node is the name of the node for this BpfApplicationStateSpec.
+	// node is the name of the Kubernetes node for this ClusterBpfApplicationState.
 	Node string `json:"node"`
-	// appLoadStatus reflects the status of loading the bpf application on the
-	// given node.
+	// appLoadStatus reflects the status of loading the eBPF application on the
+	// given node. Whether or not the eBPF program is attached to an attachment
+	// point is tracked by the linkStatus field, which is under of each link of
+	// each program.
+	//
+	// NotLoaded is a temporary state that is assigned when a
+	// ClusterBpfApplicationState is created and the initial reconcile is being
+	// processed.
+	//
+	// LoadSuccess is returned if all the programs have been loaded with no errors.
+	//
+	// LoadError is returned if one or more programs encountered an error and were
+	// not loaded.
+	//
+	// NotSelected is returned if this application did not select to run on this
+	// Kubernetes node.
+	//
+	// UnloadSuccess is returned when all the programs were successfully unloaded.
+	//
+	// UnloadError is returned if one or more programs encountered an error when
+	// being unloaded.
 	AppLoadStatus AppLoadStatus `json:"appLoadStatus"`
-	// programs is a list of bpf programs contained in the parent application.
+	// programs is a list of eBPF programs contained in the parent
+	// ClusterBpfApplication instance. Each entry in the list contains the derived
+	// program attributes as well as the attach status for each program on the
+	// given Kubernetes node.
 	Programs []ClBpfApplicationProgramState `json:"programs,omitempty"`
-	// Conditions contains the overall status of the ClusterBpfApplicationState
-	// object on the given node.
+	// conditions contains the summary state of the ClusterBpfApplication for the
+	// given Kubernetes node. If one or more programs failed to load or attach to
+	// the designated attachment point, the condition will report the error. If
+	// more than one error has occurred, condition will contain the first error
+	// encountered.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -123,7 +186,10 @@ type ClBpfApplicationStateStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// ClusterBpfApplicationState contains the per-node state of a BpfApplication.
+// ClusterBpfApplicationState contains the state of a ClusterBpfApplication
+// instance for a given Kubernetes node. When a user creates a
+// ClusterBpfApplication instance, bpfman creates a ClusterBpfApplicationState
+// instance for each node in a Kubernetes cluster.
 // +kubebuilder:printcolumn:name="Node",type=string,JSONPath=".status.node"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
@@ -131,6 +197,10 @@ type ClusterBpfApplicationState struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// status reflects the status of a ClusterBpfApplication instance for the given
+	// node. appLoadStatus and conditions provide an overall status for the given
+	// node, while each item in the programs list provides a per eBPF program
+	// status for the given node.
 	Status ClBpfApplicationStateStatus `json:"status,omitempty"`
 }
 

--- a/apis/v1alpha1/cluster_bpf_application_types.go
+++ b/apis/v1alpha1/cluster_bpf_application_types.go
@@ -62,7 +62,6 @@ const (
 	TCEgress  TCDirectionType = "Egress"
 )
 
-// ClBpfApplicationProgram defines the desired state of BpfApplication
 // +union
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'XDP' ?  has(self.xdp) : !has(self.xdp)",message="xdp configuration is required when type is xdp, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'TC' ?  has(self.tc) : !has(self.tc)",message="tc configuration is required when type is tc, and forbidden otherwise"
@@ -75,78 +74,228 @@ const (
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'URetProbe' ?  has(self.uretprobe) : !has(self.uretprobe)",message="uretprobe configuration is required when type is uretprobe, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'TracePoint' ?  has(self.tracepoint) : !has(self.tracepoint)",message="tracepoint configuration is required when type is tracepoint, and forbidden otherwise"
 type ClBpfApplicationProgram struct {
-	// name is the name of the function that is the entry point for the BPF
-	// program
+	// name is a required field and is the name of the function that is the entry
+	// point for the eBPF program. name must not be an empty string, must not
+	// exceed 64 characters in length, must start with alpha characters and must
+	// only contain alphanumeric characters.
+	// +required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
-	// type specifies the bpf program type
+	// type is a required field used to specify the type of the eBPF program. The
+	// type dictates which eBPF attachment point to use. This is where the eBPF
+	// program is executed.
+	//
+	// Allowed values are:
+	//   FEntry, FExit, KProbe, KRetProbe, TC, TCX, TracePoint, UProbe, URetProbe,
+	//   XDP
+	//
+	// When set to FEntry, the program is attached to the entry of a Linux kernel
+	// function or to another eBPF program function. When using the FEntry program
+	// type, the fentry field is required. See fentry for more details on FEntry
+	// programs.
+	//
+	// When set to FExit, the program is attached to the exit of a Linux kernel
+	// function or to another eBPF program function. When using the FExit program
+	// type, the fexit field is required. See fexit for more details on FExit
+	// programs.
+	//
+	// When set to KProbe, the program is attached to entry of a Linux kernel
+	// function. When using the KProbe program type, the kprobe field is required.
+	// See kprobe for more details on KProbe programs.
+	//
+	// When set to KRetProbe, the program is attached to exit of a Linux kernel
+	// function. When using the KRetProbe program type, the kretprobe field is
+	// required. See kretprobe for more details on KRetProbe programs.
+	//
+	// When set to TC, the eBPF program can attach to network devices (interfaces).
+	// The program can be attached on either packet ingress or egress, so the
+	// program will be called on every incoming or outgoing packet seen by the
+	// network device. When using the TC program type, the tc field is required.
+	// See tc for more details on TC programs.
+	//
+	// When set to TCX, the eBPF program can attach to network devices
+	// (interfaces). The program can be attached on either packet ingress or
+	// egress, so the program will be called on every incoming or outgoing packet
+	// seen by the network device. When using the TCX program type, the tcx field
+	// is required. See tcx for more details on TCX programs.
+	//
+	// When set to Tracepoint, the program can attach to one of the predefined set
+	// of Linux kernel functions. When using the Tracepoint program type, the
+	// tracepoint field is required. See tracepoint for more details on Tracepoint
+	// programs.
+	//
+	// When set to UProbe, the program can attach in user-space. The UProbe is
+	// attached to a binary, library or function name, and optionally an offset in
+	// the code. When using the UProbe program type, the uprobe field is required.
+	// See uprobe for more details on UProbe programs.
+	//
+	// When set to URetProbe, the program can attach in user-space.
+	// The URetProbe is attached to the return of a binary, library or function
+	// name, and optionally an offset in the code.  When using the URetProbe
+	// program type, the uretprobe field is required. See uretprobe for more
+	// details on URetProbe programs.
+	//
+	// When set to XDP, the eBPF program can attach to network devices (interfaces)
+	// and will be called on every incoming packet received by the network device.
+	// When using the XDP program type, the xdp field is required. See xdp for more
+	// details on XDP programs.
 	// +unionDiscriminator
 	// +required
 	// +kubebuilder:validation:Enum:="XDP";"TC";"TCX";"FEntry";"FExit";"KProbe";"KRetProbe";"UProbe";"URetProbe";"TracePoint"
 	Type EBPFProgType `json:"type"`
 
-	// xdp defines the desired state of the application's XdpPrograms.
+	// xdp is an optional field, but required when the type field is set to XDP.
+	// xdp defines the desired state of the application's XDP programs. XDP program
+	// can be attached to network devices (interfaces) and will be called on every
+	// incoming packet received by the network device. The XDP attachment point is
+	// just after the packet has been received off the wire, but before the Linux
+	// kernel has allocated an sk_buff, which is used to pass the packet through
+	// the kernel networking stack.
 	// +unionMember
 	// +optional
 	XDP *ClXdpProgramInfo `json:"xdp,omitempty"`
 
-	// tc defines the desired state of the application's TcPrograms.
+	// tc is an optional field, but required when the type field is set to TC. tc
+	// defines the desired state of the application's TC programs. TC programs are
+	// attached to network devices (interfaces). The program can be attached on
+	// either packet ingress or egress, so the program will be called on every
+	// incoming or outgoing packet seen by the network device. The TC attachment
+	// point is in Linux's Traffic Control (tc) subsystem, which is after the
+	// Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+	// with enhanced performance and better support for running multiple programs
+	// on a given network device. This makes TC useful for packet classification
+	// actions.
 	// +unionMember
 	// +optional
 	TC *ClTcProgramInfo `json:"tc,omitempty"`
 
-	// tcx defines the desired state of the application's TcxPrograms.
+	// tcx is an optional field, but required when the type field is set to TCX.
+	// tcx defines the desired state of the application's TCX programs. TCX
+	// programs are attached to network devices (interfaces). The program can be
+	// attached on either packet ingress or egress, so the program will be called
+	// on every incoming or outgoing packet seen by the network device. The TCX
+	// attachment point is in Linux's Traffic Control (tc) subsystem, which is
+	// after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+	// packet classification actions. TCX is a newer implementation of TC with
+	// enhanced performance and better support for running multiple programs on a
+	// given network device.
 	// +unionMember
 	// +optional
 	TCX *ClTcxProgramInfo `json:"tcx,omitempty"`
 
-	// fentry defines the desired state of the application's FentryPrograms.
+	// fentry is an optional field, but required when the type field is set to
+	// FEntry. fentry defines the desired state of the application's FEntry
+	// programs. FEntry programs are attached to the entry of a Linux kernel
+	// function or to another eBPF program function. They are attached to the first
+	// instruction, before control passes to the function. FEntry programs are
+	// similar to KProbe programs, but have higher performance.
 	// +unionMember
 	// +optional
 	FEntry *ClFentryProgramInfo `json:"fentry,omitempty"`
 
-	// fexit defines the desired state of the application's FexitPrograms.
+	// fexit is an optional field, but required when the type field is set to
+	// FExit. fexit defines the desired state of the application's FExit programs.
+	// FExit programs are attached to the exit of a Linux kernel function or to
+	// another eBPF program function. The program is invoked when the function
+	// returns, independent of where in the function that occurs. FExit programs
+	// are similar to KRetProbe programs, but get invoked with the input arguments
+	// and the return values. They also have higher performance over KRetProbe
+	// programs.
 	// +unionMember
 	// +optional
 	FExit *ClFexitProgramInfo `json:"fexit,omitempty"`
 
-	// kprobe defines the desired state of the application's KprobePrograms.
+	// kprobe is an optional field, but required when the type field is set to
+	// KProbe. kprobe defines the desired state of the application's Kprobe
+	// programs. KProbe programs are attached to a Linux kernel function. Unlike
+	// FEntry programs, which must always be attached at the entry point of a Linux
+	// kernel function, KProbe programs can be attached at any point in the
+	// function using the optional offset field. However, caution must be taken
+	// when using the offset, ensuring the offset is still in the function
+	// bytecode. FEntry programs have less overhead than KProbe programs.
 	// +unionMember
 	// +optional
 	KProbe *ClKprobeProgramInfo `json:"kprobe,omitempty"`
 
-	// kretprobe defines the desired state of the application's KretprobePrograms.
+	// kretprobe is an optional field, but required when the type field is set to
+	// KRetProbe. kretprobe defines the desired state of the application's
+	// KRetProbe programs. KRetProbe programs are attached to the exit of a Linux
+	// kernel function. FExit programs have less overhead than KRetProbe programs
+	// and FExit programs have access to both the input arguments as well as the
+	// return values. KRetProbes only have access to the return values.
 	// +unionMember
 	// +optional
 	KRetProbe *ClKretprobeProgramInfo `json:"kretprobe,omitempty"`
 
-	// uprobe defines the desired state of the application's UprobePrograms.
+	// uprobe is an optional field, but required when the type field is set to
+	// UProbe. uprobe defines the desired state of the application's UProbe
+	// programs. UProbe programs are user-space probes. A target must be provided,
+	// which is the library name or absolute path to a binary or library where the
+	// probe is attached. Optionally, a function name can also be provided to
+	// provide finer granularity on where the probe is attached. They can be
+	// attached at any point in the binary, library or function using the optional
+	// offset field. However, caution must be taken when using the offset, ensuring
+	// the offset is still in the desired bytecode.
 	// +unionMember
 	// +optional
 	UProbe *ClUprobeProgramInfo `json:"uprobe,omitempty"`
 
-	// uretprobeInfo defines the desired state of the application's UretprobePrograms.
+	// uretprobe is an optional field, but required when the type field is set to
+	// URetProbe. uretprobe defines the desired state of the application's
+	// URetProbe programs. URetProbe programs are user-space probes. A target must
+	// be provided, which is the library name or absolute path to a binary or
+	// library where the probe is attached. Optionally, a function name can also be
+	// provided to provide finer granularity on where the probe is attached. They
+	// are attached to the return point of the binary, library or function, but can
+	// be set anywhere using the optional offset field. However, caution must be
+	// taken when using the offset, ensuring the offset is still in the desired
+	// bytecode.
 	// +unionMember
 	// +optional
 	URetProbe *ClUprobeProgramInfo `json:"uretprobe,omitempty"`
 
-	// tracepointInfo defines the desired state of the application's TracepointPrograms.
+	// tracepoint is an optional field, but required when the type field is set to
+	// Tracepoint. tracepoint defines the desired state of the application's
+	// Tracepoint programs. Whereas KProbes attach to dynamically to any Linux
+	// kernel function, Tracepoint programs are programs that can only be attached
+	// at predefined locations in the Linux kernel. Use the following command to
+	// see the available attachment points:
+	//  `sudo find /sys/kernel/debug/tracing/events -type d`
+	// While KProbes are more flexible in where in the kernel the probe can be
+	// attached, the functions and data structure rely on the kernel your system is
+	// running. Tracepoints tend to be more stable across kernel versions and are
+	// better for portability.
 	// +unionMember
 	// +optional
 	TracePoint *ClTracepointProgramInfo `json:"tracepoint,omitempty"`
 }
 
-// ClBpfApplicationSpec defines the desired state of BpfApplication
+// spec defines the desired state of the ClusterBpfApplication. The
+// ClusterBpfApplication describes the set of one or more cluster scoped eBPF
+// programs that should be loaded for a given application and attributes for
+// how they should be loaded. eBPF programs that are grouped together under the
+// same ClusterBpfApplication instance can share maps and global data between
+// the eBPF programs loaded on the same Kubernetes Node.
 type ClBpfApplicationSpec struct {
 	BpfAppCommon `json:",inline"`
-	// programs is the list of bpf programs in the BpfApplication that should be
-	// loaded. The application can selectively choose which program(s) to run
-	// from this list based on the optional attach points provided.
+
+	// programs is a required field and is the list of eBPF programs in a BPF
+	// Application CRD that should be loaded in kernel memory. At least one entry
+	// is required. eBPF programs in this list will be loaded on the system based
+	// the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+	// cannot be triggered until an attachment point is provided. The different
+	// program types have different ways of attaching. The attachment points can be
+	// added at creation time or modified (added or removed) at a later time to
+	// activate or deactivate the eBPF program as desired.
+	// CAUTION: When programs are added or removed from the list, that requires all
+	// programs in the list to be reloaded, which could be temporarily service
+	// effecting. For this reason, modifying the list is currently not allowed.
+	// +required
 	// +kubebuilder:validation:MinItems:=1
-	Programs []ClBpfApplicationProgram `json:"programs,omitempty"`
+	Programs []ClBpfApplicationProgram `json:"programs"`
 }
 
 // +genclient
@@ -155,7 +304,16 @@ type ClBpfApplicationSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// ClusterBpfApplication is the Schema for the bpfapplications API
+// ClusterBpfApplication is the schema for the cluster scoped BPF Applications
+// API. Using this API allows applications to load one or more eBPF programs on
+// a Kubernetes cluster using bpfman to load the programs.
+//
+// The clusterBpfApplication.status field reports the overall status of the
+// ClusterBpfApplication CRD. A given ClusterBpfApplication CRD can result in
+// loading and attaching multiple eBPF programs on multiple nodes, so this
+// status is just a summary. More granular per-node status details can be
+// found in the corresponding ClusterBpfApplicationState CRD that bpfman
+// creates for each node.
 // +kubebuilder:printcolumn:name="NodeSelector",type=string,JSONPath=`.spec.nodeselector`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/apis/v1alpha1/cluster_bpf_application_types.go
+++ b/apis/v1alpha1/cluster_bpf_application_types.go
@@ -84,9 +84,7 @@ type ClBpfApplicationProgram struct {
 	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
-	// type is a required field used to specify the type of the eBPF program. The
-	// type dictates which eBPF attachment point to use. This is where the eBPF
-	// program is executed.
+	// type is a required field used to specify the type of the eBPF program.
 	//
 	// Allowed values are:
 	//   FEntry, FExit, KProbe, KRetProbe, TC, TCX, TracePoint, UProbe, URetProbe,
@@ -305,8 +303,8 @@ type ClBpfApplicationSpec struct {
 // +kubebuilder:resource:scope=Cluster
 
 // ClusterBpfApplication is the schema for the cluster scoped BPF Applications
-// API. Using this API allows applications to load one or more eBPF programs on
-// a Kubernetes cluster using bpfman to load the programs.
+// API. This API allows applications to use bpfman to load and attach one or
+// more eBPF programs on a Kubernetes cluster.
 //
 // The clusterBpfApplication.status field reports the overall status of the
 // ClusterBpfApplication CRD. A given ClusterBpfApplication CRD can result in

--- a/apis/v1alpha1/cluster_fentry_program_types.go
+++ b/apis/v1alpha1/cluster_fentry_program_types.go
@@ -17,19 +17,29 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// ClFentryProgramInfo defines the Fentry program details
 type ClFentryProgramInfo struct {
 	ClFentryLoadInfo `json:",inline"`
-	// Whether the program should be attached to the function.
+
+	// links is an optional field and is a flag to indicate if the FEntry program
+	// should be attached. The attachment point for a FEntry program is a Linux
+	// kernel function. Unlike other eBPF program types, an FEntry program must be
+	// provided with the target function at load time. The links field is optional,
+	// but unlike other program types where it represents a list of attachment
+	// points, for FEntry programs it contains at most one entry that determines
+	// whether the program should be attached to the specified function. To attach
+	// the program, add an entry to links with mode set to Attach. To detach it,
+	// remove the entry from links.
 	// +optional
 	// +kubebuilder:validation:MaxItems=1
 	Links []ClFentryAttachInfo `json:"links,omitempty"`
 }
 
-// ClFentryLoadInfo contains the program-specific load information for Fentry
-// programs
 type ClFentryLoadInfo struct {
-	// function is the name of the function to attach the Fentry program to.
+	// function is a required field and specifies the name of the Linux kernel
+	// function to attach the FEntry program. function must not be an empty string,
+	// must not exceed 64 characters in length, must start with alpha characters
+	// and must only contain alphanumeric characters.
+	// +required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
@@ -39,20 +49,24 @@ type ClFentryLoadInfo struct {
 type AttachTypeAttach string
 
 const (
-	Attach  AttachTypeAttach = "Attach"
-	Dettach AttachTypeAttach = "Detach"
+	Attach AttachTypeAttach = "Attach"
 )
 
-// ClFentryAttachInfo indicates that the Fentry program should be attached to
-// the function identified in ClFentryLoadInfo. The only valid value for Attach
-// is true.
 type ClFentryAttachInfo struct {
-	// +kubebuilder:validation:Enum=Attach;Dettach;
+	// mode is a required field. When set to Attach, the FEntry program will
+	// attempt to be attached. To detach the FEntry program, remove the link entry.
+	// +required
+	// +kubebuilder:validation:Enum=Attach;
 	Mode AttachTypeAttach `json:"mode"`
 }
 
 type ClFentryProgramInfoState struct {
 	ClFentryLoadInfo `json:",inline"`
+
+	// links is a list of attachment points for the FEntry program. Each entry in
+	// the list includes a linkStatus, which indicates if the attachment was
+	// successful or not on this node, a linkId, which is the kernel ID for the
+	// link if successfully attached, and other attachment specific data.
 	// +optional
 	// +kubebuilder:validation:MaxItems=1
 	Links []ClFentryAttachInfoState `json:"links,omitempty"`

--- a/apis/v1alpha1/cluster_fexit_program_types.go
+++ b/apis/v1alpha1/cluster_fexit_program_types.go
@@ -17,35 +17,50 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// ClFexitProgramInfo defines the Fexit program details
 type ClFexitProgramInfo struct {
 	ClFexitLoadInfo `json:",inline"`
-	// Whether the program should be attached to the function.
+
+	// links is an optional field and is a flag to indicate if the FExit program
+	// should be attached. The attachment point for a FExit program is a Linux
+	// kernel function. Unlike other eBPF program types, an FExit program must be
+	// provided with the target function at load time. The links field is optional,
+	// but unlike other program types where it represents a list of attachment
+	// points, for FExit programs it contains at most one entry that determines
+	// whether the program should be attached to the specified function. To attach
+	// the program, add an entry to links with mode set to Attach. To detach it,
+	// remove the entry from links.
 	// +optional
 	// +kubebuilder:validation:MaxItems=1
 	Links []ClFexitAttachInfo `json:"links,omitempty"`
 }
 
-// ClFexitLoadInfo contains the program-specific load information for Fexit
-// programs
 type ClFexitLoadInfo struct {
-	// function is the name of the function to attach the Fexit program to.
+	// function is a required field and specifies the name of the Linux kernel
+	// function to attach the FExit program. function must not be an empty string,
+	// must not exceed 64 characters in length, must start with alpha characters
+	// and must only contain alphanumeric characters.
+	// +required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
 	Function string `json:"function"`
 }
 
-// ClFexitAttachInfo indicates that the Fentry program should be attached to
-// the function identified in ClFentryLoadInfo. The only valid value for Attach
-// is true.
 type ClFexitAttachInfo struct {
-	// +kubebuilder:validation:Enum=Attach;Dettach;
+	// mode is a required field. When set to Attach, the FExit program will
+	// attempt to be attached. To detach the FExit program, remove the link entry.
+	// +required
+	// +kubebuilder:validation:Enum=Attach;
 	Mode AttachTypeAttach `json:"mode"`
 }
 
 type ClFexitProgramInfoState struct {
 	ClFexitLoadInfo `json:",inline"`
+
+	// links is a list of attachment points for the FExit program. Each entry in
+	// the list includes a linkStatus, which indicates if the attachment was
+	// successful or not, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	// +kubebuilder:validation:MaxItems=1
 	Links []ClFexitAttachInfoState `json:"links,omitempty"`

--- a/apis/v1alpha1/cluster_kretprobe_program_types.go
+++ b/apis/v1alpha1/cluster_kretprobe_program_types.go
@@ -19,14 +19,25 @@ package v1alpha1
 
 // ClKprobeProgramInfo contains the information for the kprobe program
 type ClKretprobeProgramInfo struct {
-	// The list of points to which the program should be attached.  The list items
-	// are optional and may be udated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// KRetProbe program should be attached. The eBPF program is loaded in kernel
+	// memory when the BPF Application CRD is created and the selected Kubernetes
+	// nodes are active. The eBPF program will not be triggered until the program
+	// has also been attached to an attachment point described in this list. Items
+	// may be added or removed from the list at any point, causing the eBPF program
+	// to be attached or detached.
+	//
+	// The attachment point for a KRetProbe program is a Linux kernel function.
 	// +optional
 	Links []ClKretprobeAttachInfo `json:"links,omitempty"`
 }
 
 type ClKretprobeAttachInfo struct {
-	// function to attach the kprobe to.
+	// function is a required field and specifies the name of the Linux kernel
+	// function to attach the KRetProbe program. function must not be an empty
+	// string, must not exceed 64 characters in length, must start with alpha
+	// characters and must only contain alphanumeric characters.
+	// +required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
@@ -34,11 +45,10 @@ type ClKretprobeAttachInfo struct {
 }
 
 type ClKretprobeProgramInfoState struct {
-	// List of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the KRetProbe program. Each entry
+	// in the list includes a linkStatus, which indicates if the attachment was
+	// successful or not on this node, a linkId, which is the kernel ID for the
+	// link if successfully attached, and other attachment specific data.
 	// +optional
 	Links []ClKretprobeAttachInfoState `json:"links,omitempty"`
 }
@@ -46,6 +56,7 @@ type ClKretprobeProgramInfoState struct {
 type ClKretprobeAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// Function to attach the kprobe to.
+	// function is the provisioned name of the Linux kernel function the KRetProbe
+	// program should be attached.
 	Function string `json:"function"`
 }

--- a/apis/v1alpha1/cluster_tc_program_types.go
+++ b/apis/v1alpha1/cluster_tc_program_types.go
@@ -89,7 +89,7 @@ type ClTcAttachInfo struct {
 	// program in the chain will be called. If a TC program returns Stolen, the
 	// next TC program in the chain will NOT be called.
 	// +optional
-	// +kubebuilder:default:={OK,Pipe,DispatcherReturn}
+	// +kubebuilder:default:={Pipe,DispatcherReturn}
 	ProceedOn []TcProceedOnValue `json:"proceedOn,omitempty"`
 }
 

--- a/apis/v1alpha1/cluster_tc_program_types.go
+++ b/apis/v1alpha1/cluster_tc_program_types.go
@@ -20,50 +20,84 @@ package v1alpha1
 // +kubebuilder:validation:Enum:=UnSpec;OK;ReClassify;Shot;Pipe;Stolen;Queued;Repeat;ReDirect;Trap;DispatcherReturn;
 type TcProceedOnValue string
 
-// ClTcProgramInfo defines the tc program details
 type ClTcProgramInfo struct {
-	// The list of points to which the program should be attached.  The list items
-	// are optional and may be udated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// TC program should be attached. The TC program is loaded in kernel memory
+	// when the BPF Application CRD is created and the selected Kubernetes nodes
+	// are active. The TC program will not be triggered until the program has also
+	// been attached to an attachment point described in this list. Items may be
+	// added or removed from the list at any point, causing the TC program to be
+	// attached or detached.
+	//
+	// The attachment point for a TC program is a network interface (or device).
+	// The interface can be specified by name, by allowing bpfman to discover each
+	// interface, or by setting the primaryNodeInterface flag, which instructs
+	// bpfman to use the primary interface of a Kubernetes node. Optionally, the
+	// TC program can also be installed into a set of network namespaces.
 	// +optional
 	Links []ClTcAttachInfo `json:"links,omitempty"`
 }
 
 type ClTcAttachInfo struct {
-	// interfaceSelector to determine the network interface (or interfaces)
+	// interfaceSelector is a required field and is used to determine the network
+	// interface (or interfaces) the TC program is attached. Interface list is set
+	// by providing a list of interface names, enabling auto discovery, or setting
+	// the primaryNodeInterface flag, but only one option is allowed.
+	// +required
 	InterfaceSelector InterfaceSelector `json:"interfaceSelector"`
 
-	// networkNamespaces identifies the set of network namespaces in which to
-	// attach the eBPF program. If networkNamespaces is not specified, the BPF
-	// program will be attached in the root network namespace.
+	// networkNamespaces is an optional field that identifies the set of network
+	// namespaces in which to attach the eBPF program. If networkNamespaces is not
+	// specified, the eBPF program will be attached in the root network namespace.
 	// +optional
 	NetworkNamespaces *ClNetworkNamespaceSelector `json:"networkNamespaces,omitempty"`
 
-	// direction specifies the direction of traffic the tc program should
-	// attach to for a given network device.
+	// direction is a required field and specifies the direction of traffic.
+	// Allowed values are:
+	//    Ingress, Egress
+	//
+	// When set to Ingress, the TC program is triggered when packets are received
+	// by the interface.
+	//
+	// When set to Egress, the TC program is triggered when packets are to be
+	// transmitted by the interface.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tc program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is an optional field and determines the execution order of the TC
+	// program relative to other TC programs attached to the same attachment point.
+	// It must be a value between 0 and 1000, where lower values indicate higher
+	// precedence. For TC programs on the same attachment point with the same
+	// direction and priority, the most recently attached program has a lower
+	// precedence. If not provided, priority will default to 1000.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	// +optional
+	// +kubebuilder:default:=1000
 	Priority int32 `json:"priority,omitempty"`
 
-	// proceedOn allows the user to call other tc programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is an optional field and allows the user to call other TC programs
+	// in a chain, or not call the next program in a chain based on the exit code
+	// of a TC program. Allowed values, which are the possible exit codes from a TC
+	// eBPF program, are:
+	//   UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+	//   Trap, DispatcherReturn
+	//
+	// Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+	// using the default values, if a TC program returns Pipe, the next TC
+	// program in the chain will be called. If a TC program returns Stolen, the
+	// next TC program in the chain will NOT be called.
 	// +optional
-	// +kubebuilder:default:={Pipe,DispatcherReturn}
+	// +kubebuilder:default:={OK,Pipe,DispatcherReturn}
 	ProceedOn []TcProceedOnValue `json:"proceedOn,omitempty"`
 }
 
 type ClTcProgramInfoState struct {
-	// links is the List of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attached point required by the
-	// reconciler
+	// links is a list of attachment points for the TC program. Each entry in the
+	// list includes a linkStatus, which indicates if the attachment was successful
+	// or not on this node, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	Links []ClTcAttachInfoState `json:"links,omitempty"`
 }
@@ -71,26 +105,33 @@ type ClTcProgramInfoState struct {
 type ClTcAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// interfaceName is the Interface name to attach the tc program to.
+	// interfaceName is the name of the interface the TC program should be
+	// attached.
+	// +required
 	InterfaceName string `json:"interfaceName"`
 
-	// Optional network namespace to attach the tc program in.
+	// netnsPath is the optional path to the network namespace inside of which the
+	// TC program should be attached.
 	// +optional
 	NetnsPath string `json:"netnsPath,omitempty"`
 
-	// direction specifies the direction of traffic the tc program should
-	// attach to for a given network device.
+	// direction is the provisioned direction of traffic, Ingress or Egress, the TC
+	// program should be attached for a given network device.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tc program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is the provisioned priority of the TC program in relation to other
+	// programs of the same type with the same attach point. It is a value from 0
+	// to 1000, where lower values have higher precedence.
+	// +required
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
 	Priority int32 `json:"priority"`
 
-	// proceedOn allows the user to call other tc programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+	// user to call other TC programs in a chain, or not call the next program in a
+	// chain based on the exit code of a TC program .Multiple values are supported.
+	// +required
 	ProceedOn []TcProceedOnValue `json:"proceedOn"`
 }

--- a/apis/v1alpha1/cluster_tcx_program_types.go
+++ b/apis/v1alpha1/cluster_tcx_program_types.go
@@ -19,42 +19,68 @@ package v1alpha1
 
 // ClTcxProgramInfo defines the tcx program details
 type ClTcxProgramInfo struct {
-	// links is the list of points to which the program should be attached. The list items
-	// are optional and may be updated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// TCX program should be attached. The TCX program is loaded in kernel memory
+	// when the BPF Application CRD is created and the selected Kubernetes nodes
+	// are active. The TCX program will not be triggered until the program has also
+	// been attached to an attachment point described in this list. Items may be
+	// added or removed from the list at any point, causing the TCX program to be
+	// attached or detached.
+	//
+	// The attachment point for a TCX program is a network interface (or device).
+	// The interface can be specified by name, by allowing bpfman to discover each
+	// interface, or by setting the primaryNodeInterface flag, which instructs
+	// bpfman to use the primary interface of a Kubernetes node. Optionally, the
+	// TCX program can also be installed into a set of network namespaces.
 	// +optional
 	Links []ClTcxAttachInfo `json:"links,omitempty"`
 }
 
 type ClTcxAttachInfo struct {
-	// interfaceSelector to determine the network interface (or interfaces)
+	// interfaceSelector is a required field and is used to determine the network
+	// interface (or interfaces) the TCX program is attached. Interface list is set
+	// by providing a list of interface names, enabling auto discovery, or setting
+	// the primaryNodeInterface flag, but only one option is allowed.
+	// +required
 	InterfaceSelector InterfaceSelector `json:"interfaceSelector"`
 
-	// networkNamespaces identifies the set of network namespaces in which to
-	// attach the eBPF program. If networkNamespaces is not specified, the BPF
-	// program will be attached in the root network namespace.
+	// networkNamespaces is an optional field that identifies the set of network
+	// namespaces in which to attach the eBPF program. If networkNamespaces is not
+	// specified, the eBPF program will be attached in the root network namespace.
 	// +optional
 	NetworkNamespaces *ClNetworkNamespaceSelector `json:"networkNamespaces,omitempty"`
 
-	// direction specifies the direction of traffic the tcx program should
-	// attach to for a given network device.
+	// direction is a required field and specifies the direction of traffic.
+	// Allowed values are:
+	//    Ingress, Egress
+	//
+	// When set to Ingress, the TC program is triggered when packets are received
+	// by the interface.
+	//
+	// When set to Egress, the TC program is triggered when packets are to be
+	// transmitted by the interface.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tcx program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is an optional field and determines the execution order of the TCX
+	// program relative to other TCX programs attached to the same attachment
+	// point. It must be a value between 0 and 1000, where lower values indicate
+	// higher precedence. For TCX programs on the same attachment point with the
+	// same direction and priority, the most recently attached program has a lower
+	// precedence. If not provided, priority will default to 1000.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	// +optional
+	// +kubebuilder:default:=1000
 	Priority int32 `json:"priority,omitempty"`
 }
 
 type ClTcxProgramInfoState struct {
-	// List of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the TCX program. Each entry in the
+	// list includes a linkStatus, which indicates if the attachment was successful
+	// or not on this node, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	Links []ClTcxAttachInfoState `json:"links,omitempty"`
 }
@@ -62,21 +88,26 @@ type ClTcxProgramInfoState struct {
 type ClTcxAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// interfaceName is the Interface name to attach the tc program to.
+	// interfaceName is the name of the interface the TCX program should be
+	// attached.
+	// +required
 	InterfaceName string `json:"interfaceName"`
 
-	// netnsPath is the network namespace to attach the tcx program in.
+	// netnsPath is the optional path to the network namespace inside of which the
+	// TCX program should be attached.
 	// +optional
 	NetnsPath string `json:"netnsPath,omitempty"`
 
-	// direction specifies the direction of traffic the tcx program should
-	// attach to for a given network device.
+	// direction is the provisioned direction of traffic, Ingress or Egress, the TC
+	// program should be attached for a given network device.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tcx program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is the provisioned priority of the TCX program in relation to other
+	// programs of the same type with the same attach point. It is a value from 0
+	// to 1000, where lower values have higher precedence.
+	// +required
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
 	Priority int32 `json:"priority"`

--- a/apis/v1alpha1/cluster_tracepoint_program_types.go
+++ b/apis/v1alpha1/cluster_tracepoint_program_types.go
@@ -17,17 +17,27 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// ClTracepointProgramInfo contains the Tracepoint program details
 type ClTracepointProgramInfo struct {
-	// links is the list of points to which the program should be attached.  The list items
-	// are optional and may be updated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// Tracepoint program should be attached. The Tracepoint program is loaded in
+	// kernel memory when the BPF Application CRD is created and the selected
+	// Kubernetes nodes are active. The Tracepoint program will not be triggered
+	// until the program has also been attached to an attachment point described in
+	// this list. Items may be added or removed from the list at any point, causing
+	// the Tracepoint program to be attached or detached.
+	//
+	// The attachment point for a Tracepoint program is a one of a predefined set
+	// of Linux kernel functions.
 	// +optional
 	Links []ClTracepointAttachInfo `json:"links,omitempty"`
 }
 
 type ClTracepointAttachInfo struct {
-	// name refers to the name of a kernel tracepoint to attach the
-	// bpf program to.
+	// name is a required field and specifies the name of the Linux kernel
+	// Tracepoint to attach the eBPF program. name must not be an empty string,
+	// must not exceed 64 characters in length, must start with alpha characters
+	// and must only contain alphanumeric characters.
+	// +required
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
@@ -35,11 +45,10 @@ type ClTracepointAttachInfo struct {
 }
 
 type ClTracepointProgramInfoState struct {
-	// links is the list of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the Tracepoint program. Each entry
+	// in the list includes a linkStatus, which indicates if the attachment was
+	// successful or not on this node, a linkId, which is the kernel ID for the
+	// link if successfully attached, and other attachment specific data.
 	// +optional
 	Links []ClTracepointAttachInfoState `json:"links,omitempty"`
 }
@@ -48,5 +57,8 @@ type ClTracepointAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
 	// The name of a kernel tracepoint to attach the bpf program to.
+	// name is the provisioned name of the Linux kernel tracepoint function the
+	// Tracepoint program should be attached.
+	// +required
 	Name string `json:"name"`
 }

--- a/apis/v1alpha1/cluster_uprobe_program_types.go
+++ b/apis/v1alpha1/cluster_uprobe_program_types.go
@@ -17,48 +17,65 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// ClUprobeProgramInfo contains the information for the uprobe program
 type ClUprobeProgramInfo struct {
-	// links in the list of points to which the program should be attached.  The list items
-	// are optional and may be udated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// UProbe or URetProbe program should be attached. The eBPF program is loaded
+	// in kernel memory when the BPF Application CRD is created and the selected
+	// Kubernetes nodes are active. The eBPF program will not be triggered until
+	// the program has also been attached to an attachment point described in this
+	// list. Items may be added or removed from the list at any point, causing the
+	// eBPF program to be attached or detached.
+	//
+	// The attachment point for a UProbe and URetProbe program is a user-space
+	// binary or function. By default, the eBPF program is triggered at the entry
+	// of the attachment point, but the attachment point can be adjusted using an
+	// optional function name and/or offset. Optionally, the eBPF program can be
+	// installed in a set of containers or limited to a specified PID.
 	// +optional
 	Links []ClUprobeAttachInfo `json:"links,omitempty"`
 }
 
 type ClUprobeAttachInfo struct {
-	// function to attach the uprobe to.
+	// function is an optional field and specifies the name of a user-space function
+	// to attach the UProbe or URetProbe program. If not provided, the eBPF program
+	// will be triggered on the entry of the target. function must not be an empty
+	// string, must not exceed 64 characters in length, must start with alpha
+	// characters and must only contain alphanumeric characters.
 	// +optional
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
 	Function string `json:"function,omitempty"`
 
-	// offset added to the address of the function for uprobe.
+	// offset is an optional field and the value is added to the address of the
+	// attachment point function.
 	// +optional
 	// +kubebuilder:default:=0
 	Offset uint64 `json:"offset,omitempty"`
 
-	// target is the Library name or the absolute path to a binary or library.
+	// target is a required field and is the user-space library name or the
+	// absolute path to a binary or library.
+	// +required
 	Target string `json:"target"`
 
-	// pid only execute uprobe for given process identification number (PID). If PID
-	// is not provided, uprobe executes for all PIDs.
+	// pid is an optional field and if provided, limits the execution of the UProbe
+	// or URetProbe to the provided process identification number (PID). If pid is
+	// not provided, the UProbe or URetProbe executes for all PIDs.
 	// +optional
 	Pid *int32 `json:"pid,omitempty"`
 
-	// containers identify the set of containers in which to attach the
-	// uprobe. If Containers is not specified, the uprobe will be attached in
-	// the bpfman-agent container.
+	// containers is an optional field that identifies the set of containers in
+	// which to attach the UProbe or URetProbe program. If containers is not
+	// specified, the eBPF program will be attached in the bpfman-agent container.
 	// +optional
 	Containers *ClContainerSelector `json:"containers,omitempty"`
 }
 
 type ClUprobeProgramInfoState struct {
-	// links is the list of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the UProbe program. Each entry in
+	// the list includes a linkStatus, which indicates if the attachment was
+	// successful or not on this node, a linkId, which is the kernel ID for the
+	// link if successfully attached, and other attachment specific data.
 	// +optional
 	Links []ClUprobeAttachInfoState `json:"links,omitempty"`
 }
@@ -66,24 +83,31 @@ type ClUprobeProgramInfoState struct {
 type ClUprobeAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// function to attach the uprobe to.
+	// function is the provisioned name of the user-space function the UProbe
+	// program should be attached.
 	// +optional
 	Function string `json:"function,omitempty"`
 
-	// offset added to the address of the function for uprobe.
+	// offset is the provisioned offset, whose value is added to the address of the
+	// attachment point function.
 	// +optional
 	// +kubebuilder:default:=0
 	Offset uint64 `json:"offset"`
 
-	// target is the library name or the absolute path to a binary or library.
+	// target is the provisioned user-space library name or the absolute path to a
+	// binary or library.
+	// +required
 	Target string `json:"target"`
 
-	// pid only execute uprobe for given process identification number (PID). If PID
-	// is not provided, uprobe executes for all PIDs.
+	// pid is the provisioned pid. If set, pid limits the execution of the UProbe
+	// or URetProbe to the provided process identification number (PID). If pid is
+	// not provided, the UProbe or URetProbe executes for all PIDs.
 	// +optional
 	Pid *int32 `json:"pid,omitempty"`
 
-	// Optional container pid to attach the uprobe program in.
+	// If containers is provisioned in the ClusterBpfApplication instance,
+	// containerPid is the derived PID of the container the UProbe or URetProbe this
+	// attachment point is attached.
 	// +optional
 	ContainerPid *int32 `json:"containerPid,omitempty"`
 }

--- a/apis/v1alpha1/cluster_uprobe_program_types.go
+++ b/apis/v1alpha1/cluster_uprobe_program_types.go
@@ -66,7 +66,7 @@ type ClUprobeAttachInfo struct {
 
 	// containers is an optional field that identifies the set of containers in
 	// which to attach the UProbe or URetProbe program. If containers is not
-	// specified, the eBPF program will be attached in the bpfman-agent container.
+	// specified, the eBPF program will be attached in the bpfman container.
 	// +optional
 	Containers *ClContainerSelector `json:"containers,omitempty"`
 }

--- a/apis/v1alpha1/cluster_xdp_program_types.go
+++ b/apis/v1alpha1/cluster_xdp_program_types.go
@@ -30,10 +30,10 @@ type ClXdpProgramInfo struct {
 	// attached or detached.
 	//
 	// The attachment point for an XDP program is a network interface (or device).
-	// The interface can be specified by name, or by setting the
-	// primaryNodeInterface flag, which instructs bpfman to use the primary
-	// interface of a Kubernetes node. Optionally, the XDP program can also be
-	// installed into a set of network namespaces.
+	// The interface can be specified by name, by allowing bpfman to discover each
+	// interface, or by setting the primaryNodeInterface flag, which instructs
+	// bpfman to use the primary interface of a Kubernetes node. Optionally, the
+	// XDP program can also be installed into a set of network namespaces.
 	// +optional
 	Links []ClXdpAttachInfo `json:"links,omitempty"`
 }

--- a/apis/v1alpha1/cluster_xdp_program_types.go
+++ b/apis/v1alpha1/cluster_xdp_program_types.go
@@ -20,45 +20,70 @@ package v1alpha1
 // +kubebuilder:validation:Enum:=Aborted;Drop;Pass;TX;ReDirect;DispatcherReturn;
 type XdpProceedOnValue string
 
-// ClXdpProgramInfo contains the xdp program details
 type ClXdpProgramInfo struct {
-	// links is the list of points to which the program should be attached.  The list items
-	// are optional and may be updated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// XDP program should be attached. The XDP program is loaded in kernel memory
+	// when the BPF Application CRD is created and the selected Kubernetes nodes
+	// are active. The XDP program will not be triggered until the program has also
+	// been attached to an attachment point described in this list. Items may be
+	// added or removed from the list at any point, causing the XDP program to be
+	// attached or detached.
+	//
+	// The attachment point for an XDP program is a network interface (or device).
+	// The interface can be specified by name, or by setting the
+	// primaryNodeInterface flag, which instructs bpfman to use the primary
+	// interface of a Kubernetes node. Optionally, the XDP program can also be
+	// installed into a set of network namespaces.
 	// +optional
 	Links []ClXdpAttachInfo `json:"links,omitempty"`
 }
 
 type ClXdpAttachInfo struct {
-	// interfaceSelector to determine the network interface (or interfaces)
+	// interfaceSelector is a required field and is used to determine the network
+	// interface (or interfaces) the XDP program is attached. Interface list is set
+	// by providing a list of interface names, enabling auto discovery, or setting
+	// the primaryNodeInterface flag, but only one option is allowed.
+	// +required
 	InterfaceSelector InterfaceSelector `json:"interfaceSelector"`
 
 	// networkNamespaces identifies the set of network namespaces in which to
-	// attach the eBPF program. If networkNamespaces is not specified, the BPF
+	// attach the eBPF program. If networkNamespaces is not specified, the eBPF
 	// program will be attached in the root network namespace.
 	// +optional
 	NetworkNamespaces *ClNetworkNamespaceSelector `json:"networkNamespaces,omitempty"`
 
-	// priority specifies the priority of the bpf program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is an optional field and determines the execution order of the XDP
+	// program relative to other XDP programs attached to the same attachment
+	// point. It must be a value between 0 and 1000, where lower values indicate
+	// higher precedence. For XDP programs on the same attachment point with the
+	// same priority, the most recently attached program has a lower precedence. If
+	// not provided, priority will default to 1000.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	// +optional
+	// +kubebuilder:default:=1000
 	Priority int32 `json:"priority,omitempty"`
 
-	// proceedOn allows the user to call other xdp programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is an optional field and allows the user to call other XDP
+	// programs in a chain, or not call the next program in a chain based on the
+	// exit code of an XDP program. Allowed values, which are the possible exit
+	// codes from an XDP eBPF program, are:
+	//   Aborted, Drop, Pass, TX, ReDirect, DispatcherReturn
+	//
+	// Multiple values are supported. Default is Pass and DispatcherReturn. So
+	// using the default values, if an XDP program returns Pass, the next XDP
+	// program in the chain will be called. If an XDP program returns Drop, the
+	// next XDP program in the chain will NOT be called.
 	// +optional
 	// +kubebuilder:default:={Pass,DispatcherReturn}
 	ProceedOn []XdpProceedOnValue `json:"proceedOn,omitempty"`
 }
 
 type ClXdpProgramInfoState struct {
-	// links is the list of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the XDP program. Each entry in the
+	// list includes a linkStatus, which indicates if the attachment was successful
+	// or not on this node, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	Links []ClXdpAttachInfoState `json:"links,omitempty"`
 }
@@ -66,22 +91,27 @@ type ClXdpProgramInfoState struct {
 type ClXdpAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// interfaceName is the interface name to attach the xdp program to.
+	// interfaceName is the name of the interface the XDP program should be
+	// attached.
+	// +required
 	InterfaceName string `json:"interfaceName"`
 
-	// netnsPath is an optional path for a network namespace to attach the xdp
-	// program in.
+	// netnsPath is the optional path to the network namespace inside of which the
+	// XDP program should be attached.
 	// +optional
 	NetnsPath string `json:"netnsPath,omitempty"`
 
-	// priority specifies the priority of the xdp program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is the provisioned priority of the XDP program in relation to other
+	// programs of the same type with the same attach point. It is a value from 0
+	// to 1000, where lower values have higher precedence.
+	// +required
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
 	Priority int32 `json:"priority"`
 
-	// proceedOn allows the user to call other xdp programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+	// user to call other TC programs in a chain, or not call the next program in a
+	// chain based on the exit code of a TC program .Multiple values are supported.
+	// +required
 	ProceedOn []XdpProceedOnValue `json:"proceedOn"`
 }

--- a/apis/v1alpha1/shared_types.go
+++ b/apis/v1alpha1/shared_types.go
@@ -21,57 +21,75 @@ import (
 )
 
 type InterfaceDiscovery struct {
-	// interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-	// automatically attaching eBPF hooks to newly discovered interfaces in both directions.
-	//+kubebuilder:default:=false
+	// interfaceAutoDiscovery is an optional field. When enabled, the agent
+	// monitors the creation and deletion of interfaces and automatically attached
+	// eBPF programs to the newly discovered interfaces in both directions.
+	// CAUTION: This has the potential to attach a given eBPF program to a large
+	// number of interfaces. Use with caution.
 	// +optional
+	// +kubebuilder:default:=false
 	InterfaceAutoDiscovery *bool `json:"interfaceAutoDiscovery,omitempty"`
 
-	// excludeInterfaces contains the interface names that are excluded from interface discovery
-	// it is matched as a case-sensitive string.
-	//+kubebuilder:default:={"lo"}
-	//+optional
+	// excludeInterfaces is an optional field that contains a list of interface
+	// names that are excluded from interface discovery. The interface names in
+	// the list are case-sensitive. By default, the list contains the loopback
+	// interface, "lo". This field is only taken into consideration if
+	// interfaceAutoDiscovery is set to true.
+	// +optional
+	// +kubebuilder:default:={"lo"}
 	ExcludeInterfaces []string `json:"excludeInterfaces,omitempty"`
 
-	// allowedInterfaces contains the interface names. If empty, the agent
-	// fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-	// An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-	// Otherwise, it is matched as a case-sensitive string.
-	//+optional
+	// allowedInterfaces is an optional field that contains a list of interface
+	// names that are allowed to be discovered. If empty, the agent will fetch all
+	// the interfaces in the system, excepting the ones listed in
+	// excludeInterfaces. if non-empty, only entries in the list will be considered
+	// for discovery. If an entry enclosed by slashes, such as `/br-/` or
+	// `/veth*/`, then the entry is considered as a regular expression for
+	// matching. Otherwise, the interface names in the list are case-sensitive.
+	// This field is only taken into consideration if interfaceAutoDiscovery is set
+	// to true.
+	// +optional
 	AllowedInterfaces []string `json:"allowedInterfaces,omitempty"`
 }
 
-// InterfaceSelector defines interface to attach to.
+// InterfaceSelector defines how to attach to interfaces.
 // +kubebuilder:validation:MaxProperties=1
 // +kubebuilder:validation:MinProperties=1
 type InterfaceSelector struct {
-	// discoveryConfig allow configuring interface discovery functionality,
+	// interfacesDiscoveryConfig is an optional field that is used to control if
+	// and how to automatically discover interfaces. If the agent should
+	// automatically discover and attach eBPF programs to interfaces, use the
+	// fields under interfacesDiscoveryConfig to control what is allow and excluded
+	// from discovery.
 	// +optional
 	InterfacesDiscoveryConfig *InterfaceDiscovery `json:"interfacesDiscoveryConfig,omitempty"`
 
-	// interfaces refers to a list of network interfaces to attach the BPF
-	// program to.
+	// interfaces is an optional field and is a list of network interface names to
+	// attach the eBPF program. The interface names in the list are case-sensitive.
 	// +optional
 	Interfaces []string `json:"interfaces,omitempty"`
 
-	// primaryNodeInterface to attach BPF program to the primary interface on the node. Only 'true' accepted.
+	// primaryNodeInterface is and optional field and indicates to attach the eBPF
+	// program to the primary interface on the Kubernetes node. Only 'true' is
+	// accepted.
 	// +optional
 	PrimaryNodeInterface *bool `json:"primaryNodeInterface,omitempty"`
 }
 
-// ClContainerSelector identifies a set of containers. For example, this can be
-// used to identify a set of containers in which to attach uprobes.
 type ClContainerSelector struct {
-	// namespaces indicate the target namespaces.
+	// namespace is an optional field and indicates the target Kubernetes
+	// namespace. If not provided, the default Kubernetes namespace is used.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
-	// pods indicate the target pods. This field must be specified, to select all pods use
-	// standard metav1.LabelSelector semantics and make it empty.
+	// pods is a required field and indicates the target pods. To select all pods
+	// use the standard metav1.LabelSelector semantics and make it empty.
+	// +required
 	Pods metav1.LabelSelector `json:"pods"`
 
-	// containerNames indicate the Name(s) of container(s).  If none are specified, all containers in the
-	// pod are selected.
+	// containerNames is an optional field and is a list of container names in a
+	// pod to attach the eBPF program. If no names are  specified, all containers
+	// in the pod are selected.
 	// +optional
 	ContainerNames []string `json:"containerNames,omitempty"`
 }
@@ -80,12 +98,14 @@ type ClContainerSelector struct {
 // in that "Namespace" was removed. Namespace scoped programs can only attach to the namespace
 // they are created in, so namespace at this level doesn't apply.
 type ContainerSelector struct {
-	// pods indicate the target pods. This field must be specified, to select all pods use
-	// standard metav1.LabelSelector semantics and make it empty.
+	// pods is a required field and indicates the target pods. To select all pods
+	// use the standard metav1.LabelSelector semantics and make it empty.
+	// +required
 	Pods metav1.LabelSelector `json:"pods"`
 
-	// containerNames indicate the name(s) of container(s).  If none are specified, all containers in the
-	// pod are selected.
+	// containerNames is an optional field and is a list of container names in a
+	// pod to attach the eBPF program. If no names are  specified, all containers
+	// in the pod are selected.
 	// +optional
 	ContainerNames []string `json:"containerNames,omitempty"`
 }
@@ -93,53 +113,65 @@ type ContainerSelector struct {
 // ClNetworkNamespaceSelector identifies a network namespace for network-related
 // program types in the cluster-scoped ClusterBpfApplication object.
 type ClNetworkNamespaceSelector struct {
-	// Target namespace.
+	// namespace is an optional field and indicates the target network namespace.
+	// If not provided, the default network namespace is used.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
-	// Target pods. This field must be specified, to select all pods use
-	// standard metav1.LabelSelector semantics and make it empty.
+	// pods is a required field and indicates the target pods. To select all pods
+	// use the standard metav1.LabelSelector semantics and make it empty.
+	// +required
 	Pods metav1.LabelSelector `json:"pods"`
 }
 
 // NetworkNamespaceSelector identifies a network namespace for network-related
 // program types in the namespace-scoped BpfApplication object.
 type NetworkNamespaceSelector struct {
-	// Target pods. This field must be specified, to select all pods use
-	// standard metav1.LabelSelector semantics and make it empty.
+	// pods is a required field and indicates the target pods. To select all pods
+	// use the standard metav1.LabelSelector semantics and make it empty.
+	// +required
 	Pods metav1.LabelSelector `json:"pods"`
 }
 
 // BpfAppCommon defines the common attributes for all BpfApp programs
 type BpfAppCommon struct {
-	// nodeSelector allows the user to specify which nodes to deploy the
-	// bpf program to. This field must be specified, to select all nodes
-	// use standard metav1.LabelSelector semantics and make it empty.
+	// nodeSelector is a required field and allows the user to specify which
+	// Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+	// standard metav1.LabelSelector semantics and make it empty.
+	// +required
 	NodeSelector metav1.LabelSelector `json:"nodeSelector"`
 
-	// globalData allows the user to set global variables when the program is loaded
-	// with an array of raw bytes. This is a very low level primitive. The caller
-	// is responsible for formatting the byte string appropriately considering
-	// such things as size, endianness, alignment and packing of data structures.
+	// globalData is an optional field that allows the user to set global variables
+	// when the program is loaded. This allows the same compiled bytecode to be
+	// deployed by different BPF Applications to behave differently based on
+	// globalData configuration values.  It uses an array of raw bytes. This is a
+	// very low level primitive. The caller is responsible for formatting the byte
+	// string appropriately considering such things as size, endianness, alignment
+	// and packing of data structures.
 	// +optional
 	GlobalData map[string][]byte `json:"globalData,omitempty"`
 
-	// bytecode configures where the bpf program's bytecode should be loaded
-	// from.
+	// bytecode is a required field and configures where the eBPF program's
+	// bytecode should be loaded from. The image must contain one or more
+	// eBPF programs.
+	// +required
 	ByteCode ByteCodeSelector `json:"byteCode"`
 
-	// TODO: need to work out how MapOwnerSelector will work after load-attach-split
-	// mapOwnerSelector is used to select the loaded eBPF program this eBPF program
-	// will share a map with.
+	// mapOwnerSelector is an optional field used to share maps across
+	// applications. eBPF programs loaded with the same ClusterBpfApplication or
+	// BpfApplication instance do not need to use this field. This label selector
+	// allows maps from a different ClusterBpfApplication or BpfApplication
+	// instance to be used by this instance.
+	// TODO: mapOwnerSelector is currently not supported due to recent code rework.
 	// +optional
 	MapOwnerSelector *metav1.LabelSelector `json:"mapOwnerSelector,omitempty"`
 }
 
-// BpfAppStatus reflects the status of a BpfApplication or BpfApplicationState object
+// status reflects the status of a BPF Application and indicates if all the
+// eBPF programs for a given instance loaded successfully or not.
 type BpfAppStatus struct {
-	// For a BpfApplication object, Conditions contains the global cluster state
-	// for the object. For a BpfApplicationState object, Conditions contains the
-	// state of the BpfApplication object on the given node.
+	// conditions contains the summary state for all eBPF programs defined in the
+	// BPF Application instance for all the Kubernetes nodes in the cluster.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -151,8 +183,10 @@ type BpfAppStatus struct {
 // application program
 type AttachInfoStateCommon struct {
 	// shouldAttach reflects whether the attachment should exist.
+	// +required
 	ShouldAttach bool `json:"shouldAttach"`
 	// uuid is an Unique identifier for the attach point assigned by bpfman agent.
+	// +required
 	UUID string `json:"uuid"`
 	// linkId is an identifier for the link assigned by bpfman. This field is
 	// empty until the program is successfully attached and bpfman returns the
@@ -161,15 +195,18 @@ type AttachInfoStateCommon struct {
 	LinkId *uint32 `json:"linkId,omitempty"`
 	// linkStatus reflects whether the attachment has been reconciled
 	// successfully, and if not, why.
+	// +required
 	LinkStatus LinkStatus `json:"linkStatus"`
 }
 
 type BpfProgramStateCommon struct {
-	// name is the name of the function that is the entry point for the BPF
+	// name is the name of the function that is the entry point for the eBPF
 	// program
+	// +required
 	Name string `json:"name"`
 	// programLinkStatus reflects whether all links requested for the program
 	// are in the correct state.
+	// +required
 	ProgramLinkStatus ProgramLinkStatus `json:"programLinkStatus"`
 	// programId is the id of the program in the kernel.  Not set until the
 	// program is loaded.
@@ -190,43 +227,65 @@ const (
 	PullIfNotPresent PullPolicy = "IfNotPresent"
 )
 
-// ByteCodeSelector defines the various ways to reference bpf bytecode objects.
+// ByteCodeSelector defines the various ways to reference BPF bytecode objects.
+// +kubebuilder:validation:MaxProperties=1
+// +kubebuilder:validation:MinProperties=1
 type ByteCodeSelector struct {
-	// image used to specify a bytecode container image.
+	// image is an optional field and used to specify details on how to retrieve an
+	// eBPF program packaged in a OCI container image from a given registry.
 	// +optional
 	Image *ByteCodeImage `json:"image,omitempty"`
 
-	// path is used to specify a bytecode object via filepath.
-	// +kubebuilder:validation:Pattern=`^(/[^/\0]+)+/?$`
+	// path is an optional field and used to specify a bytecode object file via
+	// filepath on a Kubernetes node.
 	// +optional
+	// +kubebuilder:validation:Pattern=`^(/[^/\0]+)+/?$`
 	Path *string `json:"path,omitempty"`
 }
 
 // ByteCodeImage defines how to specify a bytecode container image.
 type ByteCodeImage struct {
-	// url is a valid container image URL used to reference a remote bytecode image.
+	// url is a required field and is a valid container image URL used to reference
+	// a remote bytecode image. url must not be an empty string, must not exceed
+	// 525 characters in length and must be a valid URL.
+	// +required
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength:=525
 	// +kubebuilder:validation:Pattern=`[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`
 	Url string `json:"url"`
 
-	// pullPolicy describes a policy for if/when to pull a bytecode image. Defaults to IfNotPresent.
-	// +kubebuilder:default:=IfNotPresent
+	// pullPolicy is an optional field that describes a policy for if/when to pull
+	// a bytecode image. Defaults to IfNotPresent. Allowed values are:
+	//   Always, IfNotPresent and Never
+	//
+	// When set to Always, the given image will be pulled even if the image is
+	// already present on the node.
+	//
+	// When set to IfNotPresent, the given image will only be pulled if it is not
+	// present on the node.
+	//
+	// When set to Never, the given image will never be pulled and must be load on
+	// the node by some other means.
 	// +optional
+	// +kubebuilder:default:=IfNotPresent
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty"`
 
-	// imagePullSecret is the name of the secret bpfman should use to get remote image
-	// repository secrets.
+	// imagePullSecret is an optional field and indicates the secret which contains
+	// the credentials to access the image repository.
 	// +optional
 	ImagePullSecret *ImagePullSecretSelector `json:"imagePullSecret,omitempty"`
 }
 
 // ImagePullSecretSelector defines the name and namespace of an image pull secret.
 type ImagePullSecretSelector struct {
-	// name of the secret which contains the credentials to access the image repository.
+	// name is a required field and is the name of the secret which contains the
+	// credentials to access the image repository.
+	// +required
 	Name string `json:"name"`
 
-	// namespace of the secret which contains the credentials to access the image repository.
+	// namespace is a required field and is the namespace of the secret which
+	// contains the credentials to access the image repository.
+	// +required
 	Namespace string `json:"namespace"`
 }
 
@@ -243,7 +302,7 @@ const (
 	// the Bpf Application on all nodes in the cluster.
 	BpfAppCondPending BpfApplicationConditionType = "Pending"
 
-	// BpfAppCondSuccess indicates that the BPF application has been
+	// BpfAppCondSuccess indicates that the BPF Application has been
 	// successfully loaded and attached as requested on all nodes in the
 	// cluster.
 	BpfAppCondSuccess BpfApplicationConditionType = "Success"
@@ -327,7 +386,7 @@ const (
 	// reconciling the Bpf Application on the given node.
 	BpfAppStateCondPending BpfApplicationStateConditionType = "Pending"
 
-	// BpfAppStateCondSuccess indicates that the BPF application has been
+	// BpfAppStateCondSuccess indicates that the BPF Application has been
 	// successfully loaded and attached as requested on the given node.
 	BpfAppStateCondSuccess BpfApplicationStateConditionType = "Success"
 
@@ -415,7 +474,7 @@ const (
 	AppUnloadError AppLoadStatus = "UnloadError"
 	// The app is not selected to run on the node
 	NotSelected AppLoadStatus = "NotSelected"
-	// The app is not selected to run on the node
+	// The program list has changed which is not allowed
 	ProgListChangedError AppLoadStatus = "ProgramListChangedError"
 )
 

--- a/apis/v1alpha1/shared_types.go
+++ b/apis/v1alpha1/shared_types.go
@@ -22,8 +22,8 @@ import (
 
 type InterfaceDiscovery struct {
 	// interfaceAutoDiscovery is an optional field. When enabled, the agent
-	// monitors the creation and deletion of interfaces and automatically attached
-	// eBPF programs to the newly discovered interfaces in both directions.
+	// monitors the creation and deletion of interfaces and automatically
+	// attached eBPF programs to the newly discovered interfaces.
 	// CAUTION: This has the potential to attach a given eBPF program to a large
 	// number of interfaces. Use with caution.
 	// +optional
@@ -52,7 +52,7 @@ type InterfaceDiscovery struct {
 	AllowedInterfaces []string `json:"allowedInterfaces,omitempty"`
 }
 
-// InterfaceSelector defines how to attach to interfaces.
+// InterfaceSelector describes the set of interfaces to attach a program to.
 // +kubebuilder:validation:MaxProperties=1
 // +kubebuilder:validation:MinProperties=1
 type InterfaceSelector struct {
@@ -76,9 +76,10 @@ type InterfaceSelector struct {
 	PrimaryNodeInterface *bool `json:"primaryNodeInterface,omitempty"`
 }
 
+// ClContainerSelector identifies a set of containers.
 type ClContainerSelector struct {
 	// namespace is an optional field and indicates the target Kubernetes
-	// namespace. If not provided, the default Kubernetes namespace is used.
+	// namespace. If not provided, all Kubernetes namespaces are included.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
@@ -88,15 +89,15 @@ type ClContainerSelector struct {
 	Pods metav1.LabelSelector `json:"pods"`
 
 	// containerNames is an optional field and is a list of container names in a
-	// pod to attach the eBPF program. If no names are  specified, all containers
+	// pod to attach the eBPF program. If no names are specified, all containers
 	// in the pod are selected.
 	// +optional
 	ContainerNames []string `json:"containerNames,omitempty"`
 }
 
-// ContainerSelector identifies a set of containers. It is different from ContainerSelector
+// ContainerSelector identifies a set of containers. It is different from ClContainerSelector
 // in that "Namespace" was removed. Namespace scoped programs can only attach to the namespace
-// they are created in, so namespace at this level doesn't apply.
+// they are created in.
 type ContainerSelector struct {
 	// pods is a required field and indicates the target pods. To select all pods
 	// use the standard metav1.LabelSelector semantics and make it empty.
@@ -264,8 +265,8 @@ type ByteCodeImage struct {
 	// When set to IfNotPresent, the given image will only be pulled if it is not
 	// present on the node.
 	//
-	// When set to Never, the given image will never be pulled and must be load on
-	// the node by some other means.
+	// When set to Never, the given image will never be pulled and must be
+	// loaded on the node by some other means.
 	// +optional
 	// +kubebuilder:default:=IfNotPresent
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/apis/v1alpha1/tc_program_types.go
+++ b/apis/v1alpha1/tc_program_types.go
@@ -17,49 +17,83 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// TcProgramInfo defines the tc program details
 type TcProgramInfo struct {
-	// links is the list of points to which the program should be attached.  The list items
-	// are optional and may be updated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// TC program should be attached. The TC program is loaded in kernel memory
+	// when the BPF Application CRD is created and the selected Kubernetes nodes
+	// are active. The TC program will not be triggered until the program has also
+	// been attached to an attachment point described in this list. Items may be
+	// added or removed from the list at any point, causing the TC program to be
+	// attached or detached.
+	//
+	// The attachment point for a TC program is a network interface (or device).
+	// The interface can be specified by name, by allowing bpfman to discover each
+	// interface, or by setting the primaryNodeInterface flag, which instructs
+	// bpfman to use the primary interface of a Kubernetes node. Optionally, the
+	// TC program can also be installed into a set of network namespaces.
 	// +optional
 	Links []TcAttachInfo `json:"links,omitempty"`
 }
 
 type TcAttachInfo struct {
-	// interfaceSelector to determine the network interface (or interfaces)
+	// interfaceSelector is a required field and is used to determine the network
+	// interface (or interfaces) the TC program is attached. Interface list is set
+	// by providing a list of interface names, enabling auto discovery, or setting
+	// the primaryNodeInterface flag, but only one option is allowed.
+	// +required
 	InterfaceSelector InterfaceSelector `json:"interfaceSelector"`
 
-	// networkNamespaces identifies the set of network namespaces in which to
-	// attach the eBPF program. If networkNamespaces is not specified, the BPF
-	// program will be attached in the root network namespace.
+	// networkNamespaces is a required field that identifies the set of network
+	// namespaces in which to attach the eBPF program.
+	// +required
 	NetworkNamespaces NetworkNamespaceSelector `json:"networkNamespaces"`
 
-	// direction specifies the direction of traffic the tc program should
-	// attach to for a given network device.
+	// direction is a required field and specifies the direction of traffic.
+	// Allowed values are:
+	//    Ingress, Egress
+	//
+	// When set to Ingress, the TC program is triggered when packets are received
+	// by the interface.
+	//
+	// When set to Egress, the TC program is triggered when packets are to be
+	// transmitted by the interface.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tc program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is an optional field and determines the execution order of the TC
+	// program relative to other TC programs attached to the same attachment point.
+	// It must be a value between 0 and 1000, where lower values indicate higher
+	// precedence. For TC programs on the same attachment point with the same
+	// direction and priority, the most recently attached program has a lower
+	// precedence. If not provided, priority will default to 1000.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	// +optional
+	// +kubebuilder:default:=1000
 	Priority int32 `json:"priority,omitempty"`
 
-	// proceedOn allows the user to call other tc programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is an optional field and allows the user to call other TC programs
+	// in a chain, or not call the next program in a chain based on the exit code
+	// of a TC program. Allowed values, which are the possible exit codes from a TC
+	// eBPF program, are:
+	//   UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+	//   Trap, DispatcherReturn
+	//
+	// Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+	// using the default values, if a TC program returns Pipe, the next TC
+	// program in the chain will be called. If a TC program returns Stolen, the
+	// next TC program in the chain will NOT be called.
 	// +optional
 	// +kubebuilder:default:={Pipe,DispatcherReturn}
 	ProceedOn []TcProceedOnValue `json:"proceedOn,omitempty"`
 }
 
 type TcProgramInfoState struct {
-	// links is the List of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the TC program. Each entry in the
+	// list includes a linkStatus, which indicates if the attachment was successful
+	// or not on this node, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	Links []TcAttachInfoState `json:"links,omitempty"`
 }
@@ -67,25 +101,33 @@ type TcProgramInfoState struct {
 type TcAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// interfaceName is the Interface name to attach the tc program to.
+	// interfaceName is the name of the interface the TC program should be
+	// attached.
+	// +required
 	InterfaceName string `json:"interfaceName"`
 
-	// netnsPath is a path to a Network namespace to attach the tc program in.
+	// netnsPath is the path to the network namespace inside of which the TC
+	// program should be attached.
+	// +required
 	NetnsPath string `json:"netnsPath"`
 
-	// direction specifies the direction of traffic the tc program should
-	// attach to for a given network device.
+	// direction is the provisioned direction of traffic, Ingress or Egress, the TC
+	// program should be attached for a given network device.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tc program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is the provisioned priority of the TC program in relation to other
+	// programs of the same type with the same attach point. It is a value from 0
+	// to 1000, where lower values have higher precedence.
+	// +required
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
 	Priority int32 `json:"priority"`
 
-	// proceedOn allows the user to call other tc programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+	// user to call other TC programs in a chain, or not call the next program in a
+	// chain based on the exit code of a TC program .Multiple values are supported.
+	// +required
 	ProceedOn []TcProceedOnValue `json:"proceedOn"`
 }

--- a/apis/v1alpha1/tcx_program_types.go
+++ b/apis/v1alpha1/tcx_program_types.go
@@ -19,39 +19,67 @@ package v1alpha1
 
 // TcxProgramInfo defines the tcx program details
 type TcxProgramInfo struct {
-	// links is The list of points to which the program should be attached.  The list items
-	// are optional and may be updated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// TCX program should be attached. The TCX program is loaded in kernel memory
+	// when the BPF Application CRD is created and the selected Kubernetes nodes
+	// are active. The TCX program will not be triggered until the program has also
+	// been attached to an attachment point described in this list. Items may be
+	// added or removed from the list at any point, causing the TCX program to be
+	// attached or detached.
+	//
+	// The attachment point for a TCX program is a network interface (or device).
+	// The interface can be specified by name, by allowing bpfman to discover each
+	// interface, or by setting the primaryNodeInterface flag, which instructs
+	// bpfman to use the primary interface of a Kubernetes node. Optionally, the
+	// TCX program can also be installed into a set of network namespaces.
 	// +optional
 	Links []TcxAttachInfo `json:"links,omitempty"`
 }
 
 type TcxAttachInfo struct {
-	// interfaceSelector to determine the network interface (or interfaces)
+	// interfaceSelector is a required field and is used to determine the network
+	// interface (or interfaces) the TCX program is attached. Interface list is set
+	// by providing a list of interface names, enabling auto discovery, or setting
+	// the primaryNodeInterface flag, but only one option is allowed.
+	// +required
 	InterfaceSelector InterfaceSelector `json:"interfaceSelector"`
 
-	// networkNamespaces identifies the set of network namespaces in which to
-	// attach the eBPF program.
+	// networkNamespaces is a required field that identifies the set of network
+	// namespaces in which to attach the eBPF program.
+	// +required
 	NetworkNamespaces NetworkNamespaceSelector `json:"networkNamespaces"`
 
-	// direction specifies the direction of traffic the tcx program should
-	// attach to for a given network device.
+	// direction is a required field and specifies the direction of traffic.
+	// Allowed values are:
+	//    Ingress, Egress
+	//
+	// When set to Ingress, the TC program is triggered when packets are received
+	// by the interface.
+	//
+	// When set to Egress, the TC program is triggered when packets are to be
+	// transmitted by the interface.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
 	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tcx program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is an optional field and determines the execution order of the TCX
+	// program relative to other TCX programs attached to the same attachment
+	// point. It must be a value between 0 and 1000, where lower values indicate
+	// higher precedence. For TCX programs on the same attachment point with the
+	// same direction and priority, the most recently attached program has a lower
+	// precedence. If not provided, priority will default to 1000.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	Priority int32 `json:"priority"`
+	// +kubebuilder:default:=1000
+	Priority int32 `json:"priority,omitempty"`
 }
 
 type TcxProgramInfoState struct {
-	// links is the List of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the TCX program. Each entry in the
+	// list includes a linkStatus, which indicates if the attachment was successful
+	// or not on this node, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	Links []TcxAttachInfoState `json:"links,omitempty"`
 }
@@ -59,25 +87,27 @@ type TcxProgramInfoState struct {
 type TcxAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// interfaceName is the Interface name to attach the tc program to.
-	// +optional
-	InterfaceName string `json:"interfaceName,omitempty"`
+	// interfaceName is the name of the interface the TCX program should be
+	// attached.
+	// +required
+	InterfaceName string `json:"interfaceName"`
 
-	// netnsPath is the path to the Network namespace to attach the tcx program
-	// in.
+	// netnsPath is the path to the network namespace inside of which the TCX
+	// program should be attached.
+	// +required
 	NetnsPath string `json:"netnsPath"`
 
-	// direction specifies the direction of traffic the tcx program should
-	// attach to for a given network device.
+	// direction is the provisioned direction of traffic, Ingress or Egress, the
+	// TCX program should be attached for a given network device.
+	// +required
 	// +kubebuilder:validation:Enum=Ingress;Egress
-	// +optional
-	Direction TCDirectionType `json:"direction,omitempty"`
+	Direction TCDirectionType `json:"direction"`
 
-	// priority specifies the priority of the tcx program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is the provisioned priority of the TCX program in relation to other
+	// programs of the same type with the same attach point. It is a value from 0
+	// to 1000, where lower values have higher precedence.
+	// +required
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	// +optional
-	Priority int32 `json:"priority,omitempty"`
+	Priority int32 `json:"priority"`
 }

--- a/apis/v1alpha1/uprobe_program_types.go
+++ b/apis/v1alpha1/uprobe_program_types.go
@@ -66,7 +66,7 @@ type UprobeAttachInfo struct {
 
 	// containers is an optional field that identifies the set of containers in
 	// which to attach the UProbe or URetProbe program. If containers is not
-	// specified, the eBPF program will be attached in the bpfman-agent container.
+	// specified, the eBPF program will be attached in the bpfman container.
 	// uprobe.
 	Containers ContainerSelector `json:"containers"`
 }

--- a/apis/v1alpha1/uprobe_program_types.go
+++ b/apis/v1alpha1/uprobe_program_types.go
@@ -17,46 +17,65 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// UprobeProgramInfo contains the information for the uprobe program
 type UprobeProgramInfo struct {
-	// links is The list of points to which the program should be attached.  The list items
-	// are optional and may be updated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// UProbe or URetProbe program should be attached. The eBPF program is loaded
+	// in kernel memory when the BPF Application CRD is created and the selected
+	// Kubernetes nodes are active. The eBPF program will not be triggered until
+	// the program has also been attached to an attachment point described in this
+	// list. Items may be added or removed from the list at any point, causing the
+	// eBPF program to be attached or detached.
+	//
+	// The attachment point for a UProbe and URetProbe program is a user-space
+	// binary or function. By default, the eBPF program is triggered at the entry
+	// of the attachment point, but the attachment point can be adjusted using an
+	// optional function name and/or offset. Optionally, the eBPF program can be
+	// installed in a set of containers or limited to a specified PID.
 	// +optional
 	Links []UprobeAttachInfo `json:"links,omitempty"`
 }
 
 type UprobeAttachInfo struct {
-	// function to attach the uprobe to.
+	// function is an optional field and specifies the name of a user-space function
+	// to attach the UProbe or URetProbe program. If not provided, the eBPF program
+	// will be triggered on the entry of the target. function must not be an empty
+	// string, must not exceed 64 characters in length, must start with alpha
+	// characters and must only contain alphanumeric characters.
 	// +optional
 	// +kubebuilder:validation:Pattern="^[a-zA-Z][a-zA-Z0-9_]+."
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=64
 	Function string `json:"function,omitempty"`
 
-	// offset added to the address of the function for uprobe.
+	// offset is an optional field and the value is added to the address of the
+	// attachment point function. If not provided, offset defaults to 0.
 	// +optional
 	// +kubebuilder:default:=0
 	Offset uint64 `json:"offset"`
 
-	// target is the Library name or the absolute path to a binary or library.
+	// target is a required field and is the user-space library name or the
+	// absolute path to a binary or library.
+	// +required
 	Target string `json:"target"`
 
-	// pid is only execute uprobe for given process identification number (PID). If PID
-	// is not provided, uprobe executes for all PIDs.
+	// pid is an optional field and if provided, limits the execution of the UProbe
+	// or URetProbe to the provided process identification number (PID). If pid is
+	// not provided, the UProbe or URetProbe executes for all PIDs.
 	// +optional
 	Pid *int32 `json:"pid,omitempty"`
 
-	// containers identify the set of containers in which to attach the
+	// containers is an optional field that identifies the set of containers in
+	// which to attach the UProbe or URetProbe program. If containers is not
+	// specified, the eBPF program will be attached in the bpfman-agent container.
 	// uprobe.
 	Containers ContainerSelector `json:"containers"`
 }
 
 type UprobeProgramInfoState struct {
-	// List of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the UProbe program. Each entry in
+	// the list includes a linkStatus, which indicates if the attachment was
+	// successful or not on this node, a linkId, which is the kernel ID for the
+	// link if successfully attached, and other attachment specific data.
 	// +optional
 	Links []UprobeAttachInfoState `json:"links,omitempty"`
 }
@@ -64,24 +83,31 @@ type UprobeProgramInfoState struct {
 type UprobeAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// function to attach the uprobe to.
+	// function is the provisioned name of the user-space function the UProbe
+	// program should be attached.
 	// +optional
 	Function string `json:"function,omitempty"`
 
-	// offset added to the address of the function for uprobe.
+	// offset is the provisioned offset, whose value is added to the address of the
+	// attachment point function.
 	// +optional
 	// +kubebuilder:default:=0
 	Offset uint64 `json:"offset"`
 
-	// target is the library name or the absolute path to a binary or library.
+	// target is the provisioned user-space library name or the absolute path to a
+	// binary or library.
+	// +required
 	Target string `json:"target"`
 
-	// pid is Only execute uprobe for given process identification number (PID). If PID
-	// is not provided, uprobe executes for all PIDs.
+	// pid is the provisioned pid. If set, pid limits the execution of the UProbe
+	// or URetProbe to the provided process identification number (PID). If pid is
+	// not provided, the UProbe or URetProbe executes for all PIDs.
 	// +optional
 	Pid *int32 `json:"pid,omitempty"`
 
-	// containerPid is container pid to attach the uprobe program in.
+	// If containers is provisioned in the BpfApplication instance, containerPid is
+	// the derived PID of the container the UProbe or URetProbe this attachment
+	// point is attached.
 	// +optional
 	ContainerPid int32 `json:"containerPid,omitempty"`
 }

--- a/apis/v1alpha1/xdp_program_types.go
+++ b/apis/v1alpha1/xdp_program_types.go
@@ -17,43 +17,68 @@ limitations under the License.
 // All fields are required unless explicitly marked optional
 package v1alpha1
 
-// XdpProgramInfo contains the xdp program details
 type XdpProgramInfo struct {
-	// links is the list of points to which the program should be attached.  The list items
-	// are optional and may be udated after the bpf program has been loaded
+	// links is an optional field and is the list of attachment points to which the
+	// XDP program should be attached. The XDP program is loaded in kernel memory
+	// when the BPF Application CRD is created and the selected Kubernetes nodes
+	// are active. The XDP program will not be triggered until the program has also
+	// been attached to an attachment point described in this list. Items may be
+	// added or removed from the list at any point, causing the XDP program to be
+	// attached or detached.
+	//
+	// The attachment point for a XDP program is a network interface (or device).
+	// The interface can be specified by name, by allowing bpfman to discover each
+	// interface, or by setting the primaryNodeInterface flag, which instructs
+	// bpfman to use the primary interface of a Kubernetes node.
 	// +optional
 	Links []XdpAttachInfo `json:"links,omitempty"`
 }
 
 type XdpAttachInfo struct {
-	// interfaceSelector to determine the network interface (or interfaces)
+	// interfaceSelector is a required field and is used to determine the network
+	// interface (or interfaces) the XDP program is attached. Interface list is set
+	// by providing a list of interface names, enabling auto discovery, or setting
+	// the primaryNodeInterface flag, but only one option is allowed.
+	// +required
 	InterfaceSelector InterfaceSelector `json:"interfaceSelector"`
 
-	// networkNamespaces identifies the set of network namespaces in which to
-	// attach the eBPF program.
+	// networkNamespaces is a required field that identifies the set of network
+	// namespaces in which to attach the eBPF program.
+	// +required
 	NetworkNamespaces NetworkNamespaceSelector `json:"networkNamespaces"`
 
-	// priority specifies the priority of the bpf program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is an optional field and determines the execution order of the XDP
+	// program relative to other XDP programs attached to the same attachment
+	// point. It must be a value between 0 and 1000, where lower values indicate
+	// higher precedence. For XDP programs on the same attachment point with the
+	// same priority, the most recently attached program has a lower precedence.
+	// If not provided, priority will default to 1000.
+	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	// +optional
+	// +kubebuilder:default:=1000
 	Priority int32 `json:"priority,omitempty"`
 
-	// proceedOn allows the user to call other xdp programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is an optional field and allows the user to call other XDP
+	// programs in a chain, or not call the next program in a chain based on the
+	// exit code of an XDP program. Allowed values, which are the possible exit
+	// codes from an XDP eBPF program, are:
+	//   Aborted, Drop, Pass, TX, ReDirect,DispatcherReturn
+	//
+	// Multiple values are supported. Default is Pass and DispatcherReturn. So
+	// using the default values, if an XDP program returns Pass, the next XDP
+	// program in the chain will be called. If an XDP program returns Drop, the
+	// next XDP program in the chain will NOT be called.
 	// +optional
 	// +kubebuilder:default:={Pass,DispatcherReturn}
 	ProceedOn []XdpProceedOnValue `json:"proceedOn,omitempty"`
 }
 
 type XdpProgramInfoState struct {
-	// links is the list of attach points for the BPF program on the given node. Each entry
-	// in *AttachInfoState represents a specific, unique attach point that is
-	// derived from *AttachInfo by fully expanding any selectors.  Each entry
-	// also contains information about the attach point required by the
-	// reconciler
+	// links is a list of attachment points for the XDP program. Each entry in the
+	// list includes a linkStatus, which indicates if the attachment was successful
+	// or not on this node, a linkId, which is the kernel ID for the link if
+	// successfully attached, and other attachment specific data.
 	// +optional
 	Links []XdpAttachInfoState `json:"links,omitempty"`
 }
@@ -61,21 +86,27 @@ type XdpProgramInfoState struct {
 type XdpAttachInfoState struct {
 	AttachInfoStateCommon `json:",inline"`
 
-	// interfaceName is the interface name to attach the xdp program to.
+	// interfaceName is the name of the interface the XDP program should be
+	// attached.
+	// +required
 	InterfaceName string `json:"interfaceName"`
 
-	// netnsPath is the path to the Network namespace to attach the xdp program
-	// in.
+	// netnsPath is the path to the network namespace inside of which the XDP
+	// program should be attached.
+	// +required
 	NetnsPath string `json:"netnsPath"`
 
-	// priority specifies the priority of the xdp program in relation to
-	// other programs of the same type with the same attach point. It is a value
-	// from 0 to 1000 where lower values have higher precedence.
+	// priority is the provisioned priority of the XDP program in relation to other
+	// programs of the same type with the same attach point. It is a value from 0
+	// to 1000, where lower values have higher precedence.
+	// +required
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
 	Priority int32 `json:"priority"`
 
-	// proceedOn allows the user to call other xdp programs in chain on this exit code.
-	// Multiple values are supported by repeating the parameter.
+	// proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+	// user to call other TC programs in a chain, or not call the next program in a
+	// chain based on the exit code of a TC program .Multiple values are supported.
+	// +required
 	ProceedOn []XdpProceedOnValue `json:"proceedOn"`
 }

--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -998,7 +998,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:latest
-    createdAt: "2025-04-02T21:50:16Z"
+    createdAt: "2025-04-11T14:23:21Z"
     description: The bpfman Operator is designed to manage eBPF programs for applications.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -149,7 +149,7 @@ metadata:
           "apiVersion": "bpfman.io/v1alpha1",
           "kind": "BpfApplicationState",
           "metadata": {
-            "creationTimestamp": "2025-03-31T11:53:29Z",
+            "creationTimestamp": "2025-04-30T20:59:17Z",
             "finalizers": [
               "bpfman.io.nsbpfapplicationcontroller/finalizer"
             ],
@@ -158,7 +158,7 @@ metadata:
               "bpfman.io/ownedByProgram": "bpfapplication-sample",
               "kubernetes.io/hostname": "bpfman-deployment-control-plane"
             },
-            "name": "bpfapplication-sample-91e81477",
+            "name": "bpfapplication-sample-ed7beed4",
             "namespace": "acme",
             "ownerReferences": [
               {
@@ -167,89 +167,86 @@ metadata:
                 "controller": true,
                 "kind": "BpfApplication",
                 "name": "bpfapplication-sample",
-                "uid": "993bee6d-9129-4de7-9de2-11fe00c6297d"
+                "uid": "a3897014-2014-4585-90a1-ccdb70adeef9"
               }
             ],
-            "resourceVersion": "93093",
-            "uid": "73992afc-4e20-486a-bd64-9562ed1f6a34"
+            "resourceVersion": "1348",
+            "uid": "5728d3b2-a576-4144-be74-e5c83619344e"
           },
-          "spec": {},
           "status": {
             "appLoadStatus": "LoadSuccess",
-            "appStatus": {
-              "conditions": [
-                {
-                  "lastTransitionTime": "2025-03-31T11:54:03Z",
-                  "message": "The BPF application has been successfully loaded and attached",
-                  "reason": "Success",
-                  "status": "True",
-                  "type": "Success"
-                }
-              ]
-            },
+            "conditions": [
+              {
+                "lastTransitionTime": "2025-04-30T21:01:50Z",
+                "message": "The BPF application has been successfully loaded and attached",
+                "reason": "Success",
+                "status": "True",
+                "type": "Success"
+              }
+            ],
             "node": "bpfman-deployment-control-plane",
             "programs": [
               {
                 "name": "tc_pass_test",
-                "programId": 13049,
+                "programId": 1398,
                 "programLinkStatus": "Success",
                 "tc": {
                   "links": [
                     {
                       "direction": "Ingress",
                       "interfaceName": "eth0",
-                      "linkId": 9075174,
+                      "linkId": 1909324080,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/11334/ns/net",
+                      "netnsPath": "/host/proc/3041/ns/net",
                       "priority": 55,
                       "proceedOn": [
                         "Pipe",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "623614c2-8ac6-4907-b4c3-7eb19556c697"
+                      "uuid": "38e00746-b7be-4bcf-bf14-622ad349b4fa"
                     },
                     {
                       "direction": "Ingress",
                       "interfaceName": "eth0",
-                      "linkId": 470449002,
+                      "linkId": 1342701196,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/11297/ns/net",
+                      "netnsPath": "/host/proc/3032/ns/net",
                       "priority": 55,
                       "proceedOn": [
                         "Pipe",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "8b7792a1-267d-49eb-a9fe-9529e1d10704"
+                      "uuid": "ba806cdf-5980-4e7f-8d8f-d819e6a57220"
                     },
                     {
                       "direction": "Ingress",
                       "interfaceName": "eth0",
-                      "linkId": 2104185296,
+                      "linkId": 2698014225,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/12511/ns/net",
+                      "netnsPath": "/host/proc/2792/ns/net",
                       "priority": 55,
                       "proceedOn": [
                         "Pipe",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "2ab314a4-d51a-428d-9205-d9a376cd4f35"
+                      "uuid": "e74fa413-d5df-4aa8-8d17-b580b6cb42a5"
                     },
                     {
                       "direction": "Ingress",
                       "interfaceName": "eth0",
-                      "linkId": 3879948226,
+                      "linkId": 184300305,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/12502/ns/net",
+                      "netnsPath": "/host/proc/2833/ns/net",
                       "priority": 55,
                       "proceedOn": [
                         "Pipe",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "a687c020-8692-4ade-8321-b680cd83960e"
+                      "uuid": "cef8985d-f184-4b18-9ee2-fe21018fae77"
                     }
                   ]
                 },
@@ -257,49 +254,49 @@ metadata:
               },
               {
                 "name": "tcx_next_test",
-                "programId": 13050,
+                "programId": 1399,
                 "programLinkStatus": "Success",
                 "tcx": {
                   "links": [
                     {
                       "direction": "Egress",
                       "interfaceName": "eth0",
-                      "linkId": 356767155,
+                      "linkId": 1256673356,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/11334/ns/net",
+                      "netnsPath": "/host/proc/3041/ns/net",
                       "priority": 100,
                       "shouldAttach": true,
-                      "uuid": "2964d2f8-df64-4c5a-94e1-09597f60ed3e"
+                      "uuid": "3feed40b-fe4b-4a69-8e91-49624df45673"
                     },
                     {
                       "direction": "Egress",
                       "interfaceName": "eth0",
-                      "linkId": 3971612108,
+                      "linkId": 18009714,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/11297/ns/net",
+                      "netnsPath": "/host/proc/3032/ns/net",
                       "priority": 100,
                       "shouldAttach": true,
-                      "uuid": "5e1a3762-ee04-4f39-91bd-6fcc1e8b9d13"
+                      "uuid": "37b02539-0884-418d-bee4-31456384495e"
                     },
                     {
                       "direction": "Egress",
                       "interfaceName": "eth0",
-                      "linkId": 3278813340,
+                      "linkId": 3446068106,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/12511/ns/net",
+                      "netnsPath": "/host/proc/2792/ns/net",
                       "priority": 100,
                       "shouldAttach": true,
-                      "uuid": "53bc603a-fcc1-45ac-aef0-fca770a0e268"
+                      "uuid": "24a56373-8967-46f4-bbd4-423a7872f18b"
                     },
                     {
                       "direction": "Egress",
                       "interfaceName": "eth0",
-                      "linkId": 2268269530,
+                      "linkId": 733646956,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/12502/ns/net",
+                      "netnsPath": "/host/proc/2833/ns/net",
                       "priority": 100,
                       "shouldAttach": true,
-                      "uuid": "94910ca2-f6a2-458c-b868-5acf0796d60f"
+                      "uuid": "4c855178-0a35-4ac6-abf7-83e61541aca4"
                     }
                   ]
                 },
@@ -307,168 +304,168 @@ metadata:
               },
               {
                 "name": "uprobe_test",
-                "programId": 13051,
+                "programId": 1400,
                 "programLinkStatus": "Success",
                 "type": "UProbe",
                 "uprobe": {
                   "links": [
                     {
-                      "containerPid": 11334,
+                      "containerPid": 3041,
                       "function": "malloc",
-                      "linkId": 3327245542,
+                      "linkId": 3629930733,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "89870861-20a6-4c6c-a42f-f0e4aaa2d27b"
+                      "uuid": "ed72f8a7-cdc9-4245-8c40-c645fa5969d7"
                     },
                     {
-                      "containerPid": 11297,
+                      "containerPid": 3032,
                       "function": "malloc",
-                      "linkId": 3161457287,
+                      "linkId": 1860984127,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "2fc05309-1c96-4da4-b31a-f72a074e825b"
+                      "uuid": "5c3b196d-bbe9-4b2c-8c5c-9d78c5ed6512"
                     },
                     {
-                      "containerPid": 12511,
+                      "containerPid": 2792,
                       "function": "malloc",
-                      "linkId": 3840558596,
+                      "linkId": 3256920823,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "11a56460-6753-487e-9485-444e13fa34e2"
+                      "uuid": "927071d2-c574-4c1f-87f2-baa5e7cfcc8f"
                     },
                     {
-                      "containerPid": 12502,
+                      "containerPid": 2833,
                       "function": "malloc",
-                      "linkId": 2650626549,
+                      "linkId": 3700254381,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "168264ab-c59c-4f42-8903-8e0c50734f01"
+                      "uuid": "fd351a1a-fb83-4b6c-af2f-c84906c6b54b"
                     }
                   ]
                 }
               },
               {
                 "name": "uretprobe_test",
-                "programId": 13052,
+                "programId": 1401,
                 "programLinkStatus": "Success",
                 "type": "URetProbe",
                 "uretprobe": {
                   "links": [
                     {
-                      "containerPid": 11334,
+                      "containerPid": 3041,
                       "function": "malloc",
-                      "linkId": 875680773,
+                      "linkId": 4161687115,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "ff4638d3-4149-467c-a192-763f58cece20"
+                      "uuid": "2c8ad027-eca0-4da9-baa6-f7b6f0fc25fd"
                     },
                     {
-                      "containerPid": 11297,
+                      "containerPid": 3032,
                       "function": "malloc",
-                      "linkId": 1673370364,
+                      "linkId": 3445215503,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "2ed62e97-79c5-40a5-b6e0-e0e6f764e5cb"
+                      "uuid": "623f2642-9f85-45ca-bab4-8f98d8a31079"
                     },
                     {
-                      "containerPid": 12511,
+                      "containerPid": 2792,
                       "function": "malloc",
-                      "linkId": 1577310058,
+                      "linkId": 1387817990,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "10875abe-a1ef-4b8b-a10b-9fa724be8f5b"
+                      "uuid": "fe81f29b-493d-41a9-b1c7-35733c9ee861"
                     },
                     {
-                      "containerPid": 12502,
+                      "containerPid": 2833,
                       "function": "malloc",
-                      "linkId": 869427060,
+                      "linkId": 2271422622,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "cdc3632c-b2e7-466e-8a47-dea0a3d15bd9"
+                      "uuid": "d6af1106-2c72-4f7d-9ee9-5c32e59e03b7"
                     }
                   ]
                 }
               },
               {
                 "name": "xdp_pass_test",
-                "programId": 13054,
+                "programId": 1402,
                 "programLinkStatus": "Success",
                 "type": "XDP",
                 "xdp": {
                   "links": [
                     {
                       "interfaceName": "eth0",
-                      "linkId": 1076298761,
+                      "linkId": 1752219747,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/11334/ns/net",
+                      "netnsPath": "/host/proc/3041/ns/net",
                       "priority": 100,
                       "proceedOn": [
                         "Pass",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "424cd0ee-1af3-41cb-9da1-447f7feedef1"
+                      "uuid": "17760ccc-5ca7-4d21-9590-5f6e5c0fd4ab"
                     },
                     {
                       "interfaceName": "eth0",
-                      "linkId": 44043353,
+                      "linkId": 3877814802,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/11297/ns/net",
+                      "netnsPath": "/host/proc/3032/ns/net",
                       "priority": 100,
                       "proceedOn": [
                         "Pass",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "fc14fba2-8ace-4187-95a3-867648b22291"
+                      "uuid": "194d2096-a15f-417f-9be6-2032217f3e86"
                     },
                     {
                       "interfaceName": "eth0",
-                      "linkId": 2949403124,
+                      "linkId": 2514284800,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/12511/ns/net",
+                      "netnsPath": "/host/proc/2792/ns/net",
                       "priority": 100,
                       "proceedOn": [
                         "Pass",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "0f2d1d93-ea2b-47ca-a877-230415392727"
+                      "uuid": "de0f43b3-6a0e-4c22-8127-9fb519a0238b"
                     },
                     {
                       "interfaceName": "eth0",
-                      "linkId": 2792719200,
+                      "linkId": 1682543086,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/12502/ns/net",
+                      "netnsPath": "/host/proc/2833/ns/net",
                       "priority": 100,
                       "proceedOn": [
                         "Pass",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "191018f1-a4eb-48cc-9fc0-77d123a00537"
+                      "uuid": "84289766-bff1-4af5-a0bd-5d150747a29a"
                     }
                   ]
                 }
               }
             ],
-            "updateCount": 3
+            "updateCount": 2
           }
         },
         {
@@ -706,7 +703,7 @@ metadata:
           "apiVersion": "bpfman.io/v1alpha1",
           "kind": "ClusterBpfApplicationState",
           "metadata": {
-            "creationTimestamp": "2025-03-31T20:38:02Z",
+            "creationTimestamp": "2025-04-30T20:58:34Z",
             "finalizers": [
               "bpfman.io.clbpfapplicationcontroller/finalizer"
             ],
@@ -715,7 +712,7 @@ metadata:
               "bpfman.io/ownedByProgram": "clusterbpfapplication-sample",
               "kubernetes.io/hostname": "bpfman-deployment-control-plane"
             },
-            "name": "clusterbpfapplication-sample-6938aab9",
+            "name": "clusterbpfapplication-sample-d3cc4fee",
             "ownerReferences": [
               {
                 "apiVersion": "bpfman.io/v1alpha1",
@@ -723,18 +720,17 @@ metadata:
                 "controller": true,
                 "kind": "ClusterBpfApplication",
                 "name": "clusterbpfapplication-sample",
-                "uid": "e18c4760-7f89-48bb-ac24-2c01c9f7c7c8"
+                "uid": "ab16b9a6-16bd-4a22-98ec-4268efaf8c8d"
               }
             ],
-            "resourceVersion": "1483",
-            "uid": "7d8eb460-a560-4055-b1fe-5fc66e90736e"
+            "resourceVersion": "1176",
+            "uid": "6e7e7446-306f-46ae-98e6-6ff28d9b5bcd"
           },
-          "spec": {},
           "status": {
             "appLoadStatus": "LoadSuccess",
             "conditions": [
               {
-                "lastTransitionTime": "2025-03-31T20:38:54Z",
+                "lastTransitionTime": "2025-04-30T21:00:16Z",
                 "message": "The BPF application has been successfully loaded and attached",
                 "reason": "Success",
                 "status": "True",
@@ -748,16 +744,16 @@ metadata:
                   "links": [
                     {
                       "function": "try_to_wake_up",
-                      "linkId": 675202769,
+                      "linkId": 818584239,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
-                      "uuid": "4aab6ffe-ec74-4845-ab24-a54def1b555c"
+                      "uuid": "3c71185f-8d68-4be8-92cb-32a14a6f118b"
                     }
                   ]
                 },
                 "name": "kprobe_test",
-                "programId": 13394,
+                "programId": 1323,
                 "programLinkStatus": "Success",
                 "type": "KProbe"
               },
@@ -766,30 +762,30 @@ metadata:
                   "links": [
                     {
                       "function": "try_to_wake_up",
-                      "linkId": 3965865826,
+                      "linkId": 3409359936,
                       "linkStatus": "Attached",
                       "shouldAttach": true,
-                      "uuid": "919a7317-4c47-4576-aada-f93131be7686"
+                      "uuid": "44c75019-f175-4b1e-bb34-d8896e3b0456"
                     }
                   ]
                 },
                 "name": "kretprobe_test",
-                "programId": 13395,
+                "programId": 1324,
                 "programLinkStatus": "Success",
                 "type": "KRetProbe"
               },
               {
                 "name": "tracepoint_test",
-                "programId": 13396,
+                "programId": 1325,
                 "programLinkStatus": "Success",
                 "tracepoint": {
                   "links": [
                     {
-                      "linkId": 3264842258,
+                      "linkId": 2625161294,
                       "linkStatus": "Attached",
                       "name": "syscalls/sys_enter_openat",
                       "shouldAttach": true,
-                      "uuid": "1a2d782c-9c05-4ccb-a5d2-b92589fa5b7d"
+                      "uuid": "40164d8a-5b55-4ff6-8e73-aa53d9180a6d"
                     }
                   ]
                 },
@@ -797,14 +793,14 @@ metadata:
               },
               {
                 "name": "tc_pass_test",
-                "programId": 13398,
+                "programId": 1327,
                 "programLinkStatus": "Success",
                 "tc": {
                   "links": [
                     {
                       "direction": "Ingress",
                       "interfaceName": "eth0",
-                      "linkId": 2292281068,
+                      "linkId": 1304307969,
                       "linkStatus": "Attached",
                       "priority": 55,
                       "proceedOn": [
@@ -812,21 +808,21 @@ metadata:
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "4fc3a458-c93b-404f-9227-4c367a560ec4"
+                      "uuid": "44e6491e-ca98-44a0-b1b7-647b494c84fa"
                     },
                     {
                       "direction": "Egress",
                       "interfaceName": "eth0",
-                      "linkId": 3243360575,
+                      "linkId": 1425071644,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/2560/ns/net",
+                      "netnsPath": "/host/proc/2196/ns/net",
                       "priority": 100,
                       "proceedOn": [
                         "Pipe",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "8b87e1ef-a0e5-4423-abed-68c99b528357"
+                      "uuid": "89a05d8f-bb4a-448a-af11-2605d0094b98"
                     }
                   ]
                 },
@@ -834,28 +830,28 @@ metadata:
               },
               {
                 "name": "tcx_next_test",
-                "programId": 13399,
+                "programId": 1328,
                 "programLinkStatus": "Success",
                 "tcx": {
                   "links": [
                     {
                       "direction": "Ingress",
                       "interfaceName": "eth0",
-                      "linkId": 1974385552,
+                      "linkId": 858546813,
                       "linkStatus": "Attached",
                       "priority": 500,
                       "shouldAttach": true,
-                      "uuid": "18bd4721-21d6-4d44-b229-c2e7d6c215bd"
+                      "uuid": "6dff4163-4d62-4c93-bc34-739a796ddbb4"
                     },
                     {
                       "direction": "Egress",
                       "interfaceName": "eth0",
-                      "linkId": 595062609,
+                      "linkId": 5042726,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/2560/ns/net",
+                      "netnsPath": "/host/proc/2196/ns/net",
                       "priority": 100,
                       "shouldAttach": true,
-                      "uuid": "6817600b-8681-474c-ba26-c6a3ebfedef7"
+                      "uuid": "c066df6a-667e-4382-9e2f-a59f64bc1b7e"
                     }
                   ]
                 },
@@ -863,74 +859,74 @@ metadata:
               },
               {
                 "name": "uprobe_test",
-                "programId": 13400,
+                "programId": 1329,
                 "programLinkStatus": "Success",
                 "type": "UProbe",
                 "uprobe": {
                   "links": [
                     {
-                      "containerPid": 2456,
+                      "containerPid": 2089,
                       "function": "malloc",
-                      "linkId": 1114319296,
+                      "linkId": 2687038538,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "d713c6f1-9b57-4f31-a89a-6d87a9d36ddd"
+                      "uuid": "e48f1563-f56b-41fa-a87d-b8593fc5faca"
                     },
                     {
-                      "containerPid": 2401,
+                      "containerPid": 2040,
                       "function": "malloc",
-                      "linkId": 85632571,
+                      "linkId": 1651822558,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "982c752b-8b09-409a-a494-d30b20cdad9a"
+                      "uuid": "e0d778df-4791-413b-b0f4-13ed1088500c"
                     }
                   ]
                 }
               },
               {
                 "name": "uretprobe_test",
-                "programId": 13401,
+                "programId": 1330,
                 "programLinkStatus": "Success",
                 "type": "URetProbe",
                 "uretprobe": {
                   "links": [
                     {
-                      "containerPid": 2456,
+                      "containerPid": 2089,
                       "function": "malloc",
-                      "linkId": 1248121244,
+                      "linkId": 3774838420,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "13d299ce-86d0-45e2-b0ca-6563fef68b3f"
+                      "uuid": "2f37f466-6ff4-47a1-9c8d-8dd1f97528bb"
                     },
                     {
-                      "containerPid": 2401,
+                      "containerPid": 2040,
                       "function": "malloc",
-                      "linkId": 1307762276,
+                      "linkId": 1373645282,
                       "linkStatus": "Attached",
                       "offset": 0,
                       "shouldAttach": true,
                       "target": "libc",
-                      "uuid": "86eee9a7-8d03-4c9d-a12d-713ef16bb044"
+                      "uuid": "319bbaf0-1c8a-45b4-9d99-5dec27e2e5f1"
                     }
                   ]
                 }
               },
               {
                 "name": "xdp_pass_test",
-                "programId": 13403,
+                "programId": 1332,
                 "programLinkStatus": "Success",
                 "type": "XDP",
                 "xdp": {
                   "links": [
                     {
                       "interfaceName": "eth0",
-                      "linkId": 1916079109,
+                      "linkId": 4243141192,
                       "linkStatus": "Attached",
                       "priority": 55,
                       "proceedOn": [
@@ -938,20 +934,20 @@ metadata:
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "a568d8ba-36f2-4b9f-9159-faa4dffb4088"
+                      "uuid": "c3bea5b9-d3e0-4784-9a17-c286b6661fc2"
                     },
                     {
                       "interfaceName": "eth0",
-                      "linkId": 4014676018,
+                      "linkId": 1465833891,
                       "linkStatus": "Attached",
-                      "netnsPath": "/host/proc/2560/ns/net",
+                      "netnsPath": "/host/proc/2196/ns/net",
                       "priority": 100,
                       "proceedOn": [
                         "Pass",
                         "DispatcherReturn"
                       ],
                       "shouldAttach": true,
-                      "uuid": "4d998752-ed83-4ec0-a6d5-14d6dc23f116"
+                      "uuid": "1e24df86-f3ff-4e0a-8f20-6759272ddb08"
                     }
                   ]
                 }
@@ -961,15 +957,15 @@ metadata:
                   "function": "do_unlinkat",
                   "links": [
                     {
-                      "linkId": 3436717235,
+                      "linkId": 950386839,
                       "linkStatus": "Attached",
                       "shouldAttach": true,
-                      "uuid": "93e04fe2-dc09-48dc-80e5-edbe87d9cfd1"
+                      "uuid": "2eda2367-4540-478b-a40d-cc984475a570"
                     }
                   ]
                 },
                 "name": "fentry_test",
-                "programId": 13404,
+                "programId": 1333,
                 "programLinkStatus": "Success",
                 "type": "FEntry"
               },
@@ -978,27 +974,27 @@ metadata:
                   "function": "do_unlinkat",
                   "links": [
                     {
-                      "linkId": 1957573058,
+                      "linkId": 2243237521,
                       "linkStatus": "Attached",
                       "shouldAttach": true,
-                      "uuid": "feffa69f-e843-4011-b97a-0cc487699f82"
+                      "uuid": "98910fe0-cad6-457f-8797-9f8200106511"
                     }
                   ]
                 },
                 "name": "fexit_test",
-                "programId": 13405,
+                "programId": 1334,
                 "programLinkStatus": "Success",
                 "type": "FExit"
               }
             ],
-            "updateCount": 3
+            "updateCount": 2
           }
         }
       ]
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:latest
-    createdAt: "2025-04-11T14:23:21Z"
+    createdAt: "2025-04-30T21:37:41Z"
     description: The bpfman Operator is designed to manage eBPF programs for applications.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"

--- a/bundle/manifests/bpfman.io_bpfapplications.yaml
+++ b/bundle/manifests/bpfman.io_bpfapplications.yaml
@@ -27,7 +27,17 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BpfApplication is the Schema for the bpfapplications API
+        description: |-
+          BpfApplication is the schema for the namespace scoped BPF Applications API.
+          Using this API allows applications to load one or more eBPF programs on a
+          Kubernetes cluster using bpfman to load the programs.
+
+
+          The bpfApplication.status field reports the overall status of the
+          BpfApplication CRD. A given BpfApplication CRD can result in loading and
+          attaching multiple eBPF programs on multiple nodes, so this status is just a
+          summary. More granular per-node status details can be found in the
+          corresponding BpfApplicationState CRD that bpfman creates for each node.
         properties:
           apiVersion:
             description: |-
@@ -47,20 +57,45 @@ spec:
           metadata:
             type: object
           spec:
-            description: BpfApplicationSpec defines the desired state of BpfApplication
+            description: |-
+              spec defines the desired state of the BpfApplication. The BpfApplication
+              describes the set of one or more namespace scoped eBPF programs that should
+              be loaded for a given application and attributes for how they should be
+              loaded. eBPF programs that are grouped together under the same
+              BpfApplication instance can share maps and global data between the eBPF
+              programs loaded on the same Kubernetes Node.
             properties:
               byteCode:
                 description: |-
-                  bytecode configures where the bpf program's bytecode should be loaded
-                  from.
+                  bytecode is a required field and configures where the eBPF program's
+                  bytecode should be loaded from. The image must contain one or more
+                  eBPF programs.
+                maxProperties: 1
+                minProperties: 1
                 properties:
                   image:
-                    description: image used to specify a bytecode container image.
+                    description: |-
+                      image is an optional field and used to specify details on how to retrieve an
+                      eBPF program packaged in a OCI container image from a given registry.
                     properties:
                       imagePullPolicy:
                         default: IfNotPresent
-                        description: pullPolicy describes a policy for if/when to
-                          pull a bytecode image. Defaults to IfNotPresent.
+                        description: |-
+                          pullPolicy is an optional field that describes a policy for if/when to pull
+                          a bytecode image. Defaults to IfNotPresent. Allowed values are:
+                            Always, IfNotPresent and Never
+
+
+                          When set to Always, the given image will be pulled even if the image is
+                          already present on the node.
+
+
+                          When set to IfNotPresent, the given image will only be pulled if it is not
+                          present on the node.
+
+
+                          When set to Never, the given image will never be pulled and must be load on
+                          the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -68,24 +103,28 @@ spec:
                         type: string
                       imagePullSecret:
                         description: |-
-                          imagePullSecret is the name of the secret bpfman should use to get remote image
-                          repository secrets.
+                          imagePullSecret is an optional field and indicates the secret which contains
+                          the credentials to access the image repository.
                         properties:
                           name:
-                            description: name of the secret which contains the credentials
-                              to access the image repository.
+                            description: |-
+                              name is a required field and is the name of the secret which contains the
+                              credentials to access the image repository.
                             type: string
                           namespace:
-                            description: namespace of the secret which contains the
-                              credentials to access the image repository.
+                            description: |-
+                              namespace is a required field and is the namespace of the secret which
+                              contains the credentials to access the image repository.
                             type: string
                         required:
                         - name
                         - namespace
                         type: object
                       url:
-                        description: url is a valid container image URL used to reference
-                          a remote bytecode image.
+                        description: |-
+                          url is a required field and is a valid container image URL used to reference
+                          a remote bytecode image. url must not be an empty string, must not exceed
+                          525 characters in length and must be a valid URL.
                         maxLength: 525
                         pattern: '[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}'
                         type: string
@@ -93,7 +132,9 @@ spec:
                     - url
                     type: object
                   path:
-                    description: path is used to specify a bytecode object via filepath.
+                    description: |-
+                      path is an optional field and used to specify a bytecode object file via
+                      filepath on a Kubernetes node.
                     pattern: ^(/[^/\0]+)+/?$
                     type: string
                 type: object
@@ -102,16 +143,22 @@ spec:
                   format: byte
                   type: string
                 description: |-
-                  globalData allows the user to set global variables when the program is loaded
-                  with an array of raw bytes. This is a very low level primitive. The caller
-                  is responsible for formatting the byte string appropriately considering
-                  such things as size, endianness, alignment and packing of data structures.
+                  globalData is an optional field that allows the user to set global variables
+                  when the program is loaded. This allows the same compiled bytecode to be
+                  deployed by different BPF Applications to behave differently based on
+                  globalData configuration values.  It uses an array of raw bytes. This is a
+                  very low level primitive. The caller is responsible for formatting the byte
+                  string appropriately considering such things as size, endianness, alignment
+                  and packing of data structures.
                 type: object
               mapOwnerSelector:
                 description: |-
-                  TODO: need to work out how MapOwnerSelector will work after load-attach-split
-                  mapOwnerSelector is used to select the loaded eBPF program this eBPF program
-                  will share a map with.
+                  mapOwnerSelector is an optional field used to share maps across
+                  applications. eBPF programs loaded with the same ClusterBpfApplication or
+                  BpfApplication instance do not need to use this field. This label selector
+                  allows maps from a different ClusterBpfApplication or BpfApplication
+                  instance to be used by this instance.
+                  TODO: mapOwnerSelector is currently not supported due to recent code rework.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -158,9 +205,9 @@ spec:
                 x-kubernetes-map-type: atomic
               nodeSelector:
                 description: |-
-                  nodeSelector allows the user to specify which nodes to deploy the
-                  bpf program to. This field must be specified, to select all nodes
-                  use standard metav1.LabelSelector semantics and make it empty.
+                  nodeSelector is a required field and allows the user to specify which
+                  Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+                  standard metav1.LabelSelector semantics and make it empty.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -207,62 +254,114 @@ spec:
                 x-kubernetes-map-type: atomic
               programs:
                 description: |-
-                  programs is the list of bpf programs in the BpfApplication that should be
-                  loaded. The application can selectively choose which program(s) to run
-                  from this list based on the optional attach points provided.
+                  programs is a required field and is the list of eBPF programs in a BPF
+                  Application CRD that should be loaded in kernel memory. At least one entry
+                  is required. eBPF programs in this list will be loaded on the system based
+                  the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+                  cannot be triggered until an attachment point is provided. The different
+                  program types have different ways of attaching. The attachment points can be
+                  added at creation time or modified (added or removed) at a later time to
+                  activate or deactivate the eBPF program as desired.
+                  CAUTION: When programs are added or removed from the list, that requires all
+                  programs in the list to be reloaded, which could be temporarily service
+                  effecting. For this reason, modifying the list is currently not allowed.
                 items:
                   description: BpfApplicationProgram defines the desired state of
                     BpfApplication
                   properties:
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
-                        program
+                        name is a required field and is the name of the function that is the entry
+                        point for the eBPF program. name must not be an empty string, must not
+                        exceed 64 characters in length, must start with alpha characters and must
+                        only contain alphanumeric characters.
                       maxLength: 64
                       minLength: 1
                       pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: |-
+                        tc is an optional field, but required when the type field is set to TC. tc
+                        defines the desired state of the application's TC programs. TC programs are
+                        attached to network devices (interfaces). The program can be attached on
+                        either packet ingress or egress, so the program will be called on every
+                        incoming or outgoing packet seen by the network device. The TC attachment
+                        point is in Linux's Traffic Control (tc) subsystem, which is after the
+                        Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+                        with enhanced performance and better support for running multiple programs
+                        on a given network device. This makes TC useful for packet classification
+                        actions.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TC program should be attached. The TC program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TC program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TC program to be
+                            attached or detached.
+
+
+                            The attachment point for a TC program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TC program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TC program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -270,34 +369,40 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
-                                  program will be attached in the root network namespace.
+                                  networkNamespaces is a required field that identifies the set of network
+                                  namespaces in which to attach the eBPF program.
                                 properties:
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -347,10 +452,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TC
+                                  program relative to other TC programs attached to the same attachment point.
+                                  It must be a value between 0 and 1000, where lower values indicate higher
+                                  precedence. For TC programs on the same attachment point with the same
+                                  direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -360,8 +469,18 @@ spec:
                                 - Pipe
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other TC programs
+                                  in a chain, or not call the next program in a chain based on the exit code
+                                  of a TC program. Allowed values, which are the possible exit codes from a TC
+                                  eBPF program, are:
+                                    UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+                                    Trap, DispatcherReturn
+
+
+                                  Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+                                  using the default values, if a TC program returns Pipe, the next TC
+                                  program in the chain will be called. If a TC program returns Stolen, the
+                                  next TC program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - UnSpec
@@ -385,46 +504,88 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: |-
+                        tcx is an optional field, but required when the type field is set to TCX.
+                        tcx defines the desired state of the application's TCX programs. TCX
+                        programs are attached to network devices (interfaces). The program can be
+                        attached on either packet ingress or egress, so the program will be called
+                        on every incoming or outgoing packet seen by the network device. The TCX
+                        attachment point is in Linux's Traffic Control (tc) subsystem, which is
+                        after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+                        packet classification actions. TCX is a newer implementation of TC with
+                        enhanced performance and better support for running multiple programs on a
+                        given network device.
                       properties:
                         links:
                           description: |-
-                            links is The list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TCX program should be attached. The TCX program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TCX program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TCX program to be
+                            attached or detached.
+
+
+                            The attachment point for a TCX program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TCX program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TCX program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -432,33 +593,40 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program.
+                                  networkNamespaces is a required field that identifies the set of network
+                                  namespaces in which to attach the eBPF program.
                                 properties:
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -508,10 +676,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TCX
+                                  program relative to other TCX programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For TCX programs on the same attachment point with the
+                                  same direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -520,12 +692,51 @@ spec:
                             - direction
                             - interfaceSelector
                             - networkNamespaces
-                            - priority
                             type: object
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type is a required field used to specify the type of the eBPF program. The
+                        type dictates which eBPF attachment point to use. This is where the eBPF
+                        program is executed.
+
+
+                        Allowed values are:
+                          TC, TCX, UProbe, URetProbe, XDP
+
+
+                        When set to TC, the eBPF program can attach to network devices (interfaces).
+                        The program can be attached on either packet ingress or egress, so the
+                        program will be called on every incoming or outgoing packet seen by the
+                        network device. When using the TC program type, the tc field is required.
+                        See tc for more details on TC programs.
+
+
+                        When set to TCX, the eBPF program can attach to network devices
+                        (interfaces). The program can be attached on either packet ingress or
+                        egress, so the program will be called on every incoming or outgoing packet
+                        seen by the network device. When using the TCX program type, the tcx field
+                        is required. See tcx for more details on TCX programs.
+
+
+                        When set to UProbe, the program can attach in user-space. The UProbe is
+                        attached to a binary, library or function name, and optionally an offset in
+                        the code. When using the UProbe program type, the uprobe field is required.
+                        See uprobe for more details on UProbe programs.
+
+
+                        When set to URetProbe, the program can attach in user-space.
+                        The URetProbe is attached to the return of a binary, library or function
+                        name, and optionally an offset in the code.  When using the URetProbe
+                        program type, the uretprobe field is required. See uretprobe for more
+                        details on URetProbe programs.
+
+
+                        When set to XDP, the eBPF program can attach to network devices (interfaces)
+                        and will be called on every incoming packet received by the network device.
+                        When using the XDP program type, the xdp field is required. See xdp for more
+                        details on XDP programs.
                       enum:
                       - XDP
                       - TC
@@ -534,31 +745,54 @@ spec:
                       - URetProbe
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe is an optional field, but required when the type field is set to
+                        UProbe. uprobe defines the desired state of the application's UProbe
+                        programs. UProbe programs are user-space probes. A target must be provided,
+                        which is the library name or absolute path to a binary or library where the
+                        probe is attached. Optionally, a function name can also be provided to
+                        provide finer granularity on where the probe is attached. They can be
+                        attached at any point in the binary, library or function using the optional
+                        offset field. However, caution must be taken when using the offset, ensuring
+                        the offset is still in the desired bytecode.
                       properties:
                         links:
                           description: |-
-                            links is The list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                   uprobe.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -608,26 +842,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function. If not provided, offset defaults to 0.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - containers
@@ -636,31 +878,55 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobe defines the desired state of the application's
-                        UretprobePrograms.
+                      description: |-
+                        uretprobe is an optional field, but required when the type field is set to
+                        URetProbe. uretprobe defines the desired state of the application's
+                        URetProbe programs. URetProbe programs are user-space probes. A target must
+                        be provided, which is the library name or absolute path to a binary or
+                        library where the probe is attached. Optionally, a function name can also be
+                        provided to provide finer granularity on where the probe is attached. They
+                        are attached to the return point of the binary, library or function, but can
+                        be set anywhere using the optional offset field. However, caution must be
+                        taken when using the offset, ensuring the offset is still in the desired
+                        bytecode.
                       properties:
                         links:
                           description: |-
-                            links is The list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                   uprobe.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -710,26 +976,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function. If not provided, offset defaults to 0.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - containers
@@ -738,38 +1012,67 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: |-
+                        xdp is an optional field, but required when the type field is set to XDP.
+                        xdp defines the desired state of the application's XDP programs. XDP program
+                        can be attached to network devices (interfaces) and will be called on every
+                        incoming packet received by the network device. The XDP attachment point is
+                        just after the packet has been received off the wire, but before the Linux
+                        kernel has allocated an sk_buff, which is used to pass the packet through
+                        the kernel networking stack.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            XDP program should be attached. The XDP program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The XDP program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the XDP program to be
+                            attached or detached.
+
+
+                            The attachment point for a XDP program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node.
                           items:
                             properties:
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the XDP program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -777,33 +1080,40 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program.
+                                  networkNamespaces is a required field that identifies the set of network
+                                  namespaces in which to attach the eBPF program.
                                 properties:
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -853,10 +1163,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the bpf program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the XDP
+                                  program relative to other XDP programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For XDP programs on the same attachment point with the
+                                  same priority, the most recently attached program has a lower precedence.
+                                  If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -866,8 +1180,17 @@ spec:
                                 - Pass
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other XDP
+                                  programs in a chain, or not call the next program in a chain based on the
+                                  exit code of an XDP program. Allowed values, which are the possible exit
+                                  codes from an XDP eBPF program, are:
+                                    Aborted, Drop, Pass, TX, ReDirect,DispatcherReturn
+
+
+                                  Multiple values are supported. Default is Pass and DispatcherReturn. So
+                                  using the default values, if an XDP program returns Pass, the next XDP
+                                  program in the chain will be called. If an XDP program returns Drop, the
+                                  next XDP program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - Aborted
@@ -916,14 +1239,14 @@ spec:
             - nodeSelector
             type: object
           status:
-            description: BpfAppStatus reflects the status of a BpfApplication or BpfApplicationState
-              object
+            description: |-
+              status reflects the status of a BPF Application and indicates if all the
+              eBPF programs for a given instance loaded successfully or not.
             properties:
               conditions:
                 description: |-
-                  For a BpfApplication object, Conditions contains the global cluster state
-                  for the object. For a BpfApplicationState object, Conditions contains the
-                  state of the BpfApplication object on the given node.
+                  conditions contains the summary state for all eBPF programs defined in the
+                  BPF Application instance for all the Kubernetes nodes in the cluster.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for

--- a/bundle/manifests/bpfman.io_bpfapplications.yaml
+++ b/bundle/manifests/bpfman.io_bpfapplications.yaml
@@ -29,8 +29,8 @@ spec:
       openAPIV3Schema:
         description: |-
           BpfApplication is the schema for the namespace scoped BPF Applications API.
-          Using this API allows applications to load one or more eBPF programs on a
-          Kubernetes cluster using bpfman to load the programs.
+          This API allows applications to use bpfman to load and attach one or more
+          eBPF programs on a Kubernetes cluster.
 
 
           The bpfApplication.status field reports the overall status of the
@@ -94,8 +94,8 @@ spec:
                           present on the node.
 
 
-                          When set to Never, the given image will never be pulled and must be load on
-                          the node by some other means.
+                          When set to Never, the given image will never be pulled and must be
+                          loaded on the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -381,8 +381,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -605,8 +605,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -697,9 +697,7 @@ spec:
                       type: object
                     type:
                       description: |-
-                        type is a required field used to specify the type of the eBPF program. The
-                        type dictates which eBPF attachment point to use. This is where the eBPF
-                        program is executed.
+                        type is a required field used to specify the type of the eBPF program.
 
 
                         Allowed values are:
@@ -778,7 +776,7 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                   uprobe.
                                 properties:
                                   containerNames:
@@ -912,7 +910,7 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                   uprobe.
                                 properties:
                                   containerNames:
@@ -1092,8 +1090,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean

--- a/bundle/manifests/bpfman.io_bpfapplicationstates.yaml
+++ b/bundle/manifests/bpfman.io_bpfapplicationstates.yaml
@@ -27,7 +27,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BpfApplicationState contains the per-node state of a BpfApplication.
+        description: |-
+          BpfApplicationState contains the state of a BpfApplication instance for a
+          given Kubernetes node. When a user creates a BpfApplication instance, bpfman
+          creates a BpfApplicationState instance for each node in a Kubernetes
+          cluster.
         properties:
           apiVersion:
             description: |-
@@ -47,18 +51,49 @@ spec:
           metadata:
             type: object
           status:
-            description: BpfApplicationStateStatus reflects the status of the BpfApplication
-              on the given node
+            description: |-
+              status reflects the status of a BpfApplication instance for the given node.
+              appLoadStatus and conditions provide an overall status for the given node,
+              while each item in the programs list provides a per eBPF program status for
+              the given node.
             properties:
               appLoadStatus:
                 description: |-
-                  appLoadStatus reflects the status of loading the bpf application on the
-                  given node.
+                  appLoadStatus reflects the status of loading the eBPF application on the
+                  given node. Whether or not the eBPF program is attached to an attachment
+                  point is tracked by the linkStatus field, which is under of each link of
+                  each program.
+
+
+                  NotLoaded is a temporary state that is assigned when a
+                  ClusterBpfApplicationState is created and the initial reconcile is being
+                  processed.
+
+
+                  LoadSuccess is returned if all the programs have been loaded with no errors.
+
+
+                  LoadError is returned if one or more programs encountered an error and were
+                  not loaded.
+
+
+                  NotSelected is returned if this application did not select to run on this
+                  Kubernetes node.
+
+
+                  UnloadSuccess is returned when all the programs were successfully unloaded.
+
+
+                  UnloadError is returned if one or more programs encountered an error when
+                  being unloaded.
                 type: string
               conditions:
                 description: |-
-                  Conditions contains the overall status of the BpfApplicationState object
-                  on the given node.
+                  conditions contains the summary state of the BpfApplication for the given
+                  Kubernetes node. If one or more programs failed to load or attach to the
+                  designated attachment point, the condition will report the error. If more
+                  than one error has occurred, condition will contain the first error
+                  encountered.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for
@@ -131,18 +166,18 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               node:
-                description: node is the name of the node for this BpfApplicationStateSpec.
+                description: node is the name of the Kubernets node for this BpfApplicationState.
                 type: string
               programs:
-                description: programs is a list of bpf programs contained in the parent
-                  application.
+                description: |-
+                  programs is a list of eBPF programs contained in the parent BpfApplication
+                  instance. Each entry in the list contains the derived program attributes as
+                  well as the attach status for each program on the given Kubernetes node.
                 items:
-                  description: BpfApplicationProgramState defines the desired state
-                    of BpfApplication
                   properties:
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
+                        name is the name of the function that is the entry point for the eBPF
                         program
                       type: string
                     programId:
@@ -157,29 +192,29 @@ spec:
                         are in the correct state.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: tc contains the attachment data for a TC program
+                        when type is set to TC.
                       properties:
                         links:
                           description: |-
-                            links is the List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the TC program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the TC
+                                  program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TC program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -194,22 +229,24 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               netnsPath:
-                                description: netnsPath is a path to a Network namespace
-                                  to attach the tc program in.
+                                description: |-
+                                  netnsPath is the path to the network namespace inside of which the TC
+                                  program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TC program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - UnSpec
@@ -246,29 +283,29 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: tcx contains the attachment data for a TCX program
+                        when type is set to TCX.
                       properties:
                         links:
                           description: |-
-                            links is the List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the TCX program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the
+                                  TCX program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TCX program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -284,14 +321,14 @@ spec:
                                 type: string
                               netnsPath:
                                 description: |-
-                                  netnsPath is the path to the Network namespace to attach the tcx program
-                                  in.
+                                  netnsPath is the path to the network namespace inside of which the TCX
+                                  program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TCX program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -305,15 +342,41 @@ spec:
                                   attach point assigned by bpfman agent.
                                 type: string
                             required:
+                            - direction
+                            - interfaceName
                             - linkStatus
                             - netnsPath
+                            - priority
                             - shouldAttach
                             - uuid
                             type: object
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type specifies the provisioned eBPF program type for this program entry.
+                        Type will be one of:
+                          TC, TCX, UProbe, URetProbe, XDP
+
+
+                        When set to TC, the tc object will be populated with the eBPF program data
+                        associated with a TC program.
+
+
+                        When set to TCX, the tcx object will be populated with the eBPF program
+                        data associated with a TCX program.
+
+
+                        When set to UProbe, the uprobe object will be populated with the eBPF
+                        program data associated with a UProbe program.
+
+
+                        When set to URetProbe, the uretprobe object will be populated with the eBPF
+                        program data associated with a URetProbe program.
+
+
+                        When set to XDP, the xdp object will be populated with the eBPF program data
+                        associated with a URetProbe program.
                       enum:
                       - XDP
                       - TC
@@ -322,25 +385,29 @@ spec:
                       - URetProbe
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe contains the attachment data for a UProbe program when type is set to
+                        UProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: containerPid is container pid to attach
-                                  the uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the BpfApplication instance, containerPid is
+                                  the derived PID of the container the UProbe or URetProbe this attachment
+                                  point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -356,14 +423,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is Only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -371,8 +440,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -387,25 +457,29 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobe defines the desired state of the application's
-                        UretprobePrograms.
+                      description: |-
+                        uretprobe contains the attachment data for a URetProbe program when type is
+                        set to URetProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: containerPid is container pid to attach
-                                  the uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the BpfApplication instance, containerPid is
+                                  the derived PID of the container the UProbe or URetProbe this attachment
+                                  point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -421,14 +495,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is Only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -436,8 +512,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -452,21 +529,21 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: xdp contains the attachment data for an XDP program
+                        when type is set to XDP.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the XDP program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               interfaceName:
-                                description: interfaceName is the interface name to
-                                  attach the xdp program to.
+                                description: |-
+                                  interfaceName is the name of the interface the XDP program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -482,22 +559,23 @@ spec:
                                 type: string
                               netnsPath:
                                 description: |-
-                                  netnsPath is the path to the Network namespace to attach the xdp program
-                                  in.
+                                  netnsPath is the path to the network namespace inside of which the XDP
+                                  program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the xdp program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the XDP program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - Aborted
@@ -556,10 +634,10 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the BpfApplicationState has been updated. Set to 1
-                  when the object is created, then it is incremented prior to each update.
-                  This allows us to verify that the API server has the updated object prior
-                  to starting a new Reconcile operation.
+                  updateCount is the number of times the BpfApplicationState has been updated.
+                  Set to 1 when the object is created, then it is incremented prior to each
+                  update. This is used to verify that the API server has the updated object
+                  prior to starting a new Reconcile operation.
                 format: int64
                 type: integer
             required:

--- a/bundle/manifests/bpfman.io_bpfapplicationstates.yaml
+++ b/bundle/manifests/bpfman.io_bpfapplicationstates.yaml
@@ -60,9 +60,7 @@ spec:
               appLoadStatus:
                 description: |-
                   appLoadStatus reflects the status of loading the eBPF application on the
-                  given node. Whether or not the eBPF program is attached to an attachment
-                  point is tracked by the linkStatus field, which is under of each link of
-                  each program.
+                  given node.
 
 
                   NotLoaded is a temporary state that is assigned when a
@@ -70,18 +68,20 @@ spec:
                   processed.
 
 
-                  LoadSuccess is returned if all the programs have been loaded with no errors.
+                  LoadSuccess is returned if all the programs have been loaded with no
+                  errors.
 
 
-                  LoadError is returned if one or more programs encountered an error and were
-                  not loaded.
+                  LoadError is returned if one or more programs encountered an error and
+                  were not loaded.
 
 
                   NotSelected is returned if this application did not select to run on this
                   Kubernetes node.
 
 
-                  UnloadSuccess is returned when all the programs were successfully unloaded.
+                  UnloadSuccess is returned when all the programs were successfully
+                  unloaded.
 
 
                   UnloadError is returned if one or more programs encountered an error when
@@ -634,10 +634,12 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the BpfApplicationState has been updated.
-                  Set to 1 when the object is created, then it is incremented prior to each
-                  update. This is used to verify that the API server has the updated object
-                  prior to starting a new Reconcile operation.
+                  UpdateCount tracks the number of times the BpfApplicationState object has
+                  been updated. The bpfman agent initializes it to 1 when it creates the
+                  object, and then increments it before each subsequent update. It serves
+                  as a lightweight sequence number to verify that the API server is serving
+                  the most recent version of the object before beginning a new Reconcile
+                  operation.
                 format: int64
                 type: integer
             required:

--- a/bundle/manifests/bpfman.io_clusterbpfapplications.yaml
+++ b/bundle/manifests/bpfman.io_clusterbpfapplications.yaml
@@ -29,8 +29,8 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterBpfApplication is the schema for the cluster scoped BPF Applications
-          API. Using this API allows applications to load one or more eBPF programs on
-          a Kubernetes cluster using bpfman to load the programs.
+          API. This API allows applications to use bpfman to load and attach one or
+          more eBPF programs on a Kubernetes cluster.
 
 
           The clusterBpfApplication.status field reports the overall status of the
@@ -95,8 +95,8 @@ spec:
                           present on the node.
 
 
-                          When set to Never, the given image will never be pulled and must be load on
-                          the node by some other means.
+                          When set to Never, the given image will never be pulled and must be
+                          loaded on the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -563,8 +563,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -654,7 +654,6 @@ spec:
                                 type: integer
                               proceedOn:
                                 default:
-                                - OK
                                 - Pipe
                                 - DispatcherReturn
                                 description: |-
@@ -793,8 +792,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -934,9 +933,7 @@ spec:
                       type: object
                     type:
                       description: |-
-                        type is a required field used to specify the type of the eBPF program. The
-                        type dictates which eBPF attachment point to use. This is where the eBPF
-                        program is executed.
+                        type is a required field used to specify the type of the eBPF program.
 
 
                         Allowed values are:
@@ -1049,12 +1046,12 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                 properties:
                                   containerNames:
                                     description: |-
                                       containerNames is an optional field and is a list of container names in a
-                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      pod to attach the eBPF program. If no names are specified, all containers
                                       in the pod are selected.
                                     items:
                                       type: string
@@ -1062,7 +1059,7 @@ spec:
                                   namespace:
                                     description: |-
                                       namespace is an optional field and indicates the target Kubernetes
-                                      namespace. If not provided, the default Kubernetes namespace is used.
+                                      namespace. If not provided, all Kubernetes namespaces are included.
                                     type: string
                                   pods:
                                     description: |-
@@ -1186,12 +1183,12 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                 properties:
                                   containerNames:
                                     description: |-
                                       containerNames is an optional field and is a list of container names in a
-                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      pod to attach the eBPF program. If no names are specified, all containers
                                       in the pod are selected.
                                     items:
                                       type: string
@@ -1199,7 +1196,7 @@ spec:
                                   namespace:
                                     description: |-
                                       namespace is an optional field and indicates the target Kubernetes
-                                      namespace. If not provided, the default Kubernetes namespace is used.
+                                      namespace. If not provided, all Kubernetes namespaces are included.
                                     type: string
                                   pods:
                                     description: |-
@@ -1310,10 +1307,10 @@ spec:
 
 
                             The attachment point for an XDP program is a network interface (or device).
-                            The interface can be specified by name, or by setting the
-                            primaryNodeInterface flag, which instructs bpfman to use the primary
-                            interface of a Kubernetes node. Optionally, the XDP program can also be
-                            installed into a set of network namespaces.
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            XDP program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               interfaceSelector:
@@ -1370,8 +1367,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean

--- a/bundle/manifests/bpfman.io_clusterbpfapplications.yaml
+++ b/bundle/manifests/bpfman.io_clusterbpfapplications.yaml
@@ -27,7 +27,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterBpfApplication is the Schema for the bpfapplications API
+        description: |-
+          ClusterBpfApplication is the schema for the cluster scoped BPF Applications
+          API. Using this API allows applications to load one or more eBPF programs on
+          a Kubernetes cluster using bpfman to load the programs.
+
+
+          The clusterBpfApplication.status field reports the overall status of the
+          ClusterBpfApplication CRD. A given ClusterBpfApplication CRD can result in
+          loading and attaching multiple eBPF programs on multiple nodes, so this
+          status is just a summary. More granular per-node status details can be
+          found in the corresponding ClusterBpfApplicationState CRD that bpfman
+          creates for each node.
         properties:
           apiVersion:
             description: |-
@@ -47,20 +58,45 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClBpfApplicationSpec defines the desired state of BpfApplication
+            description: |-
+              spec defines the desired state of the ClusterBpfApplication. The
+              ClusterBpfApplication describes the set of one or more cluster scoped eBPF
+              programs that should be loaded for a given application and attributes for
+              how they should be loaded. eBPF programs that are grouped together under the
+              same ClusterBpfApplication instance can share maps and global data between
+              the eBPF programs loaded on the same Kubernetes Node.
             properties:
               byteCode:
                 description: |-
-                  bytecode configures where the bpf program's bytecode should be loaded
-                  from.
+                  bytecode is a required field and configures where the eBPF program's
+                  bytecode should be loaded from. The image must contain one or more
+                  eBPF programs.
+                maxProperties: 1
+                minProperties: 1
                 properties:
                   image:
-                    description: image used to specify a bytecode container image.
+                    description: |-
+                      image is an optional field and used to specify details on how to retrieve an
+                      eBPF program packaged in a OCI container image from a given registry.
                     properties:
                       imagePullPolicy:
                         default: IfNotPresent
-                        description: pullPolicy describes a policy for if/when to
-                          pull a bytecode image. Defaults to IfNotPresent.
+                        description: |-
+                          pullPolicy is an optional field that describes a policy for if/when to pull
+                          a bytecode image. Defaults to IfNotPresent. Allowed values are:
+                            Always, IfNotPresent and Never
+
+
+                          When set to Always, the given image will be pulled even if the image is
+                          already present on the node.
+
+
+                          When set to IfNotPresent, the given image will only be pulled if it is not
+                          present on the node.
+
+
+                          When set to Never, the given image will never be pulled and must be load on
+                          the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -68,24 +104,28 @@ spec:
                         type: string
                       imagePullSecret:
                         description: |-
-                          imagePullSecret is the name of the secret bpfman should use to get remote image
-                          repository secrets.
+                          imagePullSecret is an optional field and indicates the secret which contains
+                          the credentials to access the image repository.
                         properties:
                           name:
-                            description: name of the secret which contains the credentials
-                              to access the image repository.
+                            description: |-
+                              name is a required field and is the name of the secret which contains the
+                              credentials to access the image repository.
                             type: string
                           namespace:
-                            description: namespace of the secret which contains the
-                              credentials to access the image repository.
+                            description: |-
+                              namespace is a required field and is the namespace of the secret which
+                              contains the credentials to access the image repository.
                             type: string
                         required:
                         - name
                         - namespace
                         type: object
                       url:
-                        description: url is a valid container image URL used to reference
-                          a remote bytecode image.
+                        description: |-
+                          url is a required field and is a valid container image URL used to reference
+                          a remote bytecode image. url must not be an empty string, must not exceed
+                          525 characters in length and must be a valid URL.
                         maxLength: 525
                         pattern: '[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}'
                         type: string
@@ -93,7 +133,9 @@ spec:
                     - url
                     type: object
                   path:
-                    description: path is used to specify a bytecode object via filepath.
+                    description: |-
+                      path is an optional field and used to specify a bytecode object file via
+                      filepath on a Kubernetes node.
                     pattern: ^(/[^/\0]+)+/?$
                     type: string
                 type: object
@@ -102,16 +144,22 @@ spec:
                   format: byte
                   type: string
                 description: |-
-                  globalData allows the user to set global variables when the program is loaded
-                  with an array of raw bytes. This is a very low level primitive. The caller
-                  is responsible for formatting the byte string appropriately considering
-                  such things as size, endianness, alignment and packing of data structures.
+                  globalData is an optional field that allows the user to set global variables
+                  when the program is loaded. This allows the same compiled bytecode to be
+                  deployed by different BPF Applications to behave differently based on
+                  globalData configuration values.  It uses an array of raw bytes. This is a
+                  very low level primitive. The caller is responsible for formatting the byte
+                  string appropriately considering such things as size, endianness, alignment
+                  and packing of data structures.
                 type: object
               mapOwnerSelector:
                 description: |-
-                  TODO: need to work out how MapOwnerSelector will work after load-attach-split
-                  mapOwnerSelector is used to select the loaded eBPF program this eBPF program
-                  will share a map with.
+                  mapOwnerSelector is an optional field used to share maps across
+                  applications. eBPF programs loaded with the same ClusterBpfApplication or
+                  BpfApplication instance do not need to use this field. This label selector
+                  allows maps from a different ClusterBpfApplication or BpfApplication
+                  instance to be used by this instance.
+                  TODO: mapOwnerSelector is currently not supported due to recent code rework.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -158,9 +206,9 @@ spec:
                 x-kubernetes-map-type: atomic
               nodeSelector:
                 description: |-
-                  nodeSelector allows the user to specify which nodes to deploy the
-                  bpf program to. This field must be specified, to select all nodes
-                  use standard metav1.LabelSelector semantics and make it empty.
+                  nodeSelector is a required field and allows the user to specify which
+                  Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+                  standard metav1.LabelSelector semantics and make it empty.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -207,37 +255,57 @@ spec:
                 x-kubernetes-map-type: atomic
               programs:
                 description: |-
-                  programs is the list of bpf programs in the BpfApplication that should be
-                  loaded. The application can selectively choose which program(s) to run
-                  from this list based on the optional attach points provided.
+                  programs is a required field and is the list of eBPF programs in a BPF
+                  Application CRD that should be loaded in kernel memory. At least one entry
+                  is required. eBPF programs in this list will be loaded on the system based
+                  the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+                  cannot be triggered until an attachment point is provided. The different
+                  program types have different ways of attaching. The attachment points can be
+                  added at creation time or modified (added or removed) at a later time to
+                  activate or deactivate the eBPF program as desired.
+                  CAUTION: When programs are added or removed from the list, that requires all
+                  programs in the list to be reloaded, which could be temporarily service
+                  effecting. For this reason, modifying the list is currently not allowed.
                 items:
-                  description: ClBpfApplicationProgram defines the desired state of
-                    BpfApplication
                   properties:
                     fentry:
-                      description: fentry defines the desired state of the application's
-                        FentryPrograms.
+                      description: |-
+                        fentry is an optional field, but required when the type field is set to
+                        FEntry. fentry defines the desired state of the application's FEntry
+                        programs. FEntry programs are attached to the entry of a Linux kernel
+                        function or to another eBPF program function. They are attached to the first
+                        instruction, before control passes to the function. FEntry programs are
+                        similar to KProbe programs, but have higher performance.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fentry program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FEntry program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
-                          description: Whether the program should be attached to the
-                            function.
+                          description: |-
+                            links is an optional field and is a flag to indicate if the FEntry program
+                            should be attached. The attachment point for a FEntry program is a Linux
+                            kernel function. Unlike other eBPF program types, an FEntry program must be
+                            provided with the target function at load time. The links field is optional,
+                            but unlike other program types where it represents a list of attachment
+                            points, for FEntry programs it contains at most one entry that determines
+                            whether the program should be attached to the specified function. To attach
+                            the program, add an entry to links with mode set to Attach. To detach it,
+                            remove the entry from links.
                           items:
-                            description: |-
-                              ClFentryAttachInfo indicates that the Fentry program should be attached to
-                              the function identified in ClFentryLoadInfo. The only valid value for Attach
-                              is true.
                             properties:
                               mode:
+                                description: |-
+                                  mode is a required field. When set to Attach, the FEntry program will
+                                  attempt to be attached. To detach the FEntry program, remove the link entry.
                                 enum:
                                 - Attach
-                                - Dettach
                                 type: string
                             required:
                             - mode
@@ -248,29 +316,45 @@ spec:
                       - function
                       type: object
                     fexit:
-                      description: fexit defines the desired state of the application's
-                        FexitPrograms.
+                      description: |-
+                        fexit is an optional field, but required when the type field is set to
+                        FExit. fexit defines the desired state of the application's FExit programs.
+                        FExit programs are attached to the exit of a Linux kernel function or to
+                        another eBPF program function. The program is invoked when the function
+                        returns, independent of where in the function that occurs. FExit programs
+                        are similar to KRetProbe programs, but get invoked with the input arguments
+                        and the return values. They also have higher performance over KRetProbe
+                        programs.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fexit program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FExit program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
-                          description: Whether the program should be attached to the
-                            function.
+                          description: |-
+                            links is an optional field and is a flag to indicate if the FExit program
+                            should be attached. The attachment point for a FExit program is a Linux
+                            kernel function. Unlike other eBPF program types, an FExit program must be
+                            provided with the target function at load time. The links field is optional,
+                            but unlike other program types where it represents a list of attachment
+                            points, for FExit programs it contains at most one entry that determines
+                            whether the program should be attached to the specified function. To attach
+                            the program, add an entry to links with mode set to Attach. To detach it,
+                            remove the entry from links.
                           items:
-                            description: |-
-                              ClFexitAttachInfo indicates that the Fentry program should be attached to
-                              the function identified in ClFentryLoadInfo. The only valid value for Attach
-                              is true.
                             properties:
                               mode:
+                                description: |-
+                                  mode is a required field. When set to Attach, the FExit program will
+                                  attempt to be attached. To detach the FExit program, remove the link entry.
                                 enum:
                                 - Attach
-                                - Dettach
                                 type: string
                             required:
                             - mode
@@ -281,17 +365,38 @@ spec:
                       - function
                       type: object
                     kprobe:
-                      description: kprobe defines the desired state of the application's
-                        KprobePrograms.
+                      description: |-
+                        kprobe is an optional field, but required when the type field is set to
+                        KProbe. kprobe defines the desired state of the application's Kprobe
+                        programs. KProbe programs are attached to a Linux kernel function. Unlike
+                        FEntry programs, which must always be attached at the entry point of a Linux
+                        kernel function, KProbe programs can be attached at any point in the
+                        function using the optional offset field. However, caution must be taken
+                        when using the offset, ensuring the offset is still in the function
+                        bytecode. FEntry programs have less overhead than KProbe programs.
                       properties:
                         links:
                           description: |-
-                            The list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            KProbe program should be attached. The eBPF program is loaded in kernel
+                            memory when the BPF Application CRD is created and the selected Kubernetes
+                            nodes are active. The eBPF program will not be triggered until the program
+                            has also been attached to an attachment point described in this list. Items
+                            may be added or removed from the list at any point, causing the eBPF program
+                            to be attached or detached.
+
+
+                            The attachment point for a KProbe program is a Linux kernel function. By
+                            default, the eBPF program is triggered at the entry of the attachment point,
+                            but the attachment point can be adjusted using an optional offset.
                           items:
                             properties:
                               function:
-                                description: function to attach the kprobe to.
+                                description: |-
+                                  function is a required field and specifies the name of the Linux kernel
+                                  function to attach the KProbe program. function must not be an empty string,
+                                  must not exceed 64 characters in length, must start with alpha characters
+                                  and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
@@ -299,10 +404,8 @@ spec:
                               offset:
                                 default: 0
                                 description: |-
-                                  offset added to the address of the function for kprobe.
-                                  The offset must be zero for kretprobes.
-                                  TODO: Add a webhook to enforce kretprobe offset=0.
-                                  See: https://github.com/bpfman/bpfman-operator/issues/403
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function. If not provided, offset defaults to 0.
                                 format: int64
                                 type: integer
                             required:
@@ -311,17 +414,34 @@ spec:
                           type: array
                       type: object
                     kretprobe:
-                      description: kretprobe defines the desired state of the application's
-                        KretprobePrograms.
+                      description: |-
+                        kretprobe is an optional field, but required when the type field is set to
+                        KRetProbe. kretprobe defines the desired state of the application's
+                        KRetProbe programs. KRetProbe programs are attached to the exit of a Linux
+                        kernel function. FExit programs have less overhead than KRetProbe programs
+                        and FExit programs have access to both the input arguments as well as the
+                        return values. KRetProbes only have access to the return values.
                       properties:
                         links:
                           description: |-
-                            The list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            KRetProbe program should be attached. The eBPF program is loaded in kernel
+                            memory when the BPF Application CRD is created and the selected Kubernetes
+                            nodes are active. The eBPF program will not be triggered until the program
+                            has also been attached to an attachment point described in this list. Items
+                            may be added or removed from the list at any point, causing the eBPF program
+                            to be attached or detached.
+
+
+                            The attachment point for a KRetProbe program is a Linux kernel function.
                           items:
                             properties:
                               function:
-                                description: function to attach the kprobe to.
+                                description: |-
+                                  function is a required field and specifies the name of the Linux kernel
+                                  function to attach the KRetProbe program. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
@@ -333,53 +453,97 @@ spec:
                       type: object
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
-                        program
+                        name is a required field and is the name of the function that is the entry
+                        point for the eBPF program. name must not be an empty string, must not
+                        exceed 64 characters in length, must start with alpha characters and must
+                        only contain alphanumeric characters.
                       maxLength: 64
                       minLength: 1
                       pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: |-
+                        tc is an optional field, but required when the type field is set to TC. tc
+                        defines the desired state of the application's TC programs. TC programs are
+                        attached to network devices (interfaces). The program can be attached on
+                        either packet ingress or egress, so the program will be called on every
+                        incoming or outgoing packet seen by the network device. The TC attachment
+                        point is in Linux's Traffic Control (tc) subsystem, which is after the
+                        Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+                        with enhanced performance and better support for running multiple programs
+                        on a given network device. This makes TC useful for packet classification
+                        actions.
                       properties:
                         links:
                           description: |-
-                            The list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TC program should be attached. The TC program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TC program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TC program to be
+                            attached or detached.
+
+
+                            The attachment point for a TC program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TC program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TC program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -387,37 +551,46 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
-                                  program will be attached in the root network namespace.
+                                  networkNamespaces is an optional field that identifies the set of network
+                                  namespaces in which to attach the eBPF program. If networkNamespaces is not
+                                  specified, the eBPF program will be attached in the root network namespace.
                                 properties:
                                   namespace:
-                                    description: Target namespace.
+                                    description: |-
+                                      namespace is an optional field and indicates the target network namespace.
+                                      If not provided, the default network namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -467,21 +640,36 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TC
+                                  program relative to other TC programs attached to the same attachment point.
+                                  It must be a value between 0 and 1000, where lower values indicate higher
+                                  precedence. For TC programs on the same attachment point with the same
+                                  direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 default:
+                                - OK
                                 - Pipe
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other TC programs
+                                  in a chain, or not call the next program in a chain based on the exit code
+                                  of a TC program. Allowed values, which are the possible exit codes from a TC
+                                  eBPF program, are:
+                                    UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+                                    Trap, DispatcherReturn
+
+
+                                  Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+                                  using the default values, if a TC program returns Pipe, the next TC
+                                  program in the chain will be called. If a TC program returns Stolen, the
+                                  next TC program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - UnSpec
@@ -504,46 +692,88 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: |-
+                        tcx is an optional field, but required when the type field is set to TCX.
+                        tcx defines the desired state of the application's TCX programs. TCX
+                        programs are attached to network devices (interfaces). The program can be
+                        attached on either packet ingress or egress, so the program will be called
+                        on every incoming or outgoing packet seen by the network device. The TCX
+                        attachment point is in Linux's Traffic Control (tc) subsystem, which is
+                        after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+                        packet classification actions. TCX is a newer implementation of TC with
+                        enhanced performance and better support for running multiple programs on a
+                        given network device.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached. The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TCX program should be attached. The TCX program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TCX program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TCX program to be
+                            attached or detached.
+
+
+                            The attachment point for a TCX program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TCX program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TCX program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -551,37 +781,46 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
-                                  program will be attached in the root network namespace.
+                                  networkNamespaces is an optional field that identifies the set of network
+                                  namespaces in which to attach the eBPF program. If networkNamespaces is not
+                                  specified, the eBPF program will be attached in the root network namespace.
                                 properties:
                                   namespace:
-                                    description: Target namespace.
+                                    description: |-
+                                      namespace is an optional field and indicates the target network namespace.
+                                      If not provided, the default network namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -631,10 +870,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TCX
+                                  program relative to other TCX programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For TCX programs on the same attachment point with the
+                                  same direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -646,19 +889,40 @@ spec:
                           type: array
                       type: object
                     tracepoint:
-                      description: tracepointInfo defines the desired state of the
-                        application's TracepointPrograms.
+                      description: |-
+                        tracepoint is an optional field, but required when the type field is set to
+                        Tracepoint. tracepoint defines the desired state of the application's
+                        Tracepoint programs. Whereas KProbes attach to dynamically to any Linux
+                        kernel function, Tracepoint programs are programs that can only be attached
+                        at predefined locations in the Linux kernel. Use the following command to
+                        see the available attachment points:
+                         `sudo find /sys/kernel/debug/tracing/events -type d`
+                        While KProbes are more flexible in where in the kernel the probe can be
+                        attached, the functions and data structure rely on the kernel your system is
+                        running. Tracepoints tend to be more stable across kernel versions and are
+                        better for portability.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            Tracepoint program should be attached. The Tracepoint program is loaded in
+                            kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The Tracepoint program will not be triggered
+                            until the program has also been attached to an attachment point described in
+                            this list. Items may be added or removed from the list at any point, causing
+                            the Tracepoint program to be attached or detached.
+
+
+                            The attachment point for a Tracepoint program is a one of a predefined set
+                            of Linux kernel functions.
                           items:
                             properties:
                               name:
                                 description: |-
-                                  name refers to the name of a kernel tracepoint to attach the
-                                  bpf program to.
+                                  name is a required field and specifies the name of the Linux kernel
+                                  Tracepoint to attach the eBPF program. name must not be an empty string,
+                                  must not exceed 64 characters in length, must start with alpha characters
+                                  and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
@@ -669,7 +933,76 @@ spec:
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type is a required field used to specify the type of the eBPF program. The
+                        type dictates which eBPF attachment point to use. This is where the eBPF
+                        program is executed.
+
+
+                        Allowed values are:
+                          FEntry, FExit, KProbe, KRetProbe, TC, TCX, TracePoint, UProbe, URetProbe,
+                          XDP
+
+
+                        When set to FEntry, the program is attached to the entry of a Linux kernel
+                        function or to another eBPF program function. When using the FEntry program
+                        type, the fentry field is required. See fentry for more details on FEntry
+                        programs.
+
+
+                        When set to FExit, the program is attached to the exit of a Linux kernel
+                        function or to another eBPF program function. When using the FExit program
+                        type, the fexit field is required. See fexit for more details on FExit
+                        programs.
+
+
+                        When set to KProbe, the program is attached to entry of a Linux kernel
+                        function. When using the KProbe program type, the kprobe field is required.
+                        See kprobe for more details on KProbe programs.
+
+
+                        When set to KRetProbe, the program is attached to exit of a Linux kernel
+                        function. When using the KRetProbe program type, the kretprobe field is
+                        required. See kretprobe for more details on KRetProbe programs.
+
+
+                        When set to TC, the eBPF program can attach to network devices (interfaces).
+                        The program can be attached on either packet ingress or egress, so the
+                        program will be called on every incoming or outgoing packet seen by the
+                        network device. When using the TC program type, the tc field is required.
+                        See tc for more details on TC programs.
+
+
+                        When set to TCX, the eBPF program can attach to network devices
+                        (interfaces). The program can be attached on either packet ingress or
+                        egress, so the program will be called on every incoming or outgoing packet
+                        seen by the network device. When using the TCX program type, the tcx field
+                        is required. See tcx for more details on TCX programs.
+
+
+                        When set to Tracepoint, the program can attach to one of the predefined set
+                        of Linux kernel functions. When using the Tracepoint program type, the
+                        tracepoint field is required. See tracepoint for more details on Tracepoint
+                        programs.
+
+
+                        When set to UProbe, the program can attach in user-space. The UProbe is
+                        attached to a binary, library or function name, and optionally an offset in
+                        the code. When using the UProbe program type, the uprobe field is required.
+                        See uprobe for more details on UProbe programs.
+
+
+                        When set to URetProbe, the program can attach in user-space.
+                        The URetProbe is attached to the return of a binary, library or function
+                        name, and optionally an offset in the code.  When using the URetProbe
+                        program type, the uretprobe field is required. See uretprobe for more
+                        details on URetProbe programs.
+
+
+                        When set to XDP, the eBPF program can attach to network devices (interfaces)
+                        and will be called on every incoming packet received by the network device.
+                        When using the XDP program type, the xdp field is required. See xdp for more
+                        details on XDP programs.
                       enum:
                       - XDP
                       - TC
@@ -683,35 +1016,58 @@ spec:
                       - TracePoint
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe is an optional field, but required when the type field is set to
+                        UProbe. uprobe defines the desired state of the application's UProbe
+                        programs. UProbe programs are user-space probes. A target must be provided,
+                        which is the library name or absolute path to a binary or library where the
+                        probe is attached. Optionally, a function name can also be provided to
+                        provide finer granularity on where the probe is attached. They can be
+                        attached at any point in the binary, library or function using the optional
+                        offset field. However, caution must be taken when using the offset, ensuring
+                        the offset is still in the desired bytecode.
                       properties:
                         links:
                           description: |-
-                            links in the list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
-                                  uprobe. If Containers is not specified, the uprobe will be attached in
-                                  the bpfman-agent container.
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the Name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   namespace:
-                                    description: namespaces indicate the target namespaces.
+                                    description: |-
+                                      namespace is an optional field and indicates the target Kubernetes
+                                      namespace. If not provided, the default Kubernetes namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -761,26 +1117,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - target
@@ -788,35 +1152,59 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobeInfo defines the desired state of the
-                        application's UretprobePrograms.
+                      description: |-
+                        uretprobe is an optional field, but required when the type field is set to
+                        URetProbe. uretprobe defines the desired state of the application's
+                        URetProbe programs. URetProbe programs are user-space probes. A target must
+                        be provided, which is the library name or absolute path to a binary or
+                        library where the probe is attached. Optionally, a function name can also be
+                        provided to provide finer granularity on where the probe is attached. They
+                        are attached to the return point of the binary, library or function, but can
+                        be set anywhere using the optional offset field. However, caution must be
+                        taken when using the offset, ensuring the offset is still in the desired
+                        bytecode.
                       properties:
                         links:
                           description: |-
-                            links in the list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
-                                  uprobe. If Containers is not specified, the uprobe will be attached in
-                                  the bpfman-agent container.
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the Name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   namespace:
-                                    description: namespaces indicate the target namespaces.
+                                    description: |-
+                                      namespace is an optional field and indicates the target Kubernetes
+                                      namespace. If not provided, the default Kubernetes namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -866,26 +1254,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - target
@@ -893,38 +1289,68 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: |-
+                        xdp is an optional field, but required when the type field is set to XDP.
+                        xdp defines the desired state of the application's XDP programs. XDP program
+                        can be attached to network devices (interfaces) and will be called on every
+                        incoming packet received by the network device. The XDP attachment point is
+                        just after the packet has been received off the wire, but before the Linux
+                        kernel has allocated an sk_buff, which is used to pass the packet through
+                        the kernel networking stack.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            XDP program should be attached. The XDP program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The XDP program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the XDP program to be
+                            attached or detached.
+
+
+                            The attachment point for an XDP program is a network interface (or device).
+                            The interface can be specified by name, or by setting the
+                            primaryNodeInterface flag, which instructs bpfman to use the primary
+                            interface of a Kubernetes node. Optionally, the XDP program can also be
+                            installed into a set of network namespaces.
                           items:
                             properties:
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the XDP program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -932,37 +1358,46 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
                                   networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
+                                  attach the eBPF program. If networkNamespaces is not specified, the eBPF
                                   program will be attached in the root network namespace.
                                 properties:
                                   namespace:
-                                    description: Target namespace.
+                                    description: |-
+                                      namespace is an optional field and indicates the target network namespace.
+                                      If not provided, the default network namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -1012,10 +1447,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the bpf program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the XDP
+                                  program relative to other XDP programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For XDP programs on the same attachment point with the
+                                  same priority, the most recently attached program has a lower precedence. If
+                                  not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -1025,8 +1464,17 @@ spec:
                                 - Pass
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other XDP
+                                  programs in a chain, or not call the next program in a chain based on the
+                                  exit code of an XDP program. Allowed values, which are the possible exit
+                                  codes from an XDP eBPF program, are:
+                                    Aborted, Drop, Pass, TX, ReDirect, DispatcherReturn
+
+
+                                  Multiple values are supported. Default is Pass and DispatcherReturn. So
+                                  using the default values, if an XDP program returns Pass, the next XDP
+                                  program in the chain will be called. If an XDP program returns Drop, the
+                                  next XDP program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - Aborted
@@ -1092,16 +1540,17 @@ spec:
             required:
             - byteCode
             - nodeSelector
+            - programs
             type: object
           status:
-            description: BpfAppStatus reflects the status of a BpfApplication or BpfApplicationState
-              object
+            description: |-
+              status reflects the status of a BPF Application and indicates if all the
+              eBPF programs for a given instance loaded successfully or not.
             properties:
               conditions:
                 description: |-
-                  For a BpfApplication object, Conditions contains the global cluster state
-                  for the object. For a BpfApplicationState object, Conditions contains the
-                  state of the BpfApplication object on the given node.
+                  conditions contains the summary state for all eBPF programs defined in the
+                  BPF Application instance for all the Kubernetes nodes in the cluster.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for

--- a/bundle/manifests/bpfman.io_clusterbpfapplicationstates.yaml
+++ b/bundle/manifests/bpfman.io_clusterbpfapplicationstates.yaml
@@ -27,7 +27,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterBpfApplicationState contains the per-node state of a BpfApplication.
+        description: |-
+          ClusterBpfApplicationState contains the state of a ClusterBpfApplication
+          instance for a given Kubernetes node. When a user creates a
+          ClusterBpfApplication instance, bpfman creates a ClusterBpfApplicationState
+          instance for each node in a Kubernetes cluster.
         properties:
           apiVersion:
             description: |-
@@ -47,18 +51,49 @@ spec:
           metadata:
             type: object
           status:
-            description: ClBpfApplicationStateStatus reflects the status of the ClusterBpfApplicationState
-              on the given node
+            description: |-
+              status reflects the status of a ClusterBpfApplication instance for the given
+              node. appLoadStatus and conditions provide an overall status for the given
+              node, while each item in the programs list provides a per eBPF program
+              status for the given node.
             properties:
               appLoadStatus:
                 description: |-
-                  appLoadStatus reflects the status of loading the bpf application on the
-                  given node.
+                  appLoadStatus reflects the status of loading the eBPF application on the
+                  given node. Whether or not the eBPF program is attached to an attachment
+                  point is tracked by the linkStatus field, which is under of each link of
+                  each program.
+
+
+                  NotLoaded is a temporary state that is assigned when a
+                  ClusterBpfApplicationState is created and the initial reconcile is being
+                  processed.
+
+
+                  LoadSuccess is returned if all the programs have been loaded with no errors.
+
+
+                  LoadError is returned if one or more programs encountered an error and were
+                  not loaded.
+
+
+                  NotSelected is returned if this application did not select to run on this
+                  Kubernetes node.
+
+
+                  UnloadSuccess is returned when all the programs were successfully unloaded.
+
+
+                  UnloadError is returned if one or more programs encountered an error when
+                  being unloaded.
                 type: string
               conditions:
                 description: |-
-                  Conditions contains the overall status of the ClusterBpfApplicationState
-                  object on the given node.
+                  conditions contains the summary state of the ClusterBpfApplication for the
+                  given Kubernetes node. If one or more programs failed to load or attach to
+                  the designated attachment point, the condition will report the error. If
+                  more than one error has occurred, condition will contain the first error
+                  encountered.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for
@@ -131,27 +166,37 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               node:
-                description: node is the name of the node for this BpfApplicationStateSpec.
+                description: node is the name of the Kubernetes node for this ClusterBpfApplicationState.
                 type: string
               programs:
-                description: programs is a list of bpf programs contained in the parent
-                  application.
+                description: |-
+                  programs is a list of eBPF programs contained in the parent
+                  ClusterBpfApplication instance. Each entry in the list contains the derived
+                  program attributes as well as the attach status for each program on the
+                  given Kubernetes node.
                 items:
-                  description: ClBpfApplicationProgramState defines the desired state
-                    of BpfApplication
                   properties:
                     fentry:
-                      description: fentry defines the desired state of the application's
-                        FentryPrograms.
+                      description: |-
+                        fentry contains the attachment data for an FEntry program when type is set
+                        to FEntry.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fentry program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FEntry program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
+                          description: |-
+                            links is a list of attachment points for the FEntry program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               linkId:
@@ -185,17 +230,26 @@ spec:
                       - function
                       type: object
                     fexit:
-                      description: fexit defines the desired state of the application's
-                        FexitPrograms.
+                      description: |-
+                        fexit contains the attachment data for an FExit program when type is set to
+                        FExit.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fexit program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FExit program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
+                          description: |-
+                            links is a list of attachment points for the FExit program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               linkId:
@@ -229,20 +283,22 @@ spec:
                       - function
                       type: object
                     kprobe:
-                      description: kprobe defines the desired state of the application's
-                        KprobePrograms.
+                      description: |-
+                        kprobe contains the attachment data for a KProbe program when type is set to
+                        KProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the KProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               function:
-                                description: Function to attach the kprobe to.
+                                description: |-
+                                  function is the provisioned name of the Linux kernel function the KProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -257,8 +313,10 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               offset:
-                                description: Offset added to the address of the function
-                                  for kprobe.
+                                default: 0
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               shouldAttach:
@@ -272,27 +330,28 @@ spec:
                             required:
                             - function
                             - linkStatus
-                            - offset
                             - shouldAttach
                             - uuid
                             type: object
                           type: array
                       type: object
                     kretprobe:
-                      description: kretprobe defines the desired state of the application's
-                        KprobePrograms.
+                      description: |-
+                        kretprobe contains the attachment data for a KRetProbe program when type is
+                        set to KRetProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the KRetProbe program. Each entry
+                            in the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               function:
-                                description: Function to attach the kprobe to.
+                                description: |-
+                                  function is the provisioned name of the Linux kernel function the KRetProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -324,7 +383,7 @@ spec:
                       type: object
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
+                        name is the name of the function that is the entry point for the eBPF
                         program
                       type: string
                     programId:
@@ -339,29 +398,29 @@ spec:
                         are in the correct state.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: tc contains the attachment data for a TC program
+                        when type is set to TC.
                       properties:
                         links:
                           description: |-
-                            links is the List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attached point required by the
-                            reconciler
+                            links is a list of attachment points for the TC program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the TC
+                                  program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TC program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -376,22 +435,24 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               netnsPath:
-                                description: Optional network namespace to attach
-                                  the tc program in.
+                                description: |-
+                                  netnsPath is the optional path to the network namespace inside of which the
+                                  TC program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TC program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - UnSpec
@@ -427,29 +488,29 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: tcx contains the attachment data for a TCX program
+                        when type is set to TCX.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the TCX program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the TC
+                                  program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TCX program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -464,14 +525,15 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               netnsPath:
-                                description: netnsPath is the network namespace to
-                                  attach the tcx program in.
+                                description: |-
+                                  netnsPath is the optional path to the network namespace inside of which the
+                                  TCX program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TCX program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -495,16 +557,16 @@ spec:
                           type: array
                       type: object
                     tracepoint:
-                      description: tracepoint defines the desired state of the application's
-                        TracepointPrograms.
+                      description: |-
+                        tracepoint contains the attachment data for a Tracepoint program when type
+                        is set to Tracepoint.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the Tracepoint program. Each entry
+                            in the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               linkId:
@@ -520,8 +582,10 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               name:
-                                description: The name of a kernel tracepoint to attach
-                                  the bpf program to.
+                                description: |-
+                                  The name of a kernel tracepoint to attach the bpf program to.
+                                  name is the provisioned name of the Linux kernel tracepoint function the
+                                  Tracepoint program should be attached.
                                 type: string
                               shouldAttach:
                                 description: shouldAttach reflects whether the attachment
@@ -540,39 +604,87 @@ spec:
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type specifies the provisioned eBPF program type for this program entry.
+                        Type will be one of:
+                          FEntry, FExit, KProbe, KRetProbe, TC, TCX, Tracepoint, UProbe,
+                          URetProbe, XDP
+
+
+                        When set to FEntry, the fentry object will be populated with the eBPF
+                        program data associated with an FEntry program.
+
+
+                        When set to FExit, the fexit object will be populated with the eBPF program
+                        data associated with an FExit program.
+
+
+                        When set to KProbe, the kprobe object will be populated with the eBPF
+                        program data associated with a KProbe program.
+
+
+                        When set to KRetProbe, the kretprobe object will be populated with the
+                        eBPF program data associated with a KRetProbe program.
+
+
+                        When set to TC, the tc object will be populated with the eBPF program data
+                        associated with a TC program.
+
+
+                        When set to TCX, the tcx object will be populated with the eBPF program
+                        data associated with a TCX program.
+
+
+                        When set to Tracepoint, the tracepoint object will be populated with the
+                        eBPF program data associated with a Tracepoint program.
+
+
+                        When set to UProbe, the uprobe object will be populated with the eBPF
+                        program data associated with a UProbe program.
+
+
+                        When set to URetProbe, the uretprobe object will be populated with the eBPF
+                        program data associated with a URetProbe program.
+
+
+                        When set to XDP, the xdp object will be populated with the eBPF program data
+                        associated with a URetProbe program.
                       enum:
-                      - XDP
-                      - TC
-                      - TCX
                       - FEntry
                       - FExit
                       - KProbe
                       - KRetProbe
+                      - TC
+                      - TCX
+                      - TracePoint
                       - UProbe
                       - URetProbe
-                      - TracePoint
+                      - XDP
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe contains the attachment data for a UProbe program when type is set to
+                        UProbe.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: Optional container pid to attach the
-                                  uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the ClusterBpfApplication instance,
+                                  containerPid is the derived PID of the container the UProbe or URetProbe this
+                                  attachment point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -588,14 +700,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -603,8 +717,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -619,25 +734,29 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobe defines the desired state of the application's
-                        UretprobePrograms.
+                      description: |-
+                        uretprobe contains the attachment data for a URetProbe program when type is
+                        set to URetProbe.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: Optional container pid to attach the
-                                  uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the ClusterBpfApplication instance,
+                                  containerPid is the derived PID of the container the UProbe or URetProbe this
+                                  attachment point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -653,14 +772,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -668,8 +789,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -684,21 +806,21 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: xdp contains the attachment data for an XDP program
+                        when type is set to XDP.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the XDP program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               interfaceName:
-                                description: interfaceName is the interface name to
-                                  attach the xdp program to.
+                                description: |-
+                                  interfaceName is the name of the interface the XDP program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -714,22 +836,23 @@ spec:
                                 type: string
                               netnsPath:
                                 description: |-
-                                  netnsPath is an optional path for a network namespace to attach the xdp
-                                  program in.
+                                  netnsPath is the optional path to the network namespace inside of which the
+                                  XDP program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the xdp program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the XDP program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - Aborted
@@ -807,10 +930,10 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the BpfApplicationState has been updated. Set to 1
-                  when the object is created, then it is incremented prior to each update.
-                  This allows us to verify that the API server has the updated object prior
-                  to starting a new Reconcile operation.
+                  updateCount is the number of times the ClusterBpfApplicationState has been
+                  updated. Set to 1 when the object is created, then it is incremented prior
+                  to each update. This is used to verify that the API server has the updated
+                  object prior to starting a new Reconcile operation.
                 format: int64
                 type: integer
             required:

--- a/bundle/manifests/bpfman.io_clusterbpfapplicationstates.yaml
+++ b/bundle/manifests/bpfman.io_clusterbpfapplicationstates.yaml
@@ -60,9 +60,7 @@ spec:
               appLoadStatus:
                 description: |-
                   appLoadStatus reflects the status of loading the eBPF application on the
-                  given node. Whether or not the eBPF program is attached to an attachment
-                  point is tracked by the linkStatus field, which is under of each link of
-                  each program.
+                  given node.
 
 
                   NotLoaded is a temporary state that is assigned when a
@@ -930,10 +928,12 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the ClusterBpfApplicationState has been
-                  updated. Set to 1 when the object is created, then it is incremented prior
-                  to each update. This is used to verify that the API server has the updated
-                  object prior to starting a new Reconcile operation.
+                  UpdateCount tracks the number of times the BpfApplicationState object has
+                  been updated. The bpfman agent initializes it to 1 when it creates the
+                  object, and then increments it before each subsequent update. It serves
+                  as a lightweight sequence number to verify that the API server is serving
+                  the most recent version of the object before beginning a new Reconcile
+                  operation.
                 format: int64
                 type: integer
             required:

--- a/config/crd/bases/bpfman.io_bpfapplications.yaml
+++ b/config/crd/bases/bpfman.io_bpfapplications.yaml
@@ -27,7 +27,17 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BpfApplication is the Schema for the bpfapplications API
+        description: |-
+          BpfApplication is the schema for the namespace scoped BPF Applications API.
+          Using this API allows applications to load one or more eBPF programs on a
+          Kubernetes cluster using bpfman to load the programs.
+
+
+          The bpfApplication.status field reports the overall status of the
+          BpfApplication CRD. A given BpfApplication CRD can result in loading and
+          attaching multiple eBPF programs on multiple nodes, so this status is just a
+          summary. More granular per-node status details can be found in the
+          corresponding BpfApplicationState CRD that bpfman creates for each node.
         properties:
           apiVersion:
             description: |-
@@ -47,20 +57,45 @@ spec:
           metadata:
             type: object
           spec:
-            description: BpfApplicationSpec defines the desired state of BpfApplication
+            description: |-
+              spec defines the desired state of the BpfApplication. The BpfApplication
+              describes the set of one or more namespace scoped eBPF programs that should
+              be loaded for a given application and attributes for how they should be
+              loaded. eBPF programs that are grouped together under the same
+              BpfApplication instance can share maps and global data between the eBPF
+              programs loaded on the same Kubernetes Node.
             properties:
               byteCode:
                 description: |-
-                  bytecode configures where the bpf program's bytecode should be loaded
-                  from.
+                  bytecode is a required field and configures where the eBPF program's
+                  bytecode should be loaded from. The image must contain one or more
+                  eBPF programs.
+                maxProperties: 1
+                minProperties: 1
                 properties:
                   image:
-                    description: image used to specify a bytecode container image.
+                    description: |-
+                      image is an optional field and used to specify details on how to retrieve an
+                      eBPF program packaged in a OCI container image from a given registry.
                     properties:
                       imagePullPolicy:
                         default: IfNotPresent
-                        description: pullPolicy describes a policy for if/when to
-                          pull a bytecode image. Defaults to IfNotPresent.
+                        description: |-
+                          pullPolicy is an optional field that describes a policy for if/when to pull
+                          a bytecode image. Defaults to IfNotPresent. Allowed values are:
+                            Always, IfNotPresent and Never
+
+
+                          When set to Always, the given image will be pulled even if the image is
+                          already present on the node.
+
+
+                          When set to IfNotPresent, the given image will only be pulled if it is not
+                          present on the node.
+
+
+                          When set to Never, the given image will never be pulled and must be load on
+                          the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -68,24 +103,28 @@ spec:
                         type: string
                       imagePullSecret:
                         description: |-
-                          imagePullSecret is the name of the secret bpfman should use to get remote image
-                          repository secrets.
+                          imagePullSecret is an optional field and indicates the secret which contains
+                          the credentials to access the image repository.
                         properties:
                           name:
-                            description: name of the secret which contains the credentials
-                              to access the image repository.
+                            description: |-
+                              name is a required field and is the name of the secret which contains the
+                              credentials to access the image repository.
                             type: string
                           namespace:
-                            description: namespace of the secret which contains the
-                              credentials to access the image repository.
+                            description: |-
+                              namespace is a required field and is the namespace of the secret which
+                              contains the credentials to access the image repository.
                             type: string
                         required:
                         - name
                         - namespace
                         type: object
                       url:
-                        description: url is a valid container image URL used to reference
-                          a remote bytecode image.
+                        description: |-
+                          url is a required field and is a valid container image URL used to reference
+                          a remote bytecode image. url must not be an empty string, must not exceed
+                          525 characters in length and must be a valid URL.
                         maxLength: 525
                         pattern: '[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}'
                         type: string
@@ -93,7 +132,9 @@ spec:
                     - url
                     type: object
                   path:
-                    description: path is used to specify a bytecode object via filepath.
+                    description: |-
+                      path is an optional field and used to specify a bytecode object file via
+                      filepath on a Kubernetes node.
                     pattern: ^(/[^/\0]+)+/?$
                     type: string
                 type: object
@@ -102,16 +143,22 @@ spec:
                   format: byte
                   type: string
                 description: |-
-                  globalData allows the user to set global variables when the program is loaded
-                  with an array of raw bytes. This is a very low level primitive. The caller
-                  is responsible for formatting the byte string appropriately considering
-                  such things as size, endianness, alignment and packing of data structures.
+                  globalData is an optional field that allows the user to set global variables
+                  when the program is loaded. This allows the same compiled bytecode to be
+                  deployed by different BPF Applications to behave differently based on
+                  globalData configuration values.  It uses an array of raw bytes. This is a
+                  very low level primitive. The caller is responsible for formatting the byte
+                  string appropriately considering such things as size, endianness, alignment
+                  and packing of data structures.
                 type: object
               mapOwnerSelector:
                 description: |-
-                  TODO: need to work out how MapOwnerSelector will work after load-attach-split
-                  mapOwnerSelector is used to select the loaded eBPF program this eBPF program
-                  will share a map with.
+                  mapOwnerSelector is an optional field used to share maps across
+                  applications. eBPF programs loaded with the same ClusterBpfApplication or
+                  BpfApplication instance do not need to use this field. This label selector
+                  allows maps from a different ClusterBpfApplication or BpfApplication
+                  instance to be used by this instance.
+                  TODO: mapOwnerSelector is currently not supported due to recent code rework.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -158,9 +205,9 @@ spec:
                 x-kubernetes-map-type: atomic
               nodeSelector:
                 description: |-
-                  nodeSelector allows the user to specify which nodes to deploy the
-                  bpf program to. This field must be specified, to select all nodes
-                  use standard metav1.LabelSelector semantics and make it empty.
+                  nodeSelector is a required field and allows the user to specify which
+                  Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+                  standard metav1.LabelSelector semantics and make it empty.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -207,62 +254,114 @@ spec:
                 x-kubernetes-map-type: atomic
               programs:
                 description: |-
-                  programs is the list of bpf programs in the BpfApplication that should be
-                  loaded. The application can selectively choose which program(s) to run
-                  from this list based on the optional attach points provided.
+                  programs is a required field and is the list of eBPF programs in a BPF
+                  Application CRD that should be loaded in kernel memory. At least one entry
+                  is required. eBPF programs in this list will be loaded on the system based
+                  the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+                  cannot be triggered until an attachment point is provided. The different
+                  program types have different ways of attaching. The attachment points can be
+                  added at creation time or modified (added or removed) at a later time to
+                  activate or deactivate the eBPF program as desired.
+                  CAUTION: When programs are added or removed from the list, that requires all
+                  programs in the list to be reloaded, which could be temporarily service
+                  effecting. For this reason, modifying the list is currently not allowed.
                 items:
                   description: BpfApplicationProgram defines the desired state of
                     BpfApplication
                   properties:
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
-                        program
+                        name is a required field and is the name of the function that is the entry
+                        point for the eBPF program. name must not be an empty string, must not
+                        exceed 64 characters in length, must start with alpha characters and must
+                        only contain alphanumeric characters.
                       maxLength: 64
                       minLength: 1
                       pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: |-
+                        tc is an optional field, but required when the type field is set to TC. tc
+                        defines the desired state of the application's TC programs. TC programs are
+                        attached to network devices (interfaces). The program can be attached on
+                        either packet ingress or egress, so the program will be called on every
+                        incoming or outgoing packet seen by the network device. The TC attachment
+                        point is in Linux's Traffic Control (tc) subsystem, which is after the
+                        Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+                        with enhanced performance and better support for running multiple programs
+                        on a given network device. This makes TC useful for packet classification
+                        actions.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TC program should be attached. The TC program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TC program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TC program to be
+                            attached or detached.
+
+
+                            The attachment point for a TC program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TC program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TC program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -270,34 +369,40 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
-                                  program will be attached in the root network namespace.
+                                  networkNamespaces is a required field that identifies the set of network
+                                  namespaces in which to attach the eBPF program.
                                 properties:
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -347,10 +452,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TC
+                                  program relative to other TC programs attached to the same attachment point.
+                                  It must be a value between 0 and 1000, where lower values indicate higher
+                                  precedence. For TC programs on the same attachment point with the same
+                                  direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -360,8 +469,18 @@ spec:
                                 - Pipe
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other TC programs
+                                  in a chain, or not call the next program in a chain based on the exit code
+                                  of a TC program. Allowed values, which are the possible exit codes from a TC
+                                  eBPF program, are:
+                                    UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+                                    Trap, DispatcherReturn
+
+
+                                  Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+                                  using the default values, if a TC program returns Pipe, the next TC
+                                  program in the chain will be called. If a TC program returns Stolen, the
+                                  next TC program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - UnSpec
@@ -385,46 +504,88 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: |-
+                        tcx is an optional field, but required when the type field is set to TCX.
+                        tcx defines the desired state of the application's TCX programs. TCX
+                        programs are attached to network devices (interfaces). The program can be
+                        attached on either packet ingress or egress, so the program will be called
+                        on every incoming or outgoing packet seen by the network device. The TCX
+                        attachment point is in Linux's Traffic Control (tc) subsystem, which is
+                        after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+                        packet classification actions. TCX is a newer implementation of TC with
+                        enhanced performance and better support for running multiple programs on a
+                        given network device.
                       properties:
                         links:
                           description: |-
-                            links is The list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TCX program should be attached. The TCX program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TCX program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TCX program to be
+                            attached or detached.
+
+
+                            The attachment point for a TCX program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TCX program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TCX program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -432,33 +593,40 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program.
+                                  networkNamespaces is a required field that identifies the set of network
+                                  namespaces in which to attach the eBPF program.
                                 properties:
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -508,10 +676,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TCX
+                                  program relative to other TCX programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For TCX programs on the same attachment point with the
+                                  same direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -520,12 +692,51 @@ spec:
                             - direction
                             - interfaceSelector
                             - networkNamespaces
-                            - priority
                             type: object
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type is a required field used to specify the type of the eBPF program. The
+                        type dictates which eBPF attachment point to use. This is where the eBPF
+                        program is executed.
+
+
+                        Allowed values are:
+                          TC, TCX, UProbe, URetProbe, XDP
+
+
+                        When set to TC, the eBPF program can attach to network devices (interfaces).
+                        The program can be attached on either packet ingress or egress, so the
+                        program will be called on every incoming or outgoing packet seen by the
+                        network device. When using the TC program type, the tc field is required.
+                        See tc for more details on TC programs.
+
+
+                        When set to TCX, the eBPF program can attach to network devices
+                        (interfaces). The program can be attached on either packet ingress or
+                        egress, so the program will be called on every incoming or outgoing packet
+                        seen by the network device. When using the TCX program type, the tcx field
+                        is required. See tcx for more details on TCX programs.
+
+
+                        When set to UProbe, the program can attach in user-space. The UProbe is
+                        attached to a binary, library or function name, and optionally an offset in
+                        the code. When using the UProbe program type, the uprobe field is required.
+                        See uprobe for more details on UProbe programs.
+
+
+                        When set to URetProbe, the program can attach in user-space.
+                        The URetProbe is attached to the return of a binary, library or function
+                        name, and optionally an offset in the code.  When using the URetProbe
+                        program type, the uretprobe field is required. See uretprobe for more
+                        details on URetProbe programs.
+
+
+                        When set to XDP, the eBPF program can attach to network devices (interfaces)
+                        and will be called on every incoming packet received by the network device.
+                        When using the XDP program type, the xdp field is required. See xdp for more
+                        details on XDP programs.
                       enum:
                       - XDP
                       - TC
@@ -534,31 +745,54 @@ spec:
                       - URetProbe
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe is an optional field, but required when the type field is set to
+                        UProbe. uprobe defines the desired state of the application's UProbe
+                        programs. UProbe programs are user-space probes. A target must be provided,
+                        which is the library name or absolute path to a binary or library where the
+                        probe is attached. Optionally, a function name can also be provided to
+                        provide finer granularity on where the probe is attached. They can be
+                        attached at any point in the binary, library or function using the optional
+                        offset field. However, caution must be taken when using the offset, ensuring
+                        the offset is still in the desired bytecode.
                       properties:
                         links:
                           description: |-
-                            links is The list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                   uprobe.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -608,26 +842,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function. If not provided, offset defaults to 0.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - containers
@@ -636,31 +878,55 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobe defines the desired state of the application's
-                        UretprobePrograms.
+                      description: |-
+                        uretprobe is an optional field, but required when the type field is set to
+                        URetProbe. uretprobe defines the desired state of the application's
+                        URetProbe programs. URetProbe programs are user-space probes. A target must
+                        be provided, which is the library name or absolute path to a binary or
+                        library where the probe is attached. Optionally, a function name can also be
+                        provided to provide finer granularity on where the probe is attached. They
+                        are attached to the return point of the binary, library or function, but can
+                        be set anywhere using the optional offset field. However, caution must be
+                        taken when using the offset, ensuring the offset is still in the desired
+                        bytecode.
                       properties:
                         links:
                           description: |-
-                            links is The list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                   uprobe.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -710,26 +976,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function. If not provided, offset defaults to 0.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - containers
@@ -738,38 +1012,67 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: |-
+                        xdp is an optional field, but required when the type field is set to XDP.
+                        xdp defines the desired state of the application's XDP programs. XDP program
+                        can be attached to network devices (interfaces) and will be called on every
+                        incoming packet received by the network device. The XDP attachment point is
+                        just after the packet has been received off the wire, but before the Linux
+                        kernel has allocated an sk_buff, which is used to pass the packet through
+                        the kernel networking stack.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            XDP program should be attached. The XDP program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The XDP program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the XDP program to be
+                            attached or detached.
+
+
+                            The attachment point for a XDP program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node.
                           items:
                             properties:
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the XDP program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -777,33 +1080,40 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program.
+                                  networkNamespaces is a required field that identifies the set of network
+                                  namespaces in which to attach the eBPF program.
                                 properties:
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -853,10 +1163,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the bpf program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the XDP
+                                  program relative to other XDP programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For XDP programs on the same attachment point with the
+                                  same priority, the most recently attached program has a lower precedence.
+                                  If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -866,8 +1180,17 @@ spec:
                                 - Pass
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other XDP
+                                  programs in a chain, or not call the next program in a chain based on the
+                                  exit code of an XDP program. Allowed values, which are the possible exit
+                                  codes from an XDP eBPF program, are:
+                                    Aborted, Drop, Pass, TX, ReDirect,DispatcherReturn
+
+
+                                  Multiple values are supported. Default is Pass and DispatcherReturn. So
+                                  using the default values, if an XDP program returns Pass, the next XDP
+                                  program in the chain will be called. If an XDP program returns Drop, the
+                                  next XDP program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - Aborted
@@ -916,14 +1239,14 @@ spec:
             - nodeSelector
             type: object
           status:
-            description: BpfAppStatus reflects the status of a BpfApplication or BpfApplicationState
-              object
+            description: |-
+              status reflects the status of a BPF Application and indicates if all the
+              eBPF programs for a given instance loaded successfully or not.
             properties:
               conditions:
                 description: |-
-                  For a BpfApplication object, Conditions contains the global cluster state
-                  for the object. For a BpfApplicationState object, Conditions contains the
-                  state of the BpfApplication object on the given node.
+                  conditions contains the summary state for all eBPF programs defined in the
+                  BPF Application instance for all the Kubernetes nodes in the cluster.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for

--- a/config/crd/bases/bpfman.io_bpfapplications.yaml
+++ b/config/crd/bases/bpfman.io_bpfapplications.yaml
@@ -29,8 +29,8 @@ spec:
       openAPIV3Schema:
         description: |-
           BpfApplication is the schema for the namespace scoped BPF Applications API.
-          Using this API allows applications to load one or more eBPF programs on a
-          Kubernetes cluster using bpfman to load the programs.
+          This API allows applications to use bpfman to load and attach one or more
+          eBPF programs on a Kubernetes cluster.
 
 
           The bpfApplication.status field reports the overall status of the
@@ -94,8 +94,8 @@ spec:
                           present on the node.
 
 
-                          When set to Never, the given image will never be pulled and must be load on
-                          the node by some other means.
+                          When set to Never, the given image will never be pulled and must be
+                          loaded on the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -381,8 +381,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -605,8 +605,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -697,9 +697,7 @@ spec:
                       type: object
                     type:
                       description: |-
-                        type is a required field used to specify the type of the eBPF program. The
-                        type dictates which eBPF attachment point to use. This is where the eBPF
-                        program is executed.
+                        type is a required field used to specify the type of the eBPF program.
 
 
                         Allowed values are:
@@ -778,7 +776,7 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                   uprobe.
                                 properties:
                                   containerNames:
@@ -912,7 +910,7 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                   uprobe.
                                 properties:
                                   containerNames:
@@ -1092,8 +1090,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean

--- a/config/crd/bases/bpfman.io_bpfapplicationstates.yaml
+++ b/config/crd/bases/bpfman.io_bpfapplicationstates.yaml
@@ -27,7 +27,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BpfApplicationState contains the per-node state of a BpfApplication.
+        description: |-
+          BpfApplicationState contains the state of a BpfApplication instance for a
+          given Kubernetes node. When a user creates a BpfApplication instance, bpfman
+          creates a BpfApplicationState instance for each node in a Kubernetes
+          cluster.
         properties:
           apiVersion:
             description: |-
@@ -47,18 +51,49 @@ spec:
           metadata:
             type: object
           status:
-            description: BpfApplicationStateStatus reflects the status of the BpfApplication
-              on the given node
+            description: |-
+              status reflects the status of a BpfApplication instance for the given node.
+              appLoadStatus and conditions provide an overall status for the given node,
+              while each item in the programs list provides a per eBPF program status for
+              the given node.
             properties:
               appLoadStatus:
                 description: |-
-                  appLoadStatus reflects the status of loading the bpf application on the
-                  given node.
+                  appLoadStatus reflects the status of loading the eBPF application on the
+                  given node. Whether or not the eBPF program is attached to an attachment
+                  point is tracked by the linkStatus field, which is under of each link of
+                  each program.
+
+
+                  NotLoaded is a temporary state that is assigned when a
+                  ClusterBpfApplicationState is created and the initial reconcile is being
+                  processed.
+
+
+                  LoadSuccess is returned if all the programs have been loaded with no errors.
+
+
+                  LoadError is returned if one or more programs encountered an error and were
+                  not loaded.
+
+
+                  NotSelected is returned if this application did not select to run on this
+                  Kubernetes node.
+
+
+                  UnloadSuccess is returned when all the programs were successfully unloaded.
+
+
+                  UnloadError is returned if one or more programs encountered an error when
+                  being unloaded.
                 type: string
               conditions:
                 description: |-
-                  Conditions contains the overall status of the BpfApplicationState object
-                  on the given node.
+                  conditions contains the summary state of the BpfApplication for the given
+                  Kubernetes node. If one or more programs failed to load or attach to the
+                  designated attachment point, the condition will report the error. If more
+                  than one error has occurred, condition will contain the first error
+                  encountered.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for
@@ -131,18 +166,18 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               node:
-                description: node is the name of the node for this BpfApplicationStateSpec.
+                description: node is the name of the Kubernets node for this BpfApplicationState.
                 type: string
               programs:
-                description: programs is a list of bpf programs contained in the parent
-                  application.
+                description: |-
+                  programs is a list of eBPF programs contained in the parent BpfApplication
+                  instance. Each entry in the list contains the derived program attributes as
+                  well as the attach status for each program on the given Kubernetes node.
                 items:
-                  description: BpfApplicationProgramState defines the desired state
-                    of BpfApplication
                   properties:
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
+                        name is the name of the function that is the entry point for the eBPF
                         program
                       type: string
                     programId:
@@ -157,29 +192,29 @@ spec:
                         are in the correct state.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: tc contains the attachment data for a TC program
+                        when type is set to TC.
                       properties:
                         links:
                           description: |-
-                            links is the List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the TC program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the TC
+                                  program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TC program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -194,22 +229,24 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               netnsPath:
-                                description: netnsPath is a path to a Network namespace
-                                  to attach the tc program in.
+                                description: |-
+                                  netnsPath is the path to the network namespace inside of which the TC
+                                  program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TC program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - UnSpec
@@ -246,29 +283,29 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: tcx contains the attachment data for a TCX program
+                        when type is set to TCX.
                       properties:
                         links:
                           description: |-
-                            links is the List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the TCX program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the
+                                  TCX program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TCX program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -284,14 +321,14 @@ spec:
                                 type: string
                               netnsPath:
                                 description: |-
-                                  netnsPath is the path to the Network namespace to attach the tcx program
-                                  in.
+                                  netnsPath is the path to the network namespace inside of which the TCX
+                                  program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TCX program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -305,15 +342,41 @@ spec:
                                   attach point assigned by bpfman agent.
                                 type: string
                             required:
+                            - direction
+                            - interfaceName
                             - linkStatus
                             - netnsPath
+                            - priority
                             - shouldAttach
                             - uuid
                             type: object
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type specifies the provisioned eBPF program type for this program entry.
+                        Type will be one of:
+                          TC, TCX, UProbe, URetProbe, XDP
+
+
+                        When set to TC, the tc object will be populated with the eBPF program data
+                        associated with a TC program.
+
+
+                        When set to TCX, the tcx object will be populated with the eBPF program
+                        data associated with a TCX program.
+
+
+                        When set to UProbe, the uprobe object will be populated with the eBPF
+                        program data associated with a UProbe program.
+
+
+                        When set to URetProbe, the uretprobe object will be populated with the eBPF
+                        program data associated with a URetProbe program.
+
+
+                        When set to XDP, the xdp object will be populated with the eBPF program data
+                        associated with a URetProbe program.
                       enum:
                       - XDP
                       - TC
@@ -322,25 +385,29 @@ spec:
                       - URetProbe
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe contains the attachment data for a UProbe program when type is set to
+                        UProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: containerPid is container pid to attach
-                                  the uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the BpfApplication instance, containerPid is
+                                  the derived PID of the container the UProbe or URetProbe this attachment
+                                  point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -356,14 +423,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is Only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -371,8 +440,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -387,25 +457,29 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobe defines the desired state of the application's
-                        UretprobePrograms.
+                      description: |-
+                        uretprobe contains the attachment data for a URetProbe program when type is
+                        set to URetProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: containerPid is container pid to attach
-                                  the uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the BpfApplication instance, containerPid is
+                                  the derived PID of the container the UProbe or URetProbe this attachment
+                                  point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -421,14 +495,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid is Only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -436,8 +512,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -452,21 +529,21 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: xdp contains the attachment data for an XDP program
+                        when type is set to XDP.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the XDP program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               interfaceName:
-                                description: interfaceName is the interface name to
-                                  attach the xdp program to.
+                                description: |-
+                                  interfaceName is the name of the interface the XDP program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -482,22 +559,23 @@ spec:
                                 type: string
                               netnsPath:
                                 description: |-
-                                  netnsPath is the path to the Network namespace to attach the xdp program
-                                  in.
+                                  netnsPath is the path to the network namespace inside of which the XDP
+                                  program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the xdp program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the XDP program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - Aborted
@@ -556,10 +634,10 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the BpfApplicationState has been updated. Set to 1
-                  when the object is created, then it is incremented prior to each update.
-                  This allows us to verify that the API server has the updated object prior
-                  to starting a new Reconcile operation.
+                  updateCount is the number of times the BpfApplicationState has been updated.
+                  Set to 1 when the object is created, then it is incremented prior to each
+                  update. This is used to verify that the API server has the updated object
+                  prior to starting a new Reconcile operation.
                 format: int64
                 type: integer
             required:

--- a/config/crd/bases/bpfman.io_bpfapplicationstates.yaml
+++ b/config/crd/bases/bpfman.io_bpfapplicationstates.yaml
@@ -60,9 +60,7 @@ spec:
               appLoadStatus:
                 description: |-
                   appLoadStatus reflects the status of loading the eBPF application on the
-                  given node. Whether or not the eBPF program is attached to an attachment
-                  point is tracked by the linkStatus field, which is under of each link of
-                  each program.
+                  given node.
 
 
                   NotLoaded is a temporary state that is assigned when a
@@ -70,18 +68,20 @@ spec:
                   processed.
 
 
-                  LoadSuccess is returned if all the programs have been loaded with no errors.
+                  LoadSuccess is returned if all the programs have been loaded with no
+                  errors.
 
 
-                  LoadError is returned if one or more programs encountered an error and were
-                  not loaded.
+                  LoadError is returned if one or more programs encountered an error and
+                  were not loaded.
 
 
                   NotSelected is returned if this application did not select to run on this
                   Kubernetes node.
 
 
-                  UnloadSuccess is returned when all the programs were successfully unloaded.
+                  UnloadSuccess is returned when all the programs were successfully
+                  unloaded.
 
 
                   UnloadError is returned if one or more programs encountered an error when
@@ -634,10 +634,12 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the BpfApplicationState has been updated.
-                  Set to 1 when the object is created, then it is incremented prior to each
-                  update. This is used to verify that the API server has the updated object
-                  prior to starting a new Reconcile operation.
+                  UpdateCount tracks the number of times the BpfApplicationState object has
+                  been updated. The bpfman agent initializes it to 1 when it creates the
+                  object, and then increments it before each subsequent update. It serves
+                  as a lightweight sequence number to verify that the API server is serving
+                  the most recent version of the object before beginning a new Reconcile
+                  operation.
                 format: int64
                 type: integer
             required:

--- a/config/crd/bases/bpfman.io_clusterbpfapplications.yaml
+++ b/config/crd/bases/bpfman.io_clusterbpfapplications.yaml
@@ -29,8 +29,8 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterBpfApplication is the schema for the cluster scoped BPF Applications
-          API. Using this API allows applications to load one or more eBPF programs on
-          a Kubernetes cluster using bpfman to load the programs.
+          API. This API allows applications to use bpfman to load and attach one or
+          more eBPF programs on a Kubernetes cluster.
 
 
           The clusterBpfApplication.status field reports the overall status of the
@@ -95,8 +95,8 @@ spec:
                           present on the node.
 
 
-                          When set to Never, the given image will never be pulled and must be load on
-                          the node by some other means.
+                          When set to Never, the given image will never be pulled and must be
+                          loaded on the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -563,8 +563,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -654,7 +654,6 @@ spec:
                                 type: integer
                               proceedOn:
                                 default:
-                                - OK
                                 - Pipe
                                 - DispatcherReturn
                                 description: |-
@@ -793,8 +792,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean
@@ -934,9 +933,7 @@ spec:
                       type: object
                     type:
                       description: |-
-                        type is a required field used to specify the type of the eBPF program. The
-                        type dictates which eBPF attachment point to use. This is where the eBPF
-                        program is executed.
+                        type is a required field used to specify the type of the eBPF program.
 
 
                         Allowed values are:
@@ -1049,12 +1046,12 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                 properties:
                                   containerNames:
                                     description: |-
                                       containerNames is an optional field and is a list of container names in a
-                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      pod to attach the eBPF program. If no names are specified, all containers
                                       in the pod are selected.
                                     items:
                                       type: string
@@ -1062,7 +1059,7 @@ spec:
                                   namespace:
                                     description: |-
                                       namespace is an optional field and indicates the target Kubernetes
-                                      namespace. If not provided, the default Kubernetes namespace is used.
+                                      namespace. If not provided, all Kubernetes namespaces are included.
                                     type: string
                                   pods:
                                     description: |-
@@ -1186,12 +1183,12 @@ spec:
                                 description: |-
                                   containers is an optional field that identifies the set of containers in
                                   which to attach the UProbe or URetProbe program. If containers is not
-                                  specified, the eBPF program will be attached in the bpfman-agent container.
+                                  specified, the eBPF program will be attached in the bpfman container.
                                 properties:
                                   containerNames:
                                     description: |-
                                       containerNames is an optional field and is a list of container names in a
-                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      pod to attach the eBPF program. If no names are specified, all containers
                                       in the pod are selected.
                                     items:
                                       type: string
@@ -1199,7 +1196,7 @@ spec:
                                   namespace:
                                     description: |-
                                       namespace is an optional field and indicates the target Kubernetes
-                                      namespace. If not provided, the default Kubernetes namespace is used.
+                                      namespace. If not provided, all Kubernetes namespaces are included.
                                     type: string
                                   pods:
                                     description: |-
@@ -1310,10 +1307,10 @@ spec:
 
 
                             The attachment point for an XDP program is a network interface (or device).
-                            The interface can be specified by name, or by setting the
-                            primaryNodeInterface flag, which instructs bpfman to use the primary
-                            interface of a Kubernetes node. Optionally, the XDP program can also be
-                            installed into a set of network namespaces.
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            XDP program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               interfaceSelector:
@@ -1370,8 +1367,8 @@ spec:
                                         default: false
                                         description: |-
                                           interfaceAutoDiscovery is an optional field. When enabled, the agent
-                                          monitors the creation and deletion of interfaces and automatically attached
-                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          monitors the creation and deletion of interfaces and automatically
+                                          attached eBPF programs to the newly discovered interfaces.
                                           CAUTION: This has the potential to attach a given eBPF program to a large
                                           number of interfaces. Use with caution.
                                         type: boolean

--- a/config/crd/bases/bpfman.io_clusterbpfapplications.yaml
+++ b/config/crd/bases/bpfman.io_clusterbpfapplications.yaml
@@ -27,7 +27,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterBpfApplication is the Schema for the bpfapplications API
+        description: |-
+          ClusterBpfApplication is the schema for the cluster scoped BPF Applications
+          API. Using this API allows applications to load one or more eBPF programs on
+          a Kubernetes cluster using bpfman to load the programs.
+
+
+          The clusterBpfApplication.status field reports the overall status of the
+          ClusterBpfApplication CRD. A given ClusterBpfApplication CRD can result in
+          loading and attaching multiple eBPF programs on multiple nodes, so this
+          status is just a summary. More granular per-node status details can be
+          found in the corresponding ClusterBpfApplicationState CRD that bpfman
+          creates for each node.
         properties:
           apiVersion:
             description: |-
@@ -47,20 +58,45 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClBpfApplicationSpec defines the desired state of BpfApplication
+            description: |-
+              spec defines the desired state of the ClusterBpfApplication. The
+              ClusterBpfApplication describes the set of one or more cluster scoped eBPF
+              programs that should be loaded for a given application and attributes for
+              how they should be loaded. eBPF programs that are grouped together under the
+              same ClusterBpfApplication instance can share maps and global data between
+              the eBPF programs loaded on the same Kubernetes Node.
             properties:
               byteCode:
                 description: |-
-                  bytecode configures where the bpf program's bytecode should be loaded
-                  from.
+                  bytecode is a required field and configures where the eBPF program's
+                  bytecode should be loaded from. The image must contain one or more
+                  eBPF programs.
+                maxProperties: 1
+                minProperties: 1
                 properties:
                   image:
-                    description: image used to specify a bytecode container image.
+                    description: |-
+                      image is an optional field and used to specify details on how to retrieve an
+                      eBPF program packaged in a OCI container image from a given registry.
                     properties:
                       imagePullPolicy:
                         default: IfNotPresent
-                        description: pullPolicy describes a policy for if/when to
-                          pull a bytecode image. Defaults to IfNotPresent.
+                        description: |-
+                          pullPolicy is an optional field that describes a policy for if/when to pull
+                          a bytecode image. Defaults to IfNotPresent. Allowed values are:
+                            Always, IfNotPresent and Never
+
+
+                          When set to Always, the given image will be pulled even if the image is
+                          already present on the node.
+
+
+                          When set to IfNotPresent, the given image will only be pulled if it is not
+                          present on the node.
+
+
+                          When set to Never, the given image will never be pulled and must be load on
+                          the node by some other means.
                         enum:
                         - Always
                         - Never
@@ -68,24 +104,28 @@ spec:
                         type: string
                       imagePullSecret:
                         description: |-
-                          imagePullSecret is the name of the secret bpfman should use to get remote image
-                          repository secrets.
+                          imagePullSecret is an optional field and indicates the secret which contains
+                          the credentials to access the image repository.
                         properties:
                           name:
-                            description: name of the secret which contains the credentials
-                              to access the image repository.
+                            description: |-
+                              name is a required field and is the name of the secret which contains the
+                              credentials to access the image repository.
                             type: string
                           namespace:
-                            description: namespace of the secret which contains the
-                              credentials to access the image repository.
+                            description: |-
+                              namespace is a required field and is the namespace of the secret which
+                              contains the credentials to access the image repository.
                             type: string
                         required:
                         - name
                         - namespace
                         type: object
                       url:
-                        description: url is a valid container image URL used to reference
-                          a remote bytecode image.
+                        description: |-
+                          url is a required field and is a valid container image URL used to reference
+                          a remote bytecode image. url must not be an empty string, must not exceed
+                          525 characters in length and must be a valid URL.
                         maxLength: 525
                         pattern: '[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}'
                         type: string
@@ -93,7 +133,9 @@ spec:
                     - url
                     type: object
                   path:
-                    description: path is used to specify a bytecode object via filepath.
+                    description: |-
+                      path is an optional field and used to specify a bytecode object file via
+                      filepath on a Kubernetes node.
                     pattern: ^(/[^/\0]+)+/?$
                     type: string
                 type: object
@@ -102,16 +144,22 @@ spec:
                   format: byte
                   type: string
                 description: |-
-                  globalData allows the user to set global variables when the program is loaded
-                  with an array of raw bytes. This is a very low level primitive. The caller
-                  is responsible for formatting the byte string appropriately considering
-                  such things as size, endianness, alignment and packing of data structures.
+                  globalData is an optional field that allows the user to set global variables
+                  when the program is loaded. This allows the same compiled bytecode to be
+                  deployed by different BPF Applications to behave differently based on
+                  globalData configuration values.  It uses an array of raw bytes. This is a
+                  very low level primitive. The caller is responsible for formatting the byte
+                  string appropriately considering such things as size, endianness, alignment
+                  and packing of data structures.
                 type: object
               mapOwnerSelector:
                 description: |-
-                  TODO: need to work out how MapOwnerSelector will work after load-attach-split
-                  mapOwnerSelector is used to select the loaded eBPF program this eBPF program
-                  will share a map with.
+                  mapOwnerSelector is an optional field used to share maps across
+                  applications. eBPF programs loaded with the same ClusterBpfApplication or
+                  BpfApplication instance do not need to use this field. This label selector
+                  allows maps from a different ClusterBpfApplication or BpfApplication
+                  instance to be used by this instance.
+                  TODO: mapOwnerSelector is currently not supported due to recent code rework.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -158,9 +206,9 @@ spec:
                 x-kubernetes-map-type: atomic
               nodeSelector:
                 description: |-
-                  nodeSelector allows the user to specify which nodes to deploy the
-                  bpf program to. This field must be specified, to select all nodes
-                  use standard metav1.LabelSelector semantics and make it empty.
+                  nodeSelector is a required field and allows the user to specify which
+                  Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+                  standard metav1.LabelSelector semantics and make it empty.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -207,37 +255,57 @@ spec:
                 x-kubernetes-map-type: atomic
               programs:
                 description: |-
-                  programs is the list of bpf programs in the BpfApplication that should be
-                  loaded. The application can selectively choose which program(s) to run
-                  from this list based on the optional attach points provided.
+                  programs is a required field and is the list of eBPF programs in a BPF
+                  Application CRD that should be loaded in kernel memory. At least one entry
+                  is required. eBPF programs in this list will be loaded on the system based
+                  the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+                  cannot be triggered until an attachment point is provided. The different
+                  program types have different ways of attaching. The attachment points can be
+                  added at creation time or modified (added or removed) at a later time to
+                  activate or deactivate the eBPF program as desired.
+                  CAUTION: When programs are added or removed from the list, that requires all
+                  programs in the list to be reloaded, which could be temporarily service
+                  effecting. For this reason, modifying the list is currently not allowed.
                 items:
-                  description: ClBpfApplicationProgram defines the desired state of
-                    BpfApplication
                   properties:
                     fentry:
-                      description: fentry defines the desired state of the application's
-                        FentryPrograms.
+                      description: |-
+                        fentry is an optional field, but required when the type field is set to
+                        FEntry. fentry defines the desired state of the application's FEntry
+                        programs. FEntry programs are attached to the entry of a Linux kernel
+                        function or to another eBPF program function. They are attached to the first
+                        instruction, before control passes to the function. FEntry programs are
+                        similar to KProbe programs, but have higher performance.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fentry program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FEntry program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
-                          description: Whether the program should be attached to the
-                            function.
+                          description: |-
+                            links is an optional field and is a flag to indicate if the FEntry program
+                            should be attached. The attachment point for a FEntry program is a Linux
+                            kernel function. Unlike other eBPF program types, an FEntry program must be
+                            provided with the target function at load time. The links field is optional,
+                            but unlike other program types where it represents a list of attachment
+                            points, for FEntry programs it contains at most one entry that determines
+                            whether the program should be attached to the specified function. To attach
+                            the program, add an entry to links with mode set to Attach. To detach it,
+                            remove the entry from links.
                           items:
-                            description: |-
-                              ClFentryAttachInfo indicates that the Fentry program should be attached to
-                              the function identified in ClFentryLoadInfo. The only valid value for Attach
-                              is true.
                             properties:
                               mode:
+                                description: |-
+                                  mode is a required field. When set to Attach, the FEntry program will
+                                  attempt to be attached. To detach the FEntry program, remove the link entry.
                                 enum:
                                 - Attach
-                                - Dettach
                                 type: string
                             required:
                             - mode
@@ -248,29 +316,45 @@ spec:
                       - function
                       type: object
                     fexit:
-                      description: fexit defines the desired state of the application's
-                        FexitPrograms.
+                      description: |-
+                        fexit is an optional field, but required when the type field is set to
+                        FExit. fexit defines the desired state of the application's FExit programs.
+                        FExit programs are attached to the exit of a Linux kernel function or to
+                        another eBPF program function. The program is invoked when the function
+                        returns, independent of where in the function that occurs. FExit programs
+                        are similar to KRetProbe programs, but get invoked with the input arguments
+                        and the return values. They also have higher performance over KRetProbe
+                        programs.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fexit program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FExit program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
-                          description: Whether the program should be attached to the
-                            function.
+                          description: |-
+                            links is an optional field and is a flag to indicate if the FExit program
+                            should be attached. The attachment point for a FExit program is a Linux
+                            kernel function. Unlike other eBPF program types, an FExit program must be
+                            provided with the target function at load time. The links field is optional,
+                            but unlike other program types where it represents a list of attachment
+                            points, for FExit programs it contains at most one entry that determines
+                            whether the program should be attached to the specified function. To attach
+                            the program, add an entry to links with mode set to Attach. To detach it,
+                            remove the entry from links.
                           items:
-                            description: |-
-                              ClFexitAttachInfo indicates that the Fentry program should be attached to
-                              the function identified in ClFentryLoadInfo. The only valid value for Attach
-                              is true.
                             properties:
                               mode:
+                                description: |-
+                                  mode is a required field. When set to Attach, the FExit program will
+                                  attempt to be attached. To detach the FExit program, remove the link entry.
                                 enum:
                                 - Attach
-                                - Dettach
                                 type: string
                             required:
                             - mode
@@ -281,17 +365,38 @@ spec:
                       - function
                       type: object
                     kprobe:
-                      description: kprobe defines the desired state of the application's
-                        KprobePrograms.
+                      description: |-
+                        kprobe is an optional field, but required when the type field is set to
+                        KProbe. kprobe defines the desired state of the application's Kprobe
+                        programs. KProbe programs are attached to a Linux kernel function. Unlike
+                        FEntry programs, which must always be attached at the entry point of a Linux
+                        kernel function, KProbe programs can be attached at any point in the
+                        function using the optional offset field. However, caution must be taken
+                        when using the offset, ensuring the offset is still in the function
+                        bytecode. FEntry programs have less overhead than KProbe programs.
                       properties:
                         links:
                           description: |-
-                            The list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            KProbe program should be attached. The eBPF program is loaded in kernel
+                            memory when the BPF Application CRD is created and the selected Kubernetes
+                            nodes are active. The eBPF program will not be triggered until the program
+                            has also been attached to an attachment point described in this list. Items
+                            may be added or removed from the list at any point, causing the eBPF program
+                            to be attached or detached.
+
+
+                            The attachment point for a KProbe program is a Linux kernel function. By
+                            default, the eBPF program is triggered at the entry of the attachment point,
+                            but the attachment point can be adjusted using an optional offset.
                           items:
                             properties:
                               function:
-                                description: function to attach the kprobe to.
+                                description: |-
+                                  function is a required field and specifies the name of the Linux kernel
+                                  function to attach the KProbe program. function must not be an empty string,
+                                  must not exceed 64 characters in length, must start with alpha characters
+                                  and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
@@ -299,10 +404,8 @@ spec:
                               offset:
                                 default: 0
                                 description: |-
-                                  offset added to the address of the function for kprobe.
-                                  The offset must be zero for kretprobes.
-                                  TODO: Add a webhook to enforce kretprobe offset=0.
-                                  See: https://github.com/bpfman/bpfman-operator/issues/403
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function. If not provided, offset defaults to 0.
                                 format: int64
                                 type: integer
                             required:
@@ -311,17 +414,34 @@ spec:
                           type: array
                       type: object
                     kretprobe:
-                      description: kretprobe defines the desired state of the application's
-                        KretprobePrograms.
+                      description: |-
+                        kretprobe is an optional field, but required when the type field is set to
+                        KRetProbe. kretprobe defines the desired state of the application's
+                        KRetProbe programs. KRetProbe programs are attached to the exit of a Linux
+                        kernel function. FExit programs have less overhead than KRetProbe programs
+                        and FExit programs have access to both the input arguments as well as the
+                        return values. KRetProbes only have access to the return values.
                       properties:
                         links:
                           description: |-
-                            The list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            KRetProbe program should be attached. The eBPF program is loaded in kernel
+                            memory when the BPF Application CRD is created and the selected Kubernetes
+                            nodes are active. The eBPF program will not be triggered until the program
+                            has also been attached to an attachment point described in this list. Items
+                            may be added or removed from the list at any point, causing the eBPF program
+                            to be attached or detached.
+
+
+                            The attachment point for a KRetProbe program is a Linux kernel function.
                           items:
                             properties:
                               function:
-                                description: function to attach the kprobe to.
+                                description: |-
+                                  function is a required field and specifies the name of the Linux kernel
+                                  function to attach the KRetProbe program. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
@@ -333,53 +453,97 @@ spec:
                       type: object
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
-                        program
+                        name is a required field and is the name of the function that is the entry
+                        point for the eBPF program. name must not be an empty string, must not
+                        exceed 64 characters in length, must start with alpha characters and must
+                        only contain alphanumeric characters.
                       maxLength: 64
                       minLength: 1
                       pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: |-
+                        tc is an optional field, but required when the type field is set to TC. tc
+                        defines the desired state of the application's TC programs. TC programs are
+                        attached to network devices (interfaces). The program can be attached on
+                        either packet ingress or egress, so the program will be called on every
+                        incoming or outgoing packet seen by the network device. The TC attachment
+                        point is in Linux's Traffic Control (tc) subsystem, which is after the
+                        Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+                        with enhanced performance and better support for running multiple programs
+                        on a given network device. This makes TC useful for packet classification
+                        actions.
                       properties:
                         links:
                           description: |-
-                            The list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TC program should be attached. The TC program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TC program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TC program to be
+                            attached or detached.
+
+
+                            The attachment point for a TC program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TC program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TC program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -387,37 +551,46 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
-                                  program will be attached in the root network namespace.
+                                  networkNamespaces is an optional field that identifies the set of network
+                                  namespaces in which to attach the eBPF program. If networkNamespaces is not
+                                  specified, the eBPF program will be attached in the root network namespace.
                                 properties:
                                   namespace:
-                                    description: Target namespace.
+                                    description: |-
+                                      namespace is an optional field and indicates the target network namespace.
+                                      If not provided, the default network namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -467,21 +640,36 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TC
+                                  program relative to other TC programs attached to the same attachment point.
+                                  It must be a value between 0 and 1000, where lower values indicate higher
+                                  precedence. For TC programs on the same attachment point with the same
+                                  direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 default:
+                                - OK
                                 - Pipe
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other TC programs
+                                  in a chain, or not call the next program in a chain based on the exit code
+                                  of a TC program. Allowed values, which are the possible exit codes from a TC
+                                  eBPF program, are:
+                                    UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+                                    Trap, DispatcherReturn
+
+
+                                  Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+                                  using the default values, if a TC program returns Pipe, the next TC
+                                  program in the chain will be called. If a TC program returns Stolen, the
+                                  next TC program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - UnSpec
@@ -504,46 +692,88 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: |-
+                        tcx is an optional field, but required when the type field is set to TCX.
+                        tcx defines the desired state of the application's TCX programs. TCX
+                        programs are attached to network devices (interfaces). The program can be
+                        attached on either packet ingress or egress, so the program will be called
+                        on every incoming or outgoing packet seen by the network device. The TCX
+                        attachment point is in Linux's Traffic Control (tc) subsystem, which is
+                        after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+                        packet classification actions. TCX is a newer implementation of TC with
+                        enhanced performance and better support for running multiple programs on a
+                        given network device.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached. The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            TCX program should be attached. The TCX program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The TCX program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the TCX program to be
+                            attached or detached.
+
+
+                            The attachment point for a TCX program is a network interface (or device).
+                            The interface can be specified by name, by allowing bpfman to discover each
+                            interface, or by setting the primaryNodeInterface flag, which instructs
+                            bpfman to use the primary interface of a Kubernetes node. Optionally, the
+                            TCX program can also be installed into a set of network namespaces.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is a required field and specifies the direction of traffic.
+                                  Allowed values are:
+                                     Ingress, Egress
+
+
+                                  When set to Ingress, the TC program is triggered when packets are received
+                                  by the interface.
+
+
+                                  When set to Egress, the TC program is triggered when packets are to be
+                                  transmitted by the interface.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the TCX program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -551,37 +781,46 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
-                                  networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
-                                  program will be attached in the root network namespace.
+                                  networkNamespaces is an optional field that identifies the set of network
+                                  namespaces in which to attach the eBPF program. If networkNamespaces is not
+                                  specified, the eBPF program will be attached in the root network namespace.
                                 properties:
                                   namespace:
-                                    description: Target namespace.
+                                    description: |-
+                                      namespace is an optional field and indicates the target network namespace.
+                                      If not provided, the default network namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -631,10 +870,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the TCX
+                                  program relative to other TCX programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For TCX programs on the same attachment point with the
+                                  same direction and priority, the most recently attached program has a lower
+                                  precedence. If not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -646,19 +889,40 @@ spec:
                           type: array
                       type: object
                     tracepoint:
-                      description: tracepointInfo defines the desired state of the
-                        application's TracepointPrograms.
+                      description: |-
+                        tracepoint is an optional field, but required when the type field is set to
+                        Tracepoint. tracepoint defines the desired state of the application's
+                        Tracepoint programs. Whereas KProbes attach to dynamically to any Linux
+                        kernel function, Tracepoint programs are programs that can only be attached
+                        at predefined locations in the Linux kernel. Use the following command to
+                        see the available attachment points:
+                         `sudo find /sys/kernel/debug/tracing/events -type d`
+                        While KProbes are more flexible in where in the kernel the probe can be
+                        attached, the functions and data structure rely on the kernel your system is
+                        running. Tracepoints tend to be more stable across kernel versions and are
+                        better for portability.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            Tracepoint program should be attached. The Tracepoint program is loaded in
+                            kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The Tracepoint program will not be triggered
+                            until the program has also been attached to an attachment point described in
+                            this list. Items may be added or removed from the list at any point, causing
+                            the Tracepoint program to be attached or detached.
+
+
+                            The attachment point for a Tracepoint program is a one of a predefined set
+                            of Linux kernel functions.
                           items:
                             properties:
                               name:
                                 description: |-
-                                  name refers to the name of a kernel tracepoint to attach the
-                                  bpf program to.
+                                  name is a required field and specifies the name of the Linux kernel
+                                  Tracepoint to attach the eBPF program. name must not be an empty string,
+                                  must not exceed 64 characters in length, must start with alpha characters
+                                  and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
@@ -669,7 +933,76 @@ spec:
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type is a required field used to specify the type of the eBPF program. The
+                        type dictates which eBPF attachment point to use. This is where the eBPF
+                        program is executed.
+
+
+                        Allowed values are:
+                          FEntry, FExit, KProbe, KRetProbe, TC, TCX, TracePoint, UProbe, URetProbe,
+                          XDP
+
+
+                        When set to FEntry, the program is attached to the entry of a Linux kernel
+                        function or to another eBPF program function. When using the FEntry program
+                        type, the fentry field is required. See fentry for more details on FEntry
+                        programs.
+
+
+                        When set to FExit, the program is attached to the exit of a Linux kernel
+                        function or to another eBPF program function. When using the FExit program
+                        type, the fexit field is required. See fexit for more details on FExit
+                        programs.
+
+
+                        When set to KProbe, the program is attached to entry of a Linux kernel
+                        function. When using the KProbe program type, the kprobe field is required.
+                        See kprobe for more details on KProbe programs.
+
+
+                        When set to KRetProbe, the program is attached to exit of a Linux kernel
+                        function. When using the KRetProbe program type, the kretprobe field is
+                        required. See kretprobe for more details on KRetProbe programs.
+
+
+                        When set to TC, the eBPF program can attach to network devices (interfaces).
+                        The program can be attached on either packet ingress or egress, so the
+                        program will be called on every incoming or outgoing packet seen by the
+                        network device. When using the TC program type, the tc field is required.
+                        See tc for more details on TC programs.
+
+
+                        When set to TCX, the eBPF program can attach to network devices
+                        (interfaces). The program can be attached on either packet ingress or
+                        egress, so the program will be called on every incoming or outgoing packet
+                        seen by the network device. When using the TCX program type, the tcx field
+                        is required. See tcx for more details on TCX programs.
+
+
+                        When set to Tracepoint, the program can attach to one of the predefined set
+                        of Linux kernel functions. When using the Tracepoint program type, the
+                        tracepoint field is required. See tracepoint for more details on Tracepoint
+                        programs.
+
+
+                        When set to UProbe, the program can attach in user-space. The UProbe is
+                        attached to a binary, library or function name, and optionally an offset in
+                        the code. When using the UProbe program type, the uprobe field is required.
+                        See uprobe for more details on UProbe programs.
+
+
+                        When set to URetProbe, the program can attach in user-space.
+                        The URetProbe is attached to the return of a binary, library or function
+                        name, and optionally an offset in the code.  When using the URetProbe
+                        program type, the uretprobe field is required. See uretprobe for more
+                        details on URetProbe programs.
+
+
+                        When set to XDP, the eBPF program can attach to network devices (interfaces)
+                        and will be called on every incoming packet received by the network device.
+                        When using the XDP program type, the xdp field is required. See xdp for more
+                        details on XDP programs.
                       enum:
                       - XDP
                       - TC
@@ -683,35 +1016,58 @@ spec:
                       - TracePoint
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe is an optional field, but required when the type field is set to
+                        UProbe. uprobe defines the desired state of the application's UProbe
+                        programs. UProbe programs are user-space probes. A target must be provided,
+                        which is the library name or absolute path to a binary or library where the
+                        probe is attached. Optionally, a function name can also be provided to
+                        provide finer granularity on where the probe is attached. They can be
+                        attached at any point in the binary, library or function using the optional
+                        offset field. However, caution must be taken when using the offset, ensuring
+                        the offset is still in the desired bytecode.
                       properties:
                         links:
                           description: |-
-                            links in the list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
-                                  uprobe. If Containers is not specified, the uprobe will be attached in
-                                  the bpfman-agent container.
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the Name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   namespace:
-                                    description: namespaces indicate the target namespaces.
+                                    description: |-
+                                      namespace is an optional field and indicates the target Kubernetes
+                                      namespace. If not provided, the default Kubernetes namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -761,26 +1117,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - target
@@ -788,35 +1152,59 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobeInfo defines the desired state of the
-                        application's UretprobePrograms.
+                      description: |-
+                        uretprobe is an optional field, but required when the type field is set to
+                        URetProbe. uretprobe defines the desired state of the application's
+                        URetProbe programs. URetProbe programs are user-space probes. A target must
+                        be provided, which is the library name or absolute path to a binary or
+                        library where the probe is attached. Optionally, a function name can also be
+                        provided to provide finer granularity on where the probe is attached. They
+                        are attached to the return point of the binary, library or function, but can
+                        be set anywhere using the optional offset field. However, caution must be
+                        taken when using the offset, ensuring the offset is still in the desired
+                        bytecode.
                       properties:
                         links:
                           description: |-
-                            links in the list of points to which the program should be attached.  The list items
-                            are optional and may be udated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            UProbe or URetProbe program should be attached. The eBPF program is loaded
+                            in kernel memory when the BPF Application CRD is created and the selected
+                            Kubernetes nodes are active. The eBPF program will not be triggered until
+                            the program has also been attached to an attachment point described in this
+                            list. Items may be added or removed from the list at any point, causing the
+                            eBPF program to be attached or detached.
+
+
+                            The attachment point for a UProbe and URetProbe program is a user-space
+                            binary or function. By default, the eBPF program is triggered at the entry
+                            of the attachment point, but the attachment point can be adjusted using an
+                            optional function name and/or offset. Optionally, the eBPF program can be
+                            installed in a set of containers or limited to a specified PID.
                           items:
                             properties:
                               containers:
                                 description: |-
-                                  containers identify the set of containers in which to attach the
-                                  uprobe. If Containers is not specified, the uprobe will be attached in
-                                  the bpfman-agent container.
+                                  containers is an optional field that identifies the set of containers in
+                                  which to attach the UProbe or URetProbe program. If containers is not
+                                  specified, the eBPF program will be attached in the bpfman-agent container.
                                 properties:
                                   containerNames:
                                     description: |-
-                                      containerNames indicate the Name(s) of container(s).  If none are specified, all containers in the
-                                      pod are selected.
+                                      containerNames is an optional field and is a list of container names in a
+                                      pod to attach the eBPF program. If no names are  specified, all containers
+                                      in the pod are selected.
                                     items:
                                       type: string
                                     type: array
                                   namespace:
-                                    description: namespaces indicate the target namespaces.
+                                    description: |-
+                                      namespace is an optional field and indicates the target Kubernetes
+                                      namespace. If not provided, the default Kubernetes namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      pods indicate the target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -866,26 +1254,34 @@ spec:
                                 - pods
                                 type: object
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is an optional field and specifies the name of a user-space function
+                                  to attach the UProbe or URetProbe program. If not provided, the eBPF program
+                                  will be triggered on the entry of the target. function must not be an empty
+                                  string, must not exceed 64 characters in length, must start with alpha
+                                  characters and must only contain alphanumeric characters.
                                 maxLength: 64
                                 minLength: 1
                                 pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is an optional field and the value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is an optional field and if provided, limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               target:
-                                description: target is the Library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is a required field and is the user-space library name or the
+                                  absolute path to a binary or library.
                                 type: string
                             required:
                             - target
@@ -893,38 +1289,68 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: |-
+                        xdp is an optional field, but required when the type field is set to XDP.
+                        xdp defines the desired state of the application's XDP programs. XDP program
+                        can be attached to network devices (interfaces) and will be called on every
+                        incoming packet received by the network device. The XDP attachment point is
+                        just after the packet has been received off the wire, but before the Linux
+                        kernel has allocated an sk_buff, which is used to pass the packet through
+                        the kernel networking stack.
                       properties:
                         links:
                           description: |-
-                            links is the list of points to which the program should be attached.  The list items
-                            are optional and may be updated after the bpf program has been loaded
+                            links is an optional field and is the list of attachment points to which the
+                            XDP program should be attached. The XDP program is loaded in kernel memory
+                            when the BPF Application CRD is created and the selected Kubernetes nodes
+                            are active. The XDP program will not be triggered until the program has also
+                            been attached to an attachment point described in this list. Items may be
+                            added or removed from the list at any point, causing the XDP program to be
+                            attached or detached.
+
+
+                            The attachment point for an XDP program is a network interface (or device).
+                            The interface can be specified by name, or by setting the
+                            primaryNodeInterface flag, which instructs bpfman to use the primary
+                            interface of a Kubernetes node. Optionally, the XDP program can also be
+                            installed into a set of network namespaces.
                           items:
                             properties:
                               interfaceSelector:
-                                description: interfaceSelector to determine the network
-                                  interface (or interfaces)
+                                description: |-
+                                  interfaceSelector is a required field and is used to determine the network
+                                  interface (or interfaces) the XDP program is attached. Interface list is set
+                                  by providing a list of interface names, enabling auto discovery, or setting
+                                  the primaryNodeInterface flag, but only one option is allowed.
                                 maxProperties: 1
                                 minProperties: 1
                                 properties:
                                   interfaces:
                                     description: |-
-                                      interfaces refers to a list of network interfaces to attach the BPF
-                                      program to.
+                                      interfaces is an optional field and is a list of network interface names to
+                                      attach the eBPF program. The interface names in the list are case-sensitive.
                                     items:
                                       type: string
                                     type: array
                                   interfacesDiscoveryConfig:
-                                    description: discoveryConfig allow configuring
-                                      interface discovery functionality,
+                                    description: |-
+                                      interfacesDiscoveryConfig is an optional field that is used to control if
+                                      and how to automatically discover interfaces. If the agent should
+                                      automatically discover and attach eBPF programs to interfaces, use the
+                                      fields under interfacesDiscoveryConfig to control what is allow and excluded
+                                      from discovery.
                                     properties:
                                       allowedInterfaces:
                                         description: |-
-                                          allowedInterfaces contains the interface names. If empty, the agent
-                                          fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
-                                          An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
-                                          Otherwise, it is matched as a case-sensitive string.
+                                          allowedInterfaces is an optional field that contains a list of interface
+                                          names that are allowed to be discovered. If empty, the agent will fetch all
+                                          the interfaces in the system, excepting the ones listed in
+                                          excludeInterfaces. if non-empty, only entries in the list will be considered
+                                          for discovery. If an entry enclosed by slashes, such as `/br-/` or
+                                          `/veth*/`, then the entry is considered as a regular expression for
+                                          matching. Otherwise, the interface names in the list are case-sensitive.
+                                          This field is only taken into consideration if interfaceAutoDiscovery is set
+                                          to true.
                                         items:
                                           type: string
                                         type: array
@@ -932,37 +1358,46 @@ spec:
                                         default:
                                         - lo
                                         description: |-
-                                          excludeInterfaces contains the interface names that are excluded from interface discovery
-                                          it is matched as a case-sensitive string.
+                                          excludeInterfaces is an optional field that contains a list of interface
+                                          names that are excluded from interface discovery. The interface names in
+                                          the list are case-sensitive. By default, the list contains the loopback
+                                          interface, "lo". This field is only taken into consideration if
+                                          interfaceAutoDiscovery is set to true.
                                         items:
                                           type: string
                                         type: array
                                       interfaceAutoDiscovery:
                                         default: false
                                         description: |-
-                                          interfaceAutoDiscovery when enabled, the agent process monitors the creation and deletion of interfaces,
-                                          automatically attaching eBPF hooks to newly discovered interfaces in both directions.
+                                          interfaceAutoDiscovery is an optional field. When enabled, the agent
+                                          monitors the creation and deletion of interfaces and automatically attached
+                                          eBPF programs to the newly discovered interfaces in both directions.
+                                          CAUTION: This has the potential to attach a given eBPF program to a large
+                                          number of interfaces. Use with caution.
                                         type: boolean
                                     type: object
                                   primaryNodeInterface:
-                                    description: primaryNodeInterface to attach BPF
-                                      program to the primary interface on the node.
-                                      Only 'true' accepted.
+                                    description: |-
+                                      primaryNodeInterface is and optional field and indicates to attach the eBPF
+                                      program to the primary interface on the Kubernetes node. Only 'true' is
+                                      accepted.
                                     type: boolean
                                 type: object
                               networkNamespaces:
                                 description: |-
                                   networkNamespaces identifies the set of network namespaces in which to
-                                  attach the eBPF program. If networkNamespaces is not specified, the BPF
+                                  attach the eBPF program. If networkNamespaces is not specified, the eBPF
                                   program will be attached in the root network namespace.
                                 properties:
                                   namespace:
-                                    description: Target namespace.
+                                    description: |-
+                                      namespace is an optional field and indicates the target network namespace.
+                                      If not provided, the default network namespace is used.
                                     type: string
                                   pods:
                                     description: |-
-                                      Target pods. This field must be specified, to select all pods use
-                                      standard metav1.LabelSelector semantics and make it empty.
+                                      pods is a required field and indicates the target pods. To select all pods
+                                      use the standard metav1.LabelSelector semantics and make it empty.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
@@ -1012,10 +1447,14 @@ spec:
                                 - pods
                                 type: object
                               priority:
+                                default: 1000
                                 description: |-
-                                  priority specifies the priority of the bpf program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is an optional field and determines the execution order of the XDP
+                                  program relative to other XDP programs attached to the same attachment
+                                  point. It must be a value between 0 and 1000, where lower values indicate
+                                  higher precedence. For XDP programs on the same attachment point with the
+                                  same priority, the most recently attached program has a lower precedence. If
+                                  not provided, priority will default to 1000.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -1025,8 +1464,17 @@ spec:
                                 - Pass
                                 - DispatcherReturn
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is an optional field and allows the user to call other XDP
+                                  programs in a chain, or not call the next program in a chain based on the
+                                  exit code of an XDP program. Allowed values, which are the possible exit
+                                  codes from an XDP eBPF program, are:
+                                    Aborted, Drop, Pass, TX, ReDirect, DispatcherReturn
+
+
+                                  Multiple values are supported. Default is Pass and DispatcherReturn. So
+                                  using the default values, if an XDP program returns Pass, the next XDP
+                                  program in the chain will be called. If an XDP program returns Drop, the
+                                  next XDP program in the chain will NOT be called.
                                 items:
                                   enum:
                                   - Aborted
@@ -1092,16 +1540,17 @@ spec:
             required:
             - byteCode
             - nodeSelector
+            - programs
             type: object
           status:
-            description: BpfAppStatus reflects the status of a BpfApplication or BpfApplicationState
-              object
+            description: |-
+              status reflects the status of a BPF Application and indicates if all the
+              eBPF programs for a given instance loaded successfully or not.
             properties:
               conditions:
                 description: |-
-                  For a BpfApplication object, Conditions contains the global cluster state
-                  for the object. For a BpfApplicationState object, Conditions contains the
-                  state of the BpfApplication object on the given node.
+                  conditions contains the summary state for all eBPF programs defined in the
+                  BPF Application instance for all the Kubernetes nodes in the cluster.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for

--- a/config/crd/bases/bpfman.io_clusterbpfapplicationstates.yaml
+++ b/config/crd/bases/bpfman.io_clusterbpfapplicationstates.yaml
@@ -27,7 +27,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterBpfApplicationState contains the per-node state of a BpfApplication.
+        description: |-
+          ClusterBpfApplicationState contains the state of a ClusterBpfApplication
+          instance for a given Kubernetes node. When a user creates a
+          ClusterBpfApplication instance, bpfman creates a ClusterBpfApplicationState
+          instance for each node in a Kubernetes cluster.
         properties:
           apiVersion:
             description: |-
@@ -47,18 +51,49 @@ spec:
           metadata:
             type: object
           status:
-            description: ClBpfApplicationStateStatus reflects the status of the ClusterBpfApplicationState
-              on the given node
+            description: |-
+              status reflects the status of a ClusterBpfApplication instance for the given
+              node. appLoadStatus and conditions provide an overall status for the given
+              node, while each item in the programs list provides a per eBPF program
+              status for the given node.
             properties:
               appLoadStatus:
                 description: |-
-                  appLoadStatus reflects the status of loading the bpf application on the
-                  given node.
+                  appLoadStatus reflects the status of loading the eBPF application on the
+                  given node. Whether or not the eBPF program is attached to an attachment
+                  point is tracked by the linkStatus field, which is under of each link of
+                  each program.
+
+
+                  NotLoaded is a temporary state that is assigned when a
+                  ClusterBpfApplicationState is created and the initial reconcile is being
+                  processed.
+
+
+                  LoadSuccess is returned if all the programs have been loaded with no errors.
+
+
+                  LoadError is returned if one or more programs encountered an error and were
+                  not loaded.
+
+
+                  NotSelected is returned if this application did not select to run on this
+                  Kubernetes node.
+
+
+                  UnloadSuccess is returned when all the programs were successfully unloaded.
+
+
+                  UnloadError is returned if one or more programs encountered an error when
+                  being unloaded.
                 type: string
               conditions:
                 description: |-
-                  Conditions contains the overall status of the ClusterBpfApplicationState
-                  object on the given node.
+                  conditions contains the summary state of the ClusterBpfApplication for the
+                  given Kubernetes node. If one or more programs failed to load or attach to
+                  the designated attachment point, the condition will report the error. If
+                  more than one error has occurred, condition will contain the first error
+                  encountered.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource.\n---\nThis struct is intended for
@@ -131,27 +166,37 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               node:
-                description: node is the name of the node for this BpfApplicationStateSpec.
+                description: node is the name of the Kubernetes node for this ClusterBpfApplicationState.
                 type: string
               programs:
-                description: programs is a list of bpf programs contained in the parent
-                  application.
+                description: |-
+                  programs is a list of eBPF programs contained in the parent
+                  ClusterBpfApplication instance. Each entry in the list contains the derived
+                  program attributes as well as the attach status for each program on the
+                  given Kubernetes node.
                 items:
-                  description: ClBpfApplicationProgramState defines the desired state
-                    of BpfApplication
                   properties:
                     fentry:
-                      description: fentry defines the desired state of the application's
-                        FentryPrograms.
+                      description: |-
+                        fentry contains the attachment data for an FEntry program when type is set
+                        to FEntry.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fentry program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FEntry program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
+                          description: |-
+                            links is a list of attachment points for the FEntry program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               linkId:
@@ -185,17 +230,26 @@ spec:
                       - function
                       type: object
                     fexit:
-                      description: fexit defines the desired state of the application's
-                        FexitPrograms.
+                      description: |-
+                        fexit contains the attachment data for an FExit program when type is set to
+                        FExit.
                       properties:
                         function:
-                          description: function is the name of the function to attach
-                            the Fexit program to.
+                          description: |-
+                            function is a required field and specifies the name of the Linux kernel
+                            function to attach the FExit program. function must not be an empty string,
+                            must not exceed 64 characters in length, must start with alpha characters
+                            and must only contain alphanumeric characters.
                           maxLength: 64
                           minLength: 1
                           pattern: ^[a-zA-Z][a-zA-Z0-9_]+.
                           type: string
                         links:
+                          description: |-
+                            links is a list of attachment points for the FExit program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               linkId:
@@ -229,20 +283,22 @@ spec:
                       - function
                       type: object
                     kprobe:
-                      description: kprobe defines the desired state of the application's
-                        KprobePrograms.
+                      description: |-
+                        kprobe contains the attachment data for a KProbe program when type is set to
+                        KProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the KProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               function:
-                                description: Function to attach the kprobe to.
+                                description: |-
+                                  function is the provisioned name of the Linux kernel function the KProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -257,8 +313,10 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               offset:
-                                description: Offset added to the address of the function
-                                  for kprobe.
+                                default: 0
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               shouldAttach:
@@ -272,27 +330,28 @@ spec:
                             required:
                             - function
                             - linkStatus
-                            - offset
                             - shouldAttach
                             - uuid
                             type: object
                           type: array
                       type: object
                     kretprobe:
-                      description: kretprobe defines the desired state of the application's
-                        KprobePrograms.
+                      description: |-
+                        kretprobe contains the attachment data for a KRetProbe program when type is
+                        set to KRetProbe.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the KRetProbe program. Each entry
+                            in the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               function:
-                                description: Function to attach the kprobe to.
+                                description: |-
+                                  function is the provisioned name of the Linux kernel function the KRetProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -324,7 +383,7 @@ spec:
                       type: object
                     name:
                       description: |-
-                        name is the name of the function that is the entry point for the BPF
+                        name is the name of the function that is the entry point for the eBPF
                         program
                       type: string
                     programId:
@@ -339,29 +398,29 @@ spec:
                         are in the correct state.
                       type: string
                     tc:
-                      description: tc defines the desired state of the application's
-                        TcPrograms.
+                      description: tc contains the attachment data for a TC program
+                        when type is set to TC.
                       properties:
                         links:
                           description: |-
-                            links is the List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attached point required by the
-                            reconciler
+                            links is a list of attachment points for the TC program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tc program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the TC
+                                  program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TC program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -376,22 +435,24 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               netnsPath:
-                                description: Optional network namespace to attach
-                                  the tc program in.
+                                description: |-
+                                  netnsPath is the optional path to the network namespace inside of which the
+                                  TC program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tc program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TC program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other tc programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - UnSpec
@@ -427,29 +488,29 @@ spec:
                           type: array
                       type: object
                     tcx:
-                      description: tcx defines the desired state of the application's
-                        TcxPrograms.
+                      description: tcx contains the attachment data for a TCX program
+                        when type is set to TCX.
                       properties:
                         links:
                           description: |-
-                            List of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the TCX program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               direction:
                                 description: |-
-                                  direction specifies the direction of traffic the tcx program should
-                                  attach to for a given network device.
+                                  direction is the provisioned direction of traffic, Ingress or Egress, the TC
+                                  program should be attached for a given network device.
                                 enum:
                                 - Ingress
                                 - Egress
                                 type: string
                               interfaceName:
-                                description: interfaceName is the Interface name to
-                                  attach the tc program to.
+                                description: |-
+                                  interfaceName is the name of the interface the TCX program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -464,14 +525,15 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               netnsPath:
-                                description: netnsPath is the network namespace to
-                                  attach the tcx program in.
+                                description: |-
+                                  netnsPath is the optional path to the network namespace inside of which the
+                                  TCX program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the tcx program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the TCX program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
@@ -495,16 +557,16 @@ spec:
                           type: array
                       type: object
                     tracepoint:
-                      description: tracepoint defines the desired state of the application's
-                        TracepointPrograms.
+                      description: |-
+                        tracepoint contains the attachment data for a Tracepoint program when type
+                        is set to Tracepoint.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the Tracepoint program. Each entry
+                            in the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               linkId:
@@ -520,8 +582,10 @@ spec:
                                   successfully, and if not, why.
                                 type: string
                               name:
-                                description: The name of a kernel tracepoint to attach
-                                  the bpf program to.
+                                description: |-
+                                  The name of a kernel tracepoint to attach the bpf program to.
+                                  name is the provisioned name of the Linux kernel tracepoint function the
+                                  Tracepoint program should be attached.
                                 type: string
                               shouldAttach:
                                 description: shouldAttach reflects whether the attachment
@@ -540,39 +604,87 @@ spec:
                           type: array
                       type: object
                     type:
-                      description: type specifies the bpf program type
+                      description: |-
+                        type specifies the provisioned eBPF program type for this program entry.
+                        Type will be one of:
+                          FEntry, FExit, KProbe, KRetProbe, TC, TCX, Tracepoint, UProbe,
+                          URetProbe, XDP
+
+
+                        When set to FEntry, the fentry object will be populated with the eBPF
+                        program data associated with an FEntry program.
+
+
+                        When set to FExit, the fexit object will be populated with the eBPF program
+                        data associated with an FExit program.
+
+
+                        When set to KProbe, the kprobe object will be populated with the eBPF
+                        program data associated with a KProbe program.
+
+
+                        When set to KRetProbe, the kretprobe object will be populated with the
+                        eBPF program data associated with a KRetProbe program.
+
+
+                        When set to TC, the tc object will be populated with the eBPF program data
+                        associated with a TC program.
+
+
+                        When set to TCX, the tcx object will be populated with the eBPF program
+                        data associated with a TCX program.
+
+
+                        When set to Tracepoint, the tracepoint object will be populated with the
+                        eBPF program data associated with a Tracepoint program.
+
+
+                        When set to UProbe, the uprobe object will be populated with the eBPF
+                        program data associated with a UProbe program.
+
+
+                        When set to URetProbe, the uretprobe object will be populated with the eBPF
+                        program data associated with a URetProbe program.
+
+
+                        When set to XDP, the xdp object will be populated with the eBPF program data
+                        associated with a URetProbe program.
                       enum:
-                      - XDP
-                      - TC
-                      - TCX
                       - FEntry
                       - FExit
                       - KProbe
                       - KRetProbe
+                      - TC
+                      - TCX
+                      - TracePoint
                       - UProbe
                       - URetProbe
-                      - TracePoint
+                      - XDP
                       type: string
                     uprobe:
-                      description: uprobe defines the desired state of the application's
-                        UprobePrograms.
+                      description: |-
+                        uprobe contains the attachment data for a UProbe program when type is set to
+                        UProbe.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: Optional container pid to attach the
-                                  uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the ClusterBpfApplication instance,
+                                  containerPid is the derived PID of the container the UProbe or URetProbe this
+                                  attachment point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -588,14 +700,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -603,8 +717,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -619,25 +734,29 @@ spec:
                           type: array
                       type: object
                     uretprobe:
-                      description: uretprobe defines the desired state of the application's
-                        UretprobePrograms.
+                      description: |-
+                        uretprobe contains the attachment data for a URetProbe program when type is
+                        set to URetProbe.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the UProbe program. Each entry in
+                            the list includes a linkStatus, which indicates if the attachment was
+                            successful or not on this node, a linkId, which is the kernel ID for the
+                            link if successfully attached, and other attachment specific data.
                           items:
                             properties:
                               containerPid:
-                                description: Optional container pid to attach the
-                                  uprobe program in.
+                                description: |-
+                                  If containers is provisioned in the ClusterBpfApplication instance,
+                                  containerPid is the derived PID of the container the UProbe or URetProbe this
+                                  attachment point is attached.
                                 format: int32
                                 type: integer
                               function:
-                                description: function to attach the uprobe to.
+                                description: |-
+                                  function is the provisioned name of the user-space function the UProbe
+                                  program should be attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -653,14 +772,16 @@ spec:
                                 type: string
                               offset:
                                 default: 0
-                                description: offset added to the address of the function
-                                  for uprobe.
+                                description: |-
+                                  offset is the provisioned offset, whose value is added to the address of the
+                                  attachment point function.
                                 format: int64
                                 type: integer
                               pid:
                                 description: |-
-                                  pid only execute uprobe for given process identification number (PID). If PID
-                                  is not provided, uprobe executes for all PIDs.
+                                  pid is the provisioned pid. If set, pid limits the execution of the UProbe
+                                  or URetProbe to the provided process identification number (PID). If pid is
+                                  not provided, the UProbe or URetProbe executes for all PIDs.
                                 format: int32
                                 type: integer
                               shouldAttach:
@@ -668,8 +789,9 @@ spec:
                                   should exist.
                                 type: boolean
                               target:
-                                description: target is the library name or the absolute
-                                  path to a binary or library.
+                                description: |-
+                                  target is the provisioned user-space library name or the absolute path to a
+                                  binary or library.
                                 type: string
                               uuid:
                                 description: uuid is an Unique identifier for the
@@ -684,21 +806,21 @@ spec:
                           type: array
                       type: object
                     xdp:
-                      description: xdp defines the desired state of the application's
-                        XdpPrograms.
+                      description: xdp contains the attachment data for an XDP program
+                        when type is set to XDP.
                       properties:
                         links:
                           description: |-
-                            links is the list of attach points for the BPF program on the given node. Each entry
-                            in *AttachInfoState represents a specific, unique attach point that is
-                            derived from *AttachInfo by fully expanding any selectors.  Each entry
-                            also contains information about the attach point required by the
-                            reconciler
+                            links is a list of attachment points for the XDP program. Each entry in the
+                            list includes a linkStatus, which indicates if the attachment was successful
+                            or not on this node, a linkId, which is the kernel ID for the link if
+                            successfully attached, and other attachment specific data.
                           items:
                             properties:
                               interfaceName:
-                                description: interfaceName is the interface name to
-                                  attach the xdp program to.
+                                description: |-
+                                  interfaceName is the name of the interface the XDP program should be
+                                  attached.
                                 type: string
                               linkId:
                                 description: |-
@@ -714,22 +836,23 @@ spec:
                                 type: string
                               netnsPath:
                                 description: |-
-                                  netnsPath is an optional path for a network namespace to attach the xdp
-                                  program in.
+                                  netnsPath is the optional path to the network namespace inside of which the
+                                  XDP program should be attached.
                                 type: string
                               priority:
                                 description: |-
-                                  priority specifies the priority of the xdp program in relation to
-                                  other programs of the same type with the same attach point. It is a value
-                                  from 0 to 1000 where lower values have higher precedence.
+                                  priority is the provisioned priority of the XDP program in relation to other
+                                  programs of the same type with the same attach point. It is a value from 0
+                                  to 1000, where lower values have higher precedence.
                                 format: int32
                                 maximum: 1000
                                 minimum: 0
                                 type: integer
                               proceedOn:
                                 description: |-
-                                  proceedOn allows the user to call other xdp programs in chain on this exit code.
-                                  Multiple values are supported by repeating the parameter.
+                                  proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+                                  user to call other TC programs in a chain, or not call the next program in a
+                                  chain based on the exit code of a TC program .Multiple values are supported.
                                 items:
                                   enum:
                                   - Aborted
@@ -807,10 +930,10 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the BpfApplicationState has been updated. Set to 1
-                  when the object is created, then it is incremented prior to each update.
-                  This allows us to verify that the API server has the updated object prior
-                  to starting a new Reconcile operation.
+                  updateCount is the number of times the ClusterBpfApplicationState has been
+                  updated. Set to 1 when the object is created, then it is incremented prior
+                  to each update. This is used to verify that the API server has the updated
+                  object prior to starting a new Reconcile operation.
                 format: int64
                 type: integer
             required:

--- a/config/crd/bases/bpfman.io_clusterbpfapplicationstates.yaml
+++ b/config/crd/bases/bpfman.io_clusterbpfapplicationstates.yaml
@@ -60,9 +60,7 @@ spec:
               appLoadStatus:
                 description: |-
                   appLoadStatus reflects the status of loading the eBPF application on the
-                  given node. Whether or not the eBPF program is attached to an attachment
-                  point is tracked by the linkStatus field, which is under of each link of
-                  each program.
+                  given node.
 
 
                   NotLoaded is a temporary state that is assigned when a
@@ -930,10 +928,12 @@ spec:
                 type: array
               updateCount:
                 description: |-
-                  updateCount is the number of times the ClusterBpfApplicationState has been
-                  updated. Set to 1 when the object is created, then it is incremented prior
-                  to each update. This is used to verify that the API server has the updated
-                  object prior to starting a new Reconcile operation.
+                  UpdateCount tracks the number of times the BpfApplicationState object has
+                  been updated. The bpfman agent initializes it to 1 when it creates the
+                  object, and then increments it before each subsequent update. It serves
+                  as a lightweight sequence number to verify that the API server is serving
+                  the most recent version of the object before beginning a new Reconcile
+                  operation.
                 format: int64
                 type: integer
             required:

--- a/config/samples/bpfman.io_v1alpha1_bpfapplicationstate.yaml
+++ b/config/samples/bpfman.io_v1alpha1_bpfapplicationstate.yaml
@@ -1,249 +1,242 @@
-apiVersion: v1
-items:
-- apiVersion: bpfman.io/v1alpha1
-  kind: BpfApplicationState
-  metadata:
-    creationTimestamp: "2025-03-31T11:53:29Z"
-    finalizers:
-    - bpfman.io.nsbpfapplicationcontroller/finalizer
-    generation: 1
-    labels:
-      bpfman.io/ownedByProgram: bpfapplication-sample
-      kubernetes.io/hostname: bpfman-deployment-control-plane
-    name: bpfapplication-sample-91e81477
-    namespace: acme
-    ownerReferences:
-    - apiVersion: bpfman.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: BpfApplication
-      name: bpfapplication-sample
-      uid: 993bee6d-9129-4de7-9de2-11fe00c6297d
-    resourceVersion: "93093"
-    uid: 73992afc-4e20-486a-bd64-9562ed1f6a34
-  spec: {}
-  status:
-    appLoadStatus: LoadSuccess
-    appStatus:
-      conditions:
-      - lastTransitionTime: "2025-03-31T11:54:03Z"
-        message: The BPF application has been successfully loaded and attached
-        reason: Success
-        status: "True"
-        type: Success
-    node: bpfman-deployment-control-plane
-    programs:
-    - name: tc_pass_test
-      programId: 13049
-      programLinkStatus: Success
-      tc:
-        links:
-        - direction: Ingress
-          interfaceName: eth0
-          linkId: 9075174
-          linkStatus: Attached
-          netnsPath: /host/proc/11334/ns/net
-          priority: 55
-          proceedOn:
-          - Pipe
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: 623614c2-8ac6-4907-b4c3-7eb19556c697
-        - direction: Ingress
-          interfaceName: eth0
-          linkId: 470449002
-          linkStatus: Attached
-          netnsPath: /host/proc/11297/ns/net
-          priority: 55
-          proceedOn:
-          - Pipe
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: 8b7792a1-267d-49eb-a9fe-9529e1d10704
-        - direction: Ingress
-          interfaceName: eth0
-          linkId: 2104185296
-          linkStatus: Attached
-          netnsPath: /host/proc/12511/ns/net
-          priority: 55
-          proceedOn:
-          - Pipe
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: 2ab314a4-d51a-428d-9205-d9a376cd4f35
-        - direction: Ingress
-          interfaceName: eth0
-          linkId: 3879948226
-          linkStatus: Attached
-          netnsPath: /host/proc/12502/ns/net
-          priority: 55
-          proceedOn:
-          - Pipe
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: a687c020-8692-4ade-8321-b680cd83960e
-      type: TC
-    - name: tcx_next_test
-      programId: 13050
-      programLinkStatus: Success
-      tcx:
-        links:
-        - direction: Egress
-          interfaceName: eth0
-          linkId: 356767155
-          linkStatus: Attached
-          netnsPath: /host/proc/11334/ns/net
-          priority: 100
-          shouldAttach: true
-          uuid: 2964d2f8-df64-4c5a-94e1-09597f60ed3e
-        - direction: Egress
-          interfaceName: eth0
-          linkId: 3971612108
-          linkStatus: Attached
-          netnsPath: /host/proc/11297/ns/net
-          priority: 100
-          shouldAttach: true
-          uuid: 5e1a3762-ee04-4f39-91bd-6fcc1e8b9d13
-        - direction: Egress
-          interfaceName: eth0
-          linkId: 3278813340
-          linkStatus: Attached
-          netnsPath: /host/proc/12511/ns/net
-          priority: 100
-          shouldAttach: true
-          uuid: 53bc603a-fcc1-45ac-aef0-fca770a0e268
-        - direction: Egress
-          interfaceName: eth0
-          linkId: 2268269530
-          linkStatus: Attached
-          netnsPath: /host/proc/12502/ns/net
-          priority: 100
-          shouldAttach: true
-          uuid: 94910ca2-f6a2-458c-b868-5acf0796d60f
-      type: TCX
-    - name: uprobe_test
-      programId: 13051
-      programLinkStatus: Success
-      type: UProbe
-      uprobe:
-        links:
-        - containerPid: 11334
-          function: malloc
-          linkId: 3327245542
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: 89870861-20a6-4c6c-a42f-f0e4aaa2d27b
-        - containerPid: 11297
-          function: malloc
-          linkId: 3161457287
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: 2fc05309-1c96-4da4-b31a-f72a074e825b
-        - containerPid: 12511
-          function: malloc
-          linkId: 3840558596
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: 11a56460-6753-487e-9485-444e13fa34e2
-        - containerPid: 12502
-          function: malloc
-          linkId: 2650626549
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: 168264ab-c59c-4f42-8903-8e0c50734f01
-    - name: uretprobe_test
-      programId: 13052
-      programLinkStatus: Success
-      type: URetProbe
-      uretprobe:
-        links:
-        - containerPid: 11334
-          function: malloc
-          linkId: 875680773
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: ff4638d3-4149-467c-a192-763f58cece20
-        - containerPid: 11297
-          function: malloc
-          linkId: 1673370364
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: 2ed62e97-79c5-40a5-b6e0-e0e6f764e5cb
-        - containerPid: 12511
-          function: malloc
-          linkId: 1577310058
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: 10875abe-a1ef-4b8b-a10b-9fa724be8f5b
-        - containerPid: 12502
-          function: malloc
-          linkId: 869427060
-          linkStatus: Attached
-          offset: 0
-          shouldAttach: true
-          target: libc
-          uuid: cdc3632c-b2e7-466e-8a47-dea0a3d15bd9
-    - name: xdp_pass_test
-      programId: 13054
-      programLinkStatus: Success
-      type: XDP
-      xdp:
-        links:
-        - interfaceName: eth0
-          linkId: 1076298761
-          linkStatus: Attached
-          netnsPath: /host/proc/11334/ns/net
-          priority: 100
-          proceedOn:
-          - Pass
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: 424cd0ee-1af3-41cb-9da1-447f7feedef1
-        - interfaceName: eth0
-          linkId: 44043353
-          linkStatus: Attached
-          netnsPath: /host/proc/11297/ns/net
-          priority: 100
-          proceedOn:
-          - Pass
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: fc14fba2-8ace-4187-95a3-867648b22291
-        - interfaceName: eth0
-          linkId: 2949403124
-          linkStatus: Attached
-          netnsPath: /host/proc/12511/ns/net
-          priority: 100
-          proceedOn:
-          - Pass
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: 0f2d1d93-ea2b-47ca-a877-230415392727
-        - interfaceName: eth0
-          linkId: 2792719200
-          linkStatus: Attached
-          netnsPath: /host/proc/12502/ns/net
-          priority: 100
-          proceedOn:
-          - Pass
-          - DispatcherReturn
-          shouldAttach: true
-          uuid: 191018f1-a4eb-48cc-9fc0-77d123a00537
-    updateCount: 3
-kind: List
+apiVersion: bpfman.io/v1alpha1
+kind: BpfApplicationState
 metadata:
-  resourceVersion: ""
+  creationTimestamp: "2025-04-30T20:59:17Z"
+  finalizers:
+  - bpfman.io.nsbpfapplicationcontroller/finalizer
+  generation: 1
+  labels:
+    bpfman.io/ownedByProgram: bpfapplication-sample
+    kubernetes.io/hostname: bpfman-deployment-control-plane
+  name: bpfapplication-sample-ed7beed4
+  namespace: acme
+  ownerReferences:
+  - apiVersion: bpfman.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: BpfApplication
+    name: bpfapplication-sample
+    uid: a3897014-2014-4585-90a1-ccdb70adeef9
+  resourceVersion: "1348"
+  uid: 5728d3b2-a576-4144-be74-e5c83619344e
+status:
+  appLoadStatus: LoadSuccess
+  conditions:
+  - lastTransitionTime: "2025-04-30T21:01:50Z"
+    message: The BPF application has been successfully loaded and attached
+    reason: Success
+    status: "True"
+    type: Success
+  node: bpfman-deployment-control-plane
+  programs:
+  - name: tc_pass_test
+    programId: 1398
+    programLinkStatus: Success
+    tc:
+      links:
+      - direction: Ingress
+        interfaceName: eth0
+        linkId: 1909324080
+        linkStatus: Attached
+        netnsPath: /host/proc/3041/ns/net
+        priority: 55
+        proceedOn:
+        - Pipe
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: 38e00746-b7be-4bcf-bf14-622ad349b4fa
+      - direction: Ingress
+        interfaceName: eth0
+        linkId: 1342701196
+        linkStatus: Attached
+        netnsPath: /host/proc/3032/ns/net
+        priority: 55
+        proceedOn:
+        - Pipe
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: ba806cdf-5980-4e7f-8d8f-d819e6a57220
+      - direction: Ingress
+        interfaceName: eth0
+        linkId: 2698014225
+        linkStatus: Attached
+        netnsPath: /host/proc/2792/ns/net
+        priority: 55
+        proceedOn:
+        - Pipe
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: e74fa413-d5df-4aa8-8d17-b580b6cb42a5
+      - direction: Ingress
+        interfaceName: eth0
+        linkId: 184300305
+        linkStatus: Attached
+        netnsPath: /host/proc/2833/ns/net
+        priority: 55
+        proceedOn:
+        - Pipe
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: cef8985d-f184-4b18-9ee2-fe21018fae77
+    type: TC
+  - name: tcx_next_test
+    programId: 1399
+    programLinkStatus: Success
+    tcx:
+      links:
+      - direction: Egress
+        interfaceName: eth0
+        linkId: 1256673356
+        linkStatus: Attached
+        netnsPath: /host/proc/3041/ns/net
+        priority: 100
+        shouldAttach: true
+        uuid: 3feed40b-fe4b-4a69-8e91-49624df45673
+      - direction: Egress
+        interfaceName: eth0
+        linkId: 18009714
+        linkStatus: Attached
+        netnsPath: /host/proc/3032/ns/net
+        priority: 100
+        shouldAttach: true
+        uuid: 37b02539-0884-418d-bee4-31456384495e
+      - direction: Egress
+        interfaceName: eth0
+        linkId: 3446068106
+        linkStatus: Attached
+        netnsPath: /host/proc/2792/ns/net
+        priority: 100
+        shouldAttach: true
+        uuid: 24a56373-8967-46f4-bbd4-423a7872f18b
+      - direction: Egress
+        interfaceName: eth0
+        linkId: 733646956
+        linkStatus: Attached
+        netnsPath: /host/proc/2833/ns/net
+        priority: 100
+        shouldAttach: true
+        uuid: 4c855178-0a35-4ac6-abf7-83e61541aca4
+    type: TCX
+  - name: uprobe_test
+    programId: 1400
+    programLinkStatus: Success
+    type: UProbe
+    uprobe:
+      links:
+      - containerPid: 3041
+        function: malloc
+        linkId: 3629930733
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: ed72f8a7-cdc9-4245-8c40-c645fa5969d7
+      - containerPid: 3032
+        function: malloc
+        linkId: 1860984127
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: 5c3b196d-bbe9-4b2c-8c5c-9d78c5ed6512
+      - containerPid: 2792
+        function: malloc
+        linkId: 3256920823
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: 927071d2-c574-4c1f-87f2-baa5e7cfcc8f
+      - containerPid: 2833
+        function: malloc
+        linkId: 3700254381
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: fd351a1a-fb83-4b6c-af2f-c84906c6b54b
+  - name: uretprobe_test
+    programId: 1401
+    programLinkStatus: Success
+    type: URetProbe
+    uretprobe:
+      links:
+      - containerPid: 3041
+        function: malloc
+        linkId: 4161687115
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: 2c8ad027-eca0-4da9-baa6-f7b6f0fc25fd
+      - containerPid: 3032
+        function: malloc
+        linkId: 3445215503
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: 623f2642-9f85-45ca-bab4-8f98d8a31079
+      - containerPid: 2792
+        function: malloc
+        linkId: 1387817990
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: fe81f29b-493d-41a9-b1c7-35733c9ee861
+      - containerPid: 2833
+        function: malloc
+        linkId: 2271422622
+        linkStatus: Attached
+        offset: 0
+        shouldAttach: true
+        target: libc
+        uuid: d6af1106-2c72-4f7d-9ee9-5c32e59e03b7
+  - name: xdp_pass_test
+    programId: 1402
+    programLinkStatus: Success
+    type: XDP
+    xdp:
+      links:
+      - interfaceName: eth0
+        linkId: 1752219747
+        linkStatus: Attached
+        netnsPath: /host/proc/3041/ns/net
+        priority: 100
+        proceedOn:
+        - Pass
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: 17760ccc-5ca7-4d21-9590-5f6e5c0fd4ab
+      - interfaceName: eth0
+        linkId: 3877814802
+        linkStatus: Attached
+        netnsPath: /host/proc/3032/ns/net
+        priority: 100
+        proceedOn:
+        - Pass
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: 194d2096-a15f-417f-9be6-2032217f3e86
+      - interfaceName: eth0
+        linkId: 2514284800
+        linkStatus: Attached
+        netnsPath: /host/proc/2792/ns/net
+        priority: 100
+        proceedOn:
+        - Pass
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: de0f43b3-6a0e-4c22-8127-9fb519a0238b
+      - interfaceName: eth0
+        linkId: 1682543086
+        linkStatus: Attached
+        netnsPath: /host/proc/2833/ns/net
+        priority: 100
+        proceedOn:
+        - Pass
+        - DispatcherReturn
+        shouldAttach: true
+        uuid: 84289766-bff1-4af5-a0bd-5d150747a29a
+  updateCount: 2

--- a/config/samples/bpfman.io_v1alpha1_clusterbpfapplicationstate.yaml
+++ b/config/samples/bpfman.io_v1alpha1_clusterbpfapplicationstate.yaml
@@ -1,28 +1,27 @@
 apiVersion: bpfman.io/v1alpha1
 kind: ClusterBpfApplicationState
 metadata:
-  creationTimestamp: "2025-03-31T20:38:02Z"
+  creationTimestamp: "2025-04-30T20:58:34Z"
   finalizers:
   - bpfman.io.clbpfapplicationcontroller/finalizer
   generation: 1
   labels:
     bpfman.io/ownedByProgram: clusterbpfapplication-sample
     kubernetes.io/hostname: bpfman-deployment-control-plane
-  name: clusterbpfapplication-sample-6938aab9
+  name: clusterbpfapplication-sample-d3cc4fee
   ownerReferences:
   - apiVersion: bpfman.io/v1alpha1
     blockOwnerDeletion: true
     controller: true
     kind: ClusterBpfApplication
     name: clusterbpfapplication-sample
-    uid: e18c4760-7f89-48bb-ac24-2c01c9f7c7c8
-  resourceVersion: "1483"
-  uid: 7d8eb460-a560-4055-b1fe-5fc66e90736e
-spec: {}
+    uid: ab16b9a6-16bd-4a22-98ec-4268efaf8c8d
+  resourceVersion: "1176"
+  uid: 6e7e7446-306f-46ae-98e6-6ff28d9b5bcd
 status:
   appLoadStatus: LoadSuccess
   conditions:
-  - lastTransitionTime: "2025-03-31T20:38:54Z"
+  - lastTransitionTime: "2025-04-30T21:00:16Z"
     message: The BPF application has been successfully loaded and attached
     reason: Success
     status: "True"
@@ -32,174 +31,174 @@ status:
   - kprobe:
       links:
       - function: try_to_wake_up
-        linkId: 675202769
+        linkId: 818584239
         linkStatus: Attached
         offset: 0
         shouldAttach: true
-        uuid: 4aab6ffe-ec74-4845-ab24-a54def1b555c
+        uuid: 3c71185f-8d68-4be8-92cb-32a14a6f118b
     name: kprobe_test
-    programId: 13394
+    programId: 1323
     programLinkStatus: Success
     type: KProbe
   - kretprobe:
       links:
       - function: try_to_wake_up
-        linkId: 3965865826
+        linkId: 3409359936
         linkStatus: Attached
         shouldAttach: true
-        uuid: 919a7317-4c47-4576-aada-f93131be7686
+        uuid: 44c75019-f175-4b1e-bb34-d8896e3b0456
     name: kretprobe_test
-    programId: 13395
+    programId: 1324
     programLinkStatus: Success
     type: KRetProbe
   - name: tracepoint_test
-    programId: 13396
+    programId: 1325
     programLinkStatus: Success
     tracepoint:
       links:
-      - linkId: 3264842258
+      - linkId: 2625161294
         linkStatus: Attached
         name: syscalls/sys_enter_openat
         shouldAttach: true
-        uuid: 1a2d782c-9c05-4ccb-a5d2-b92589fa5b7d
+        uuid: 40164d8a-5b55-4ff6-8e73-aa53d9180a6d
     type: TracePoint
   - name: tc_pass_test
-    programId: 13398
+    programId: 1327
     programLinkStatus: Success
     tc:
       links:
       - direction: Ingress
         interfaceName: eth0
-        linkId: 2292281068
+        linkId: 1304307969
         linkStatus: Attached
         priority: 55
         proceedOn:
         - Pipe
         - DispatcherReturn
         shouldAttach: true
-        uuid: 4fc3a458-c93b-404f-9227-4c367a560ec4
+        uuid: 44e6491e-ca98-44a0-b1b7-647b494c84fa
       - direction: Egress
         interfaceName: eth0
-        linkId: 3243360575
+        linkId: 1425071644
         linkStatus: Attached
-        netnsPath: /host/proc/2560/ns/net
+        netnsPath: /host/proc/2196/ns/net
         priority: 100
         proceedOn:
         - Pipe
         - DispatcherReturn
         shouldAttach: true
-        uuid: 8b87e1ef-a0e5-4423-abed-68c99b528357
+        uuid: 89a05d8f-bb4a-448a-af11-2605d0094b98
     type: TC
   - name: tcx_next_test
-    programId: 13399
+    programId: 1328
     programLinkStatus: Success
     tcx:
       links:
       - direction: Ingress
         interfaceName: eth0
-        linkId: 1974385552
+        linkId: 858546813
         linkStatus: Attached
         priority: 500
         shouldAttach: true
-        uuid: 18bd4721-21d6-4d44-b229-c2e7d6c215bd
+        uuid: 6dff4163-4d62-4c93-bc34-739a796ddbb4
       - direction: Egress
         interfaceName: eth0
-        linkId: 595062609
+        linkId: 5042726
         linkStatus: Attached
-        netnsPath: /host/proc/2560/ns/net
+        netnsPath: /host/proc/2196/ns/net
         priority: 100
         shouldAttach: true
-        uuid: 6817600b-8681-474c-ba26-c6a3ebfedef7
+        uuid: c066df6a-667e-4382-9e2f-a59f64bc1b7e
     type: TCX
   - name: uprobe_test
-    programId: 13400
+    programId: 1329
     programLinkStatus: Success
     type: UProbe
     uprobe:
       links:
-      - containerPid: 2456
+      - containerPid: 2089
         function: malloc
-        linkId: 1114319296
+        linkId: 2687038538
         linkStatus: Attached
         offset: 0
         shouldAttach: true
         target: libc
-        uuid: d713c6f1-9b57-4f31-a89a-6d87a9d36ddd
-      - containerPid: 2401
+        uuid: e48f1563-f56b-41fa-a87d-b8593fc5faca
+      - containerPid: 2040
         function: malloc
-        linkId: 85632571
+        linkId: 1651822558
         linkStatus: Attached
         offset: 0
         shouldAttach: true
         target: libc
-        uuid: 982c752b-8b09-409a-a494-d30b20cdad9a
+        uuid: e0d778df-4791-413b-b0f4-13ed1088500c
   - name: uretprobe_test
-    programId: 13401
+    programId: 1330
     programLinkStatus: Success
     type: URetProbe
     uretprobe:
       links:
-      - containerPid: 2456
+      - containerPid: 2089
         function: malloc
-        linkId: 1248121244
+        linkId: 3774838420
         linkStatus: Attached
         offset: 0
         shouldAttach: true
         target: libc
-        uuid: 13d299ce-86d0-45e2-b0ca-6563fef68b3f
-      - containerPid: 2401
+        uuid: 2f37f466-6ff4-47a1-9c8d-8dd1f97528bb
+      - containerPid: 2040
         function: malloc
-        linkId: 1307762276
+        linkId: 1373645282
         linkStatus: Attached
         offset: 0
         shouldAttach: true
         target: libc
-        uuid: 86eee9a7-8d03-4c9d-a12d-713ef16bb044
+        uuid: 319bbaf0-1c8a-45b4-9d99-5dec27e2e5f1
   - name: xdp_pass_test
-    programId: 13403
+    programId: 1332
     programLinkStatus: Success
     type: XDP
     xdp:
       links:
       - interfaceName: eth0
-        linkId: 1916079109
+        linkId: 4243141192
         linkStatus: Attached
         priority: 55
         proceedOn:
         - Pass
         - DispatcherReturn
         shouldAttach: true
-        uuid: a568d8ba-36f2-4b9f-9159-faa4dffb4088
+        uuid: c3bea5b9-d3e0-4784-9a17-c286b6661fc2
       - interfaceName: eth0
-        linkId: 4014676018
+        linkId: 1465833891
         linkStatus: Attached
-        netnsPath: /host/proc/2560/ns/net
+        netnsPath: /host/proc/2196/ns/net
         priority: 100
         proceedOn:
         - Pass
         - DispatcherReturn
         shouldAttach: true
-        uuid: 4d998752-ed83-4ec0-a6d5-14d6dc23f116
+        uuid: 1e24df86-f3ff-4e0a-8f20-6759272ddb08
   - fentry:
       function: do_unlinkat
       links:
-      - linkId: 3436717235
+      - linkId: 950386839
         linkStatus: Attached
         shouldAttach: true
-        uuid: 93e04fe2-dc09-48dc-80e5-edbe87d9cfd1
+        uuid: 2eda2367-4540-478b-a40d-cc984475a570
     name: fentry_test
-    programId: 13404
+    programId: 1333
     programLinkStatus: Success
     type: FEntry
   - fexit:
       function: do_unlinkat
       links:
-      - linkId: 1957573058
+      - linkId: 2243237521
         linkStatus: Attached
         shouldAttach: true
-        uuid: feffa69f-e843-4011-b97a-0cc487699f82
+        uuid: 98910fe0-cad6-457f-8797-9f8200106511
     name: fexit_test
-    programId: 13405
+    programId: 1334
     programLinkStatus: Success
     type: FExit
-  updateCount: 3
+  updateCount: 2


### PR DESCRIPTION
As part of the API review, a comment was made to improve the description of all fields. This commit makes a pass at the ClusterBpfApplication, BpfApplication, ClusterBpfApplicationState and BpfApplicationState CRD fields.

The description fields are most easily seen using the `kubectl explain` command. For example:
```
$ kubectl explain clusterbpfapplication
GROUP:      bpfman.io
KIND:       ClusterBpfApplication
VERSION:    v1alpha1

DESCRIPTION:
    ClusterBpfApplication is the schema for the cluster scoped BPF Applications
    API. Using this API allows applications to load one or more eBPF programs on
    a Kubernetes cluster using bpfman to load the programs.
    
    
    The clusterBpfApplication.status field can be used to determine if any
    errors occurred in the loading of the eBPF programs. Because one eBPF
    program can be loaded on multiple Kubernetes nodes, and then attached
    multiple times on each Kubernetes node, clusterBpfApplication.status is just
    a summary, all loaded or something failed. bpfman creates a
    ClusterBpfApplicationState CRD instance for each Kubernetes Node for each
    ClusterBpfApplication instance. The ClusterBpfApplicationState CRD provides
    load status for each eBPF program and each of it's attachment points
    (links).
    
FIELDS:
  apiVersion	<string>
    APIVersion defines the versioned schema of this representation of an object.
    Servers should convert recognized schemas to the latest internal value, and
    may reject unrecognized values. More info:
    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

  kind	<string>
    Kind is a string value representing the REST resource this object
    represents. Servers may infer this from the endpoint the client submits
    requests to. Cannot be updated. In CamelCase. More info:
    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

  metadata	<ObjectMeta>
    Standard object's metadata. More info:
    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

  spec	<Object>
    spec defines the desired state of the ClusterBpfApplication. The
    ClusterBpfApplication describes the set of one or more cluster scoped eBPF
    programs that should be loaded for a given application and attributes for
    how they should be loaded. eBPF programs that are grouped together under the
    same ClusterBpfApplication instance can share maps and global data between
    the eBPF programs loaded on the same Kubernetes Node.

  status	<Object>
    status reflects the status of a BPF Application and indicates if all the
    eBPF programs for a given instance loaded successfully or not.
```

The following gist collects all the `kubectl explain` output:
https://gist.github.com/Billy99/b871e60f04944d4b03c9c0106d2c8a43