### PR TITLE
Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Go report card][go-report-card-badge]][go-report-card-report]
 [![OpenSSF Scorecard][openssf-badge]][openssf-url]
 [![FOSSA Status][fossa-badge]][fossa-url]
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bpfman/bpfman-operator)
 
 [apache2-badge]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [apache2-url]: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
DeepWiki is a free version of Devin Wiki and Devin Search that works with public GitHub repositories. It automatically generates architecture diagrams, documentation, and links to source code to help you understand unfamiliar codebases quickly. You can also ask complex questions about the codebase to get context-grounded specific answers.

By adding the badge, users can access the resource easily, and DeepWiki will index this repo on a weekly basis to keep the info provided up to date.