### PR TITLE
Makefile: wait for ConfigMap deletion before undeploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ deploy: manifests kustomize ## Deploy bpfman-operator to the K8s cluster specifi
 .PHONY: undeploy
 undeploy: ## Undeploy bpfman-operator from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	kubectl delete --ignore-not-found=$(ignore-not-found) cm bpfman-config -n bpfman
-	sleep 5 # Wait for the operator to cleanup the daemonset
+	kubectl wait --for=delete configmap/bpfman-config -n bpfman --timeout=60s
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: kind-reload-images
@@ -459,6 +459,8 @@ deploy-openshift: manifests kustomize ## Deploy bpfman-operator to the Openshift
 
 .PHONY: undeploy-openshift
 undeploy-openshift: ## Undeploy bpfman-operator from the Openshift cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	kubectl delete --ignore-not-found=$(ignore-not-found) cm bpfman-config -n bpfman
+	kubectl wait --for=delete configmap/bpfman-config -n bpfman --timeout=60s
 	$(KUSTOMIZE) build config/openshift | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 # Deploy the catalog.


### PR DESCRIPTION
Stop using a fixed pause in the undeploy target. Instead, wait for configuration ConfigMap deletion, with a timeout of 60 seconds. Apply the same approach in the undeploy-openshift target: explicitly delete the ConfigMap and block until it is removed before deleting the operator and other resources.

Previously, on OpenShift, deleting resources did not allow the operator to remove its finalisers on the ConfigMap and DaemonSet, causing undeploy to hang while waiting on remaining finalisers.

Waiting for the ConfigMap deletion guarantees the operator completes cleanup and removes all finalisers, preventing resource leaks and hangs.