### PR TITLE
Set CGO_ENABLED=1 to support FIPS-compatible builds

### DIFF
--- a/Containerfile.bpfman-agent
+++ b/Containerfile.bpfman-agent
@@ -22,7 +22,7 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-agent ./cmd/bpfman-agent/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-agent ./cmd/bpfman-agent/main.go
 
 
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23 AS cri-tools-build

--- a/Containerfile.bpfman-agent.openshift
+++ b/Containerfile.bpfman-agent.openshift
@@ -22,7 +22,7 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-agent ./cmd/bpfman-agent/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-agent ./cmd/bpfman-agent/main.go
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1725849298
 ARG DNF_CMD="microdnf"

--- a/Containerfile.bpfman-operator
+++ b/Containerfile.bpfman-operator
@@ -22,7 +22,7 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-operator ./cmd/bpfman-operator/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-operator ./cmd/bpfman-operator/main.go
 
 # Use the fedora minimal image to reduce the size of the final image but still
 # be able to easily install extra packages.

--- a/Containerfile.bpfman-operator.openshift
+++ b/Containerfile.bpfman-operator.openshift
@@ -22,7 +22,7 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-operator ./cmd/bpfman-operator/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod vendor -o bpfman-operator ./cmd/bpfman-operator/main.go
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1725849298
 

--- a/Makefile
+++ b/Makefile
@@ -320,8 +320,8 @@ build-release-yamls: generate kustomize ## Generate the crd install bundle for a
 
 .PHONY: build
 build: fmt ## Build bpfman-operator and bpfman-agent binaries.
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -mod vendor -o bin/bpfman-operator cmd/bpfman-operator/main.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -mod vendor -o bin/bpfman-agent cmd/bpfman-agent/main.go
+	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) go build -mod vendor -o bin/bpfman-operator cmd/bpfman-operator/main.go
+	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) go build -mod vendor -o bin/bpfman-agent cmd/bpfman-agent/main.go
 
 # These paths map the host's GOCACHE location to the container's
 # location. We want to mount the host's Go cache in the container to


### PR DESCRIPTION
Set CGO_ENABLED=1 in all containerfiles and the Makefile to allow [1]
linking against FIPS-compliant C libraries (e.g. OpenSSL).

This is a prerequisite for enabling strict FIPS runtime support:(e.g.
via GOEXPERIMENT=strictfipsruntime and -tags strictfipsruntime) in
downstream builds.

No functional change expected in non-FIPS environments.

[1] https://developers.redhat.com/articles/2025/01/23/fips-mode-red-hat-go-toolset#validating_fips_mode_capabilities

Signed-off-by: Andrew McDermott <amcdermo@redhat.com>
