### PR TITLE
BpfApplicationReconcilers: wrap loadRequest error

### DIFF
--- a/controllers/bpfman-agent/cl_application_program.go
+++ b/controllers/bpfman-agent/cl_application_program.go
@@ -742,7 +742,7 @@ func (r *ClBpfApplicationReconciler) getLoadRequest() (*gobpfman.LoadRequest, er
 func (r *ClBpfApplicationReconciler) load(ctx context.Context) error {
 	loadRequest, err := r.getLoadRequest()
 	if err != nil {
-		return fmt.Errorf("failed to get LoadRequest")
+		return fmt.Errorf("failed to get LoadRequest: %w", err)
 	}
 
 	loadResponse, err := r.BpfmanClient.Load(ctx, loadRequest)

--- a/controllers/bpfman-agent/ns_application_program.go
+++ b/controllers/bpfman-agent/ns_application_program.go
@@ -659,7 +659,7 @@ func (r *NsBpfApplicationReconciler) getLoadRequest() (*gobpfman.LoadRequest, er
 func (r *NsBpfApplicationReconciler) load(ctx context.Context) error {
 	loadRequest, err := r.getLoadRequest()
 	if err != nil {
-		return fmt.Errorf("failed to get LoadRequest")
+		return fmt.Errorf("failed to get LoadRequest: %w", err)
 	}
 
 	loadResponse, err := r.BpfmanClient.Load(ctx, loadRequest)


### PR DESCRIPTION
When BpfApplicationReconcilers fail, they must pass the err from r.getLoadRequest() up the stack.

fixes https://github.com/bpfman/bpfman-operator/issues/447