### PR TITLE
Check for Duplicate Network Namespace Inodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,6 @@ build-agent-image: ## Build bpfman-agent image.
 push-images: ## Push bpfman-agent and bpfman-operator images.
 	$(OCI_BIN) push ${BPFMAN_OPERATOR_IMG}
 	$(OCI_BIN) push ${BPFMAN_AGENT_IMG}
-	$(OCI_BIN) push ${BPFMAN_IMG}
 
 .PHONY: load-images-kind
 load-images-kind: ## Load bpfman-agent, and bpfman-operator images into the running local kind devel cluster.

--- a/cmd/bpfman-agent/main.go
+++ b/cmd/bpfman-agent/main.go
@@ -224,11 +224,11 @@ func interfaceListener(ctx context.Context, ifaceEvents <-chan ifaces.Event, int
 			iface := event.Interface
 			switch event.Type {
 			case ifaces.EventAdded:
-				setupLog.Info("interface created", "Name", iface.Name, "netns", iface.NetNS)
+				setupLog.Info("interface created", "Name", iface.Name, "netns", iface.NSName, "NsHandle", iface.NetNS)
 				interfaces.Store(iface, true)
 			case ifaces.EventDeleted:
-				setupLog.Info("interface deleted", "Name", iface.Name, "netns", iface.NetNS)
-				interfaces.Store(iface, false)
+				setupLog.Info("interface deleted", "Name", iface.Name, "netns", iface.NSName, "NsHandle", iface.NetNS)
+				interfaces.Delete(iface)
 			default:
 			}
 		}

--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -147,6 +147,9 @@ spec:
               name: host-dockerd
             - mountPath: /etc/crictl.yaml
               name: host-crictl-config
+            - mountPath: /host/proc
+              name: host-proc
+              mountPropagation: HostToContainer
             - mountPath: /var/run/netns
               name: var-run-netns
               mountPropagation: HostToContainer

--- a/controllers/bpfman-agent/cl_application_program.go
+++ b/controllers/bpfman-agent/cl_application_program.go
@@ -125,6 +125,7 @@ func (r *ClBpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.Logger = ctrl.Log.WithName("cluster-app")
 	r.finalizer = internal.ClBpfApplicationControllerFinalizer
 	r.recType = internal.ApplicationString
+	r.NetnsCache = make(map[string]uint64)
 
 	r.Logger.Info("Enter ClusterBpfApplication Reconcile", "Name", req.Name)
 

--- a/controllers/bpfman-agent/cl_application_program.go
+++ b/controllers/bpfman-agent/cl_application_program.go
@@ -126,7 +126,7 @@ func (r *ClBpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.finalizer = internal.ClBpfApplicationControllerFinalizer
 	r.recType = internal.ApplicationString
 
-	r.Logger.Info("Enter BpfApplication Reconcile", "Name", req.Name)
+	r.Logger.Info("Enter ClusterBpfApplication Reconcile", "Name", req.Name)
 
 	// Lookup K8s node object for this bpfman-agent This should always succeed
 	if err := r.Get(ctx, types.NamespacedName{Namespace: v1.NamespaceAll, Name: r.NodeName}, r.ourNode); err != nil {

--- a/controllers/bpfman-agent/cl_tc_program.go
+++ b/controllers/bpfman-agent/cl_tc_program.go
@@ -212,7 +212,7 @@ func (r *ClTcProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha1
 }
 
 func (r *ClTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClTcAttachInfoState) (*int, error) {
-	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	newNetnsId := r.getNetnsId(attachInfoState.NetnsPath)
 	if newNetnsId == nil {
 		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
 	}
@@ -224,7 +224,7 @@ func (r *ClTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClTcAt
 			a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
 			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
-			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			reflect.DeepEqual(r.getNetnsId(a.NetnsPath), newNetnsId) {
 			return &i, nil
 		}
 	}

--- a/controllers/bpfman-agent/cl_tc_program.go
+++ b/controllers/bpfman-agent/cl_tc_program.go
@@ -200,8 +200,8 @@ func (r *ClTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClTcAt
 		// same: InterfaceName, Direction, Priority, NetnsPath, and ProceedOn.
 		if a.InterfaceName == attachInfoState.InterfaceName && a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
-			reflect.DeepEqual(a.NetnsPath, attachInfoState.NetnsPath) &&
-			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) {
+			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
+			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
 			return &i
 		}
 	}

--- a/controllers/bpfman-agent/cl_tcx_program.go
+++ b/controllers/bpfman-agent/cl_tcx_program.go
@@ -165,7 +165,7 @@ func (r *ClTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClTcx
 		// same: InterfaceName, NetnsPath, Priority, and Direction.
 		if a.InterfaceName == attachInfoState.InterfaceName && a.Priority == attachInfoState.Priority &&
 			a.Direction == attachInfoState.Direction &&
-			reflect.DeepEqual(a.NetnsPath, attachInfoState.NetnsPath) {
+			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
 			return &i
 		}
 	}

--- a/controllers/bpfman-agent/cl_tcx_program.go
+++ b/controllers/bpfman-agent/cl_tcx_program.go
@@ -177,7 +177,7 @@ func (r *ClTcxProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha
 }
 
 func (r *ClTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClTcxAttachInfoState) (*int, error) {
-	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	newNetnsId := r.getNetnsId(attachInfoState.NetnsPath)
 	if newNetnsId == nil {
 		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
 	}
@@ -188,7 +188,7 @@ func (r *ClTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClTcx
 		if a.InterfaceName == attachInfoState.InterfaceName &&
 			a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
-			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			reflect.DeepEqual(r.getNetnsId(a.NetnsPath), newNetnsId) {
 			return &i, nil
 		}
 	}

--- a/controllers/bpfman-agent/cl_xdp_program.go
+++ b/controllers/bpfman-agent/cl_xdp_program.go
@@ -187,8 +187,8 @@ func (r *ClXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClXdp
 		// attachInfoState is the same as a if the the following fields are the
 		// same: IfName, NetnsPath, Priority, and ProceedOn.
 		if a.InterfaceName == attachInfoState.InterfaceName && a.Priority == attachInfoState.Priority &&
-			reflect.DeepEqual(a.NetnsPath, attachInfoState.NetnsPath) &&
-			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) {
+			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
+			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
 			return &i
 		}
 	}

--- a/controllers/bpfman-agent/cl_xdp_program.go
+++ b/controllers/bpfman-agent/cl_xdp_program.go
@@ -162,7 +162,11 @@ func (r *ClXdpProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted
 				return fmt.Errorf("failed to get node links: %v", error)
 			}
 			for _, link := range expectedLinks {
-				index := r.findLink(link)
+				index, err := r.findLink(link)
+				if err != nil {
+					r.Logger.Info("Error", "Invalid link", r.printAttachInfo(link), "Error", err)
+					continue
+				}
 				if index != nil {
 					// Link already exists, so set ShouldAttach to true.
 					r.currentProgramState.XDP.Links[*index].AttachInfoStateCommon.ShouldAttach = true
@@ -182,17 +186,35 @@ func (r *ClXdpProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted
 	return nil
 }
 
-func (r *ClXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClXdpAttachInfoState) *int {
+func (r *ClXdpProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha1.ClXdpAttachInfoState) string {
+	var netnsPath string
+	if attachInfoState.NetnsPath == "" {
+		netnsPath = "host"
+	} else {
+		netnsPath = attachInfoState.NetnsPath
+	}
+
+	return fmt.Sprintf("interfaceName: %s, netnsPath: %s, priority: %d",
+		attachInfoState.InterfaceName, netnsPath, attachInfoState.Priority)
+}
+
+func (r *ClXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClXdpAttachInfoState) (*int, error) {
+	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	if newNetnsId == nil {
+		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
+	}
+	r.Logger.V(1).Info("findlink", "New Path", attachInfoState.NetnsPath, "NetnsId", newNetnsId)
 	for i, a := range r.currentProgramState.XDP.Links {
 		// attachInfoState is the same as a if the the following fields are the
-		// same: IfName, NetnsPath, Priority, and ProceedOn.
-		if a.InterfaceName == attachInfoState.InterfaceName && a.Priority == attachInfoState.Priority &&
+		// same: InterfaceName, Priority, ProceedOn, and network namespace.
+		if a.InterfaceName == attachInfoState.InterfaceName &&
+			a.Priority == attachInfoState.Priority &&
 			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
-			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
-			return &i
+			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			return &i, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // processLinks calls reconcileBpfLink() for each link. It

--- a/controllers/bpfman-agent/cl_xdp_program.go
+++ b/controllers/bpfman-agent/cl_xdp_program.go
@@ -201,7 +201,7 @@ func (r *ClXdpProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha
 }
 
 func (r *ClXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClXdpAttachInfoState) (*int, error) {
-	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	newNetnsId := r.getNetnsId(attachInfoState.NetnsPath)
 	if newNetnsId == nil {
 		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
 	}
@@ -212,7 +212,7 @@ func (r *ClXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.ClXdp
 		if a.InterfaceName == attachInfoState.InterfaceName &&
 			a.Priority == attachInfoState.Priority &&
 			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
-			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			reflect.DeepEqual(r.getNetnsId(a.NetnsPath), newNetnsId) {
 			return &i, nil
 		}
 	}
@@ -302,7 +302,6 @@ func (r *ClXdpProgramReconciler) getExpectedLinks(ctx context.Context, attachInf
 	// Handle interface discovery
 	if isInterfacesDiscoveryEnabled(&attachInfo.InterfaceSelector) {
 		discoveredInterfaces := getDiscoveredInterfaces(&attachInfo.InterfaceSelector, r.Interfaces)
-
 		r.Logger.Info("getExpectedLinks", "num discoveredInterfaces", len(discoveredInterfaces))
 		for _, intf := range discoveredInterfaces {
 			nodeLinks = append(nodeLinks, createLinkEntry(intf.interfaceName, intf.netNSPath))

--- a/controllers/bpfman-agent/cl_xdp_program.go
+++ b/controllers/bpfman-agent/cl_xdp_program.go
@@ -157,9 +157,10 @@ func (r *ClXdpProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted
 
 	if r.currentProgram.XDP != nil && r.currentProgram.XDP.Links != nil {
 		for _, attachInfo := range r.currentProgram.XDP.Links {
-			expectedLinks, error := r.getExpectedLinks(ctx, attachInfo)
-			if error != nil {
-				return fmt.Errorf("failed to get node links: %v", error)
+			expectedLinks, err := r.getExpectedLinks(ctx, attachInfo)
+			if err != nil {
+				r.Logger.V(1).Info("updateLinks() failed", "error", err)
+				return fmt.Errorf("failed to get node links: %v", err)
 			}
 			for _, link := range expectedLinks {
 				index, err := r.findLink(link)
@@ -172,6 +173,7 @@ func (r *ClXdpProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted
 					r.currentProgramState.XDP.Links[*index].AttachInfoStateCommon.ShouldAttach = true
 				} else {
 					// Link doesn't exist, so add it.
+					r.Logger.Info("Link doesn't exist.  Adding it.")
 					r.currentProgramState.XDP.Links = append(r.currentProgramState.XDP.Links, link)
 				}
 			}
@@ -299,21 +301,24 @@ func (r *ClXdpProgramReconciler) getExpectedLinks(ctx context.Context, attachInf
 
 	// Handle interface discovery
 	if isInterfacesDiscoveryEnabled(&attachInfo.InterfaceSelector) {
-		discoveredInterfaces, err := getDiscoveredInterfaces(&attachInfo.InterfaceSelector, r.Interfaces)
-		if err != nil {
-			return nil, fmt.Errorf("failed to discover interfaces: %w", err)
-		}
+		discoveredInterfaces := getDiscoveredInterfaces(&attachInfo.InterfaceSelector, r.Interfaces)
+
+		r.Logger.Info("getExpectedLinks", "num discoveredInterfaces", len(discoveredInterfaces))
 		for _, intf := range discoveredInterfaces {
 			nodeLinks = append(nodeLinks, createLinkEntry(intf.interfaceName, intf.netNSPath))
 		}
+		r.Logger.V(1).Info("getExpectedLinks-discovery", "Links created", len(nodeLinks))
 		return nodeLinks, nil
 	}
 
 	// Fetch interfaces if discovery is disabled
 	interfaces, err := getInterfaces(&attachInfo.InterfaceSelector, r.ourNode)
 	if err != nil {
+		r.Logger.V(1).Info("getExpectedLinks failed to get interfaces", "error", err)
 		return nil, fmt.Errorf("failed to get interfaces for XdpProgram: %w", err)
 	}
+
+	r.Logger.Info("getExpectedLinks", "Number of interfaces", len(interfaces))
 
 	// Handle network namespaces if provided
 	if attachInfo.NetworkNamespaces != nil {
@@ -325,6 +330,7 @@ func (r *ClXdpProgramReconciler) getExpectedLinks(ctx context.Context, attachInf
 			r.Logger,
 		)
 		if err != nil {
+			r.Logger.V(1).Info("getExpectedLinks failed to get container pids", "error", err)
 			return nil, fmt.Errorf("failed to get container pids: %w", err)
 		}
 
@@ -340,6 +346,7 @@ func (r *ClXdpProgramReconciler) getExpectedLinks(ctx context.Context, attachInf
 				nodeLinks = append(nodeLinks, createLinkEntry(iface, netnsPath))
 			}
 		}
+		r.Logger.V(1).Info("getExpectedLinks", "Links created", len(nodeLinks))
 		return nodeLinks, nil
 	}
 
@@ -348,6 +355,7 @@ func (r *ClXdpProgramReconciler) getExpectedLinks(ctx context.Context, attachInf
 		nodeLinks = append(nodeLinks, createLinkEntry(iface, ""))
 	}
 
+	r.Logger.V(1).Info("getExpectedLinks", "Links created", len(nodeLinks))
 	return nodeLinks, nil
 }
 

--- a/controllers/bpfman-agent/common.go
+++ b/controllers/bpfman-agent/common.go
@@ -207,6 +207,7 @@ func (r *ReconcilerCommon) updateBpfAppStateCondition(
 func (r *ReconcilerCommon) reconcileProgram(ctx context.Context, program ProgramReconciler, isBeingDeleted bool) error {
 	err := program.updateLinks(ctx, isBeingDeleted)
 	if err != nil {
+		r.Logger.V(1).Info("updateLinks() failed", "error", err)
 		program.setProgramLinkStatus(bpfmaniov1alpha1.UpdateAttachInfoError)
 		return err
 	}
@@ -286,7 +287,7 @@ type discoveredInterface struct {
 	netNSPath     string
 }
 
-func getDiscoveredInterfaces(interfaceSelector *bpfmaniov1alpha1.InterfaceSelector, discoveredInterfacesMap *sync.Map) ([]discoveredInterface, error) {
+func getDiscoveredInterfaces(interfaceSelector *bpfmaniov1alpha1.InterfaceSelector, discoveredInterfacesMap *sync.Map) []discoveredInterface {
 	var discoveredInterfaces []discoveredInterface
 	var netNSPath string
 	allowedRegexpes, allowedMatches := setupAllowedInterfacesLists(interfaceSelector)
@@ -310,10 +311,7 @@ func getDiscoveredInterfaces(interfaceSelector *bpfmaniov1alpha1.InterfaceSelect
 		}
 		return true
 	})
-	if len(discoveredInterfaces) > 0 {
-		return discoveredInterfaces, nil
-	}
-	return nil, fmt.Errorf("interfaces discovery is enabled but no interface discovered")
+	return discoveredInterfaces
 }
 
 func getInterfaces(interfaceSelector *bpfmaniov1alpha1.InterfaceSelector, ourNode *v1.Node) ([]string, error) {

--- a/controllers/bpfman-agent/common.go
+++ b/controllers/bpfman-agent/common.go
@@ -611,24 +611,31 @@ func isInterfacesDiscoveryEnabled(interfaceSelector *bpfmaniov1alpha1.InterfaceS
 	return false
 }
 
-func getInode(log logr.Logger, path string) *uint64 {
+// getNetnsId returns the network namespace ID from the given path. If the path
+// is empty, it defaults to "/host/proc/1/ns/net".  If the file is a hard link,
+// it returns the inode number of the file.  If the file is a soft link, it
+// returns the inode of the file linked. If the path is not valid or the
+// conversion to Stat_t fails, it returns nil.
+func getNetnsId(log logr.Logger, path string) *uint64 {
 	if path == "" {
-		log.V(1).Info("getInode: Path is empty.  Using /proc/1/ns/net")
-		path = "/proc/1/ns/net"
+		log.V(1).Info("Enter getNetnsId: Path is empty.  Using /host/proc/1/ns/net")
+		path = "/host/proc/1/ns/net"
+	} else {
+		log.V(1).Info("Enter getNetnsId", "Path", path)
 	}
 
 	info, err := os.Stat(path)
 	if err != nil {
-		log.Info("getInode: Failed to stat file", "path", path, "error", err)
+		log.V(1).Info("Exit getNetnsId: Failed to stat file", "path", path, "error", err)
 		return nil
 	}
 
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		log.Info("getInode: Failed to convert to Stat_t", "path", path)
+		log.V(1).Info("Exit getNetnsId: Failed to convert to Stat_t", "path", path)
 		return nil
 	}
 
-	log.V(1).Info("getInode", "Path", path, "inode", stat.Ino)
+	log.V(1).Info("Exit getNetnsId", "Path", path, "inode", stat.Ino)
 	return &stat.Ino
 }

--- a/controllers/bpfman-agent/ns_application_program.go
+++ b/controllers/bpfman-agent/ns_application_program.go
@@ -126,6 +126,7 @@ func (r *NsBpfApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.Logger = ctrl.Log.WithName("namespace-app")
 	r.finalizer = internal.NsBpfApplicationControllerFinalizer
 	r.recType = internal.ApplicationString
+	r.NetnsCache = make(map[string]uint64)
 
 	r.Logger.Info("Enter BpfApplication Reconcile", "Name", req.Name)
 

--- a/controllers/bpfman-agent/ns_tc_program.go
+++ b/controllers/bpfman-agent/ns_tc_program.go
@@ -165,8 +165,8 @@ func (r *NsTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcAtta
 		// same: InterfaceName, Direction, Priority, NetnsPath, and ProceedOn.
 		if a.InterfaceName == attachInfoState.InterfaceName && a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
-			reflect.DeepEqual(a.NetnsPath, attachInfoState.NetnsPath) &&
-			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) {
+			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
+			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
 			return &i
 		}
 	}

--- a/controllers/bpfman-agent/ns_tc_program.go
+++ b/controllers/bpfman-agent/ns_tc_program.go
@@ -176,7 +176,7 @@ func (r *NsTcProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha1
 }
 
 func (r *NsTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcAttachInfoState) (*int, error) {
-	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	newNetnsId := r.getNetnsId(attachInfoState.NetnsPath)
 	if newNetnsId == nil {
 		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
 	}
@@ -188,7 +188,7 @@ func (r *NsTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcAtta
 			a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
 			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
-			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			reflect.DeepEqual(r.getNetnsId(a.NetnsPath), newNetnsId) {
 			return &i, nil
 		}
 	}

--- a/controllers/bpfman-agent/ns_tc_program.go
+++ b/controllers/bpfman-agent/ns_tc_program.go
@@ -138,7 +138,11 @@ func (r *NsTcProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted 
 				return fmt.Errorf("failed to get node links: %v", error)
 			}
 			for _, link := range expectedLinks {
-				index := r.findLink(link)
+				index, err := r.findLink(link)
+				if err != nil {
+					r.Logger.Info("Error", "Invalid link", r.printAttachInfo(link), "Error", err)
+					continue
+				}
 				if index != nil {
 					// Link already exists, so set ShouldAttach to true.
 					r.currentProgramState.TC.Links[*index].AttachInfoStateCommon.ShouldAttach = true
@@ -159,18 +163,36 @@ func (r *NsTcProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted 
 	return nil
 }
 
-func (r *NsTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcAttachInfoState) *int {
+func (r *NsTcProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha1.TcAttachInfoState) string {
+	var netnsPath string
+	if attachInfoState.NetnsPath == "" {
+		netnsPath = "host"
+	} else {
+		netnsPath = attachInfoState.NetnsPath
+	}
+
+	return fmt.Sprintf("interfaceName: %s, netnsPath: %s, direction: %s, priority: %d",
+		attachInfoState.InterfaceName, netnsPath, attachInfoState.Direction, attachInfoState.Priority)
+}
+
+func (r *NsTcProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcAttachInfoState) (*int, error) {
+	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	if newNetnsId == nil {
+		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
+	}
+	r.Logger.V(1).Info("findlink", "New Path", attachInfoState.NetnsPath, "NetnsId", newNetnsId)
 	for i, a := range r.currentProgramState.TC.Links {
 		// attachInfoState is the same as a if the the following fields are the
-		// same: InterfaceName, Direction, Priority, NetnsPath, and ProceedOn.
-		if a.InterfaceName == attachInfoState.InterfaceName && a.Direction == attachInfoState.Direction &&
+		// same: InterfaceName, Direction, Priority, ProceedOn, and network namespace.
+		if a.InterfaceName == attachInfoState.InterfaceName &&
+			a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
 			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
-			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
-			return &i
+			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			return &i, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // processLinks calls reconcileBpfLink() for each link. It

--- a/controllers/bpfman-agent/ns_tcx_program.go
+++ b/controllers/bpfman-agent/ns_tcx_program.go
@@ -164,7 +164,7 @@ func (r *NsTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcxAt
 		// same: InterfaceName, NetnsPath, Priority, and Direction.
 		if a.InterfaceName == attachInfoState.InterfaceName && a.Priority == attachInfoState.Priority &&
 			a.Direction == attachInfoState.Direction &&
-			reflect.DeepEqual(a.NetnsPath, attachInfoState.NetnsPath) {
+			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
 			return &i
 		}
 	}

--- a/controllers/bpfman-agent/ns_tcx_program.go
+++ b/controllers/bpfman-agent/ns_tcx_program.go
@@ -175,7 +175,7 @@ func (r *NsTcxProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha
 }
 
 func (r *NsTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcxAttachInfoState) (*int, error) {
-	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	newNetnsId := r.getNetnsId(attachInfoState.NetnsPath)
 	if newNetnsId == nil {
 		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
 	}
@@ -186,7 +186,7 @@ func (r *NsTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcxAt
 		if a.InterfaceName == attachInfoState.InterfaceName &&
 			a.Direction == attachInfoState.Direction &&
 			a.Priority == attachInfoState.Priority &&
-			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			reflect.DeepEqual(r.getNetnsId(a.NetnsPath), newNetnsId) {
 			return &i, nil
 		}
 	}

--- a/controllers/bpfman-agent/ns_tcx_program.go
+++ b/controllers/bpfman-agent/ns_tcx_program.go
@@ -137,7 +137,11 @@ func (r *NsTcxProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted
 				return fmt.Errorf("failed to get node links: %v", error)
 			}
 			for _, link := range expectedLinks {
-				index := r.findLink(link)
+				index, err := r.findLink(link)
+				if err != nil {
+					r.Logger.Info("Error", "Invalid link", r.printAttachInfo(link), "Error", err)
+					continue
+				}
 				if index != nil {
 					// Link already exists, so set ShouldAttach to true.
 					r.currentProgramState.TCX.Links[*index].AttachInfoStateCommon.ShouldAttach = true
@@ -158,17 +162,35 @@ func (r *NsTcxProgramReconciler) updateLinks(ctx context.Context, isBeingDeleted
 	return nil
 }
 
-func (r *NsTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcxAttachInfoState) *int {
+func (r *NsTcxProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha1.TcxAttachInfoState) string {
+	var netnsPath string
+	if attachInfoState.NetnsPath == "" {
+		netnsPath = "host"
+	} else {
+		netnsPath = attachInfoState.NetnsPath
+	}
+
+	return fmt.Sprintf("interfaceName: %s, netnsPath: %s, direction: %s, priority: %d",
+		attachInfoState.InterfaceName, netnsPath, attachInfoState.Direction, attachInfoState.Priority)
+}
+
+func (r *NsTcxProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.TcxAttachInfoState) (*int, error) {
+	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	if newNetnsId == nil {
+		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
+	}
+	r.Logger.V(1).Info("findlink", "New Path", attachInfoState.NetnsPath, "NetnsId", newNetnsId)
 	for i, a := range r.currentProgramState.TCX.Links {
 		// attachInfoState is the same as a if the the following fields are the
-		// same: InterfaceName, NetnsPath, Priority, and Direction.
-		if a.InterfaceName == attachInfoState.InterfaceName && a.Priority == attachInfoState.Priority &&
+		// same: InterfaceName, Direction, Priority, and network namespace.
+		if a.InterfaceName == attachInfoState.InterfaceName &&
 			a.Direction == attachInfoState.Direction &&
-			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
-			return &i
+			a.Priority == attachInfoState.Priority &&
+			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			return &i, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // processLinks calls reconcileBpfLink() for each link. It

--- a/controllers/bpfman-agent/ns_xdp_program.go
+++ b/controllers/bpfman-agent/ns_xdp_program.go
@@ -162,8 +162,8 @@ func (r *NsXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.XdpAt
 		// attachInfoState is the same as a if the the following fields are the
 		// same: IfName, NetnsPath, Priority, and ProceedOn.
 		if a.InterfaceName == attachInfoState.InterfaceName && a.Priority == attachInfoState.Priority &&
-			reflect.DeepEqual(a.NetnsPath, attachInfoState.NetnsPath) &&
-			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) {
+			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
+			reflect.DeepEqual(getInode(r.Logger, a.NetnsPath), getInode(r.Logger, attachInfoState.NetnsPath)) {
 			return &i
 		}
 	}

--- a/controllers/bpfman-agent/ns_xdp_program.go
+++ b/controllers/bpfman-agent/ns_xdp_program.go
@@ -174,7 +174,7 @@ func (r *NsXdpProgramReconciler) printAttachInfo(attachInfoState bpfmaniov1alpha
 }
 
 func (r *NsXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.XdpAttachInfoState) (*int, error) {
-	newNetnsId := getNetnsId(r.Logger, attachInfoState.NetnsPath)
+	newNetnsId := r.getNetnsId(attachInfoState.NetnsPath)
 	if newNetnsId == nil {
 		return nil, fmt.Errorf("failed to get netnsId for path %s", attachInfoState.NetnsPath)
 	}
@@ -185,7 +185,7 @@ func (r *NsXdpProgramReconciler) findLink(attachInfoState bpfmaniov1alpha1.XdpAt
 		if a.InterfaceName == attachInfoState.InterfaceName &&
 			a.Priority == attachInfoState.Priority &&
 			reflect.DeepEqual(a.ProceedOn, attachInfoState.ProceedOn) &&
-			reflect.DeepEqual(getNetnsId(r.Logger, a.NetnsPath), newNetnsId) {
+			reflect.DeepEqual(r.getNetnsId(a.NetnsPath), newNetnsId) {
 			return &i, nil
 		}
 	}

--- a/hack/startpods.sh
+++ b/hack/startpods.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Number of test pods to launch (default: 5)
+NUM_PODS=${1:-5}
+NAMESPACE="default"
+IMAGE="busybox"
+LABEL="app=test-pod"
+
+echo "Creating $NUM_PODS test pods in namespace '$NAMESPACE'..."
+
+for i in $(seq 1 $NUM_PODS); do
+  POD_NAME="test-pod-$i"
+  echo "Creating pod: $POD_NAME"
+  kubectl run $POD_NAME \
+    --image=$IMAGE \
+    --restart=Never \
+    --labels="$LABEL" \
+    --command -- sleep 3600
+done
+
+echo "Done. Use 'kubectl get pods -l $LABEL' to see the pods."

--- a/hack/test-target-deployment.yaml
+++ b/hack/test-target-deployment.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: test-target
     spec:
+      # hostNetwork: true # Enable host networking
       containers:
         - name: test-target
           image: quay.io/bpfman-userspace/go-target:latest


### PR DESCRIPTION
It’s possible for multiple pods to share the same network namespace, even though unique handles for that namespace are created in /var/run/netns. This most commonly occurs when pods are configured with "hostNetwork": true.

The interface discovery process watches /var/run/netns, and when it detects a new entry, it begins monitoring the interfaces in that namespace and informs bpfman. However, if bpfman attempts to attach multiple programs — especially TCX programs — to the same interface in the same netns, it will return an error. It's also possible to run into this situation using the network namespace selector.

For TC and XDP programs, the attach might not fail immediately, but bpfman limits the number of programs per attach point (currently to 10). If more than 10 handles reference the same network namespace — which is common on OpenShift clusters — this limit is quickly reached. That can lead to subtle and unexpected failures, even though the individual netns paths appear different.

The solution is to compare inodes rather than file paths when identifying network namespaces. This allows the system to correctly recognize when multiple entries actually refer to the same underlying namespace.

Additional changes:
- bpfman needs to mount /proc to get the inodes for interfaces inside
  pods.
- getDiscoveredInterfaces() shouldn't return an error if no interfaces
  are found.  This could be valid depending on the configuration of
  allowed and excluded interfaces.
- Added a NetnsCache to remember mapping the results of inode lookups.
  This avoids multiple syscalls for the same network namespace path.
  This cache is initialized at the beginning of each Reconcile loop
  so that changes can be detected.

Fixes: #433