### PR TITLE
Fix SEGV (nil pointer access) in getBpfAppState logging functions

### DIFF
--- a/controllers/bpfman-agent/cl_application_program.go
+++ b/controllers/bpfman-agent/cl_application_program.go
@@ -547,8 +547,7 @@ func (r *ClBpfApplicationReconciler) getBpfAppState(ctx context.Context) (*bpfma
 
 	switch len(appProgramList.Items) {
 	case 1:
-		// We got exactly one BpfApplicationState, so update r.currentAppState
-		r.Logger.V(1).Info("Found BpfApplicationState", "Name", r.currentAppState.Name)
+		r.Logger.V(1).Info("Found BpfApplicationState", "Name", appProgramList.Items[0].Name)
 		return &appProgramList.Items[0], nil
 	case 0:
 		// No BpfApplicationState found, so return nil

--- a/controllers/bpfman-agent/cl_application_program_test.go
+++ b/controllers/bpfman-agent/cl_application_program_test.go
@@ -37,6 +37,55 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+func TestClBpfApplicationReconcilerGetBpfAppState(t *testing.T) {
+	s := scheme.Scheme
+	s.AddKnownTypes(bpfmaniov1alpha1.SchemeGroupVersion, &bpfmaniov1alpha1.ClusterBpfApplication{})
+	s.AddKnownTypes(bpfmaniov1alpha1.SchemeGroupVersion, &bpfmaniov1alpha1.ClusterBpfApplicationState{})
+	s.AddKnownTypes(bpfmaniov1alpha1.SchemeGroupVersion, &bpfmaniov1alpha1.ClusterBpfApplicationStateList{})
+
+	// Create a mock ClusterBpfApplicationState that will be
+	// found.
+	mockAppState := &bpfmaniov1alpha1.ClusterBpfApplicationState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-app-state",
+			Labels: map[string]string{
+				internal.BpfAppStateOwner: "test-app",
+				internal.K8sHostLabel:     "test-node",
+			},
+		},
+	}
+
+	objs := []runtime.Object{mockAppState}
+	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	cli := agenttestutils.NewBpfmanClientFake()
+
+	rc := ReconcilerCommon{
+		Client:       cl,
+		Scheme:       s,
+		BpfmanClient: cli,
+		NodeName:     "test-node",
+	}
+
+	r := &ClBpfApplicationReconciler{
+		ReconcilerCommon: rc,
+	}
+
+	// Set currentApp (required for getBpfAppState).
+	r.currentApp = &bpfmaniov1alpha1.ClusterBpfApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-app",
+		},
+	}
+
+	// Test getBpfAppState when currentAppState is nil.
+	ctx := context.Background()
+	result, err := r.getBpfAppState(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "test-app-state", result.Name)
+}
+
 func TestClBpfApplicationControllerCreate(t *testing.T) {
 	var (
 		// global config

--- a/controllers/bpfman-agent/ns_application_program.go
+++ b/controllers/bpfman-agent/ns_application_program.go
@@ -490,8 +490,7 @@ func (r *NsBpfApplicationReconciler) getBpfAppState(ctx context.Context) (*bpfma
 
 	switch len(appProgramList.Items) {
 	case 1:
-		// We got exactly one BpfApplicationState, so update r.currentAppState
-		r.Logger.V(1).Info("Found BpfApplicationState", "Name", r.currentAppState.Name)
+		r.Logger.V(1).Info("Found BpfApplicationState", "Name", appProgramList.Items[0].Name)
 		return &appProgramList.Items[0], nil
 	case 0:
 		// No BpfApplicationState found, so return nil


### PR DESCRIPTION
The panic occurred because the logging statement tried to access `r.currentAppState.Name` before `r.currentAppState` was initialised in the reconciliation flow.

### Root Cause

The `getBpfAppState()` function is called during the reconciliation process to find existing BpfApplicationState objects. When a matching state is found, the function logs the state name and returns the object. However, the logging statement incorrectly tried to access `r.currentAppState.Name` when `r.currentAppState` was still nil. The assignment of `r.currentAppState` happens in the caller after the function returns successfully.

### Solution

Fixed the logging to use the correct state name from the found object (`appProgramList.Items[0].Name`) instead of the uninitialised `r.currentAppState.Name` field. This change ensures the logging statement accesses valid data and properly reflects what was actually found by the function.

Also corrected misleading comments that incorrectly suggested the function updates `r.currentAppState` when it actually just returns the found object for the caller to assign.

### Testing

- Added unit tests that demonstrate the bug existed and verify the fix
- Tested with `make deploy-uprobe` to confirm uprobe deployment now works without panics
- Verified logs show correct state names being logged during reconciliation

I can see multiple instances of the corrected logging statement:

```sh
{"level":"info","ts":"2025-07-14T10:16:02Z","logger":"cluster-app","msg":"Found BpfApplicationState","Name":"go-uprobe-counter-example-0f2d006d"}
{"level":"info","ts":"2025-07-14T10:16:02Z","logger":"cluster-app","msg":"Found BpfApplicationState","Name":"go-uprobe-counter-example-0f2d006d"}
{"level":"info","ts":"2025-07-14T10:16:07Z","logger":"cluster-app","msg":"Found BpfApplicationState","Name":"go-uprobe-counter-example-0f2d006d"}
{"level":"info","ts":"2025-07-14T10:16:10Z","logger":"cluster-app","msg":"Found BpfApplicationState","Name":"go-uprobe-counter-example-0f2d006d"}
```

Note: Whilst this fix resolves the immediate nil pointer exception, a more robust solution would be to restructure the code to make illegal states unrepresentable. This would involve redesigning the reconciler to prevent methods from being called when required state is uninitialised. However, such refactoring is beyond the scope of this immediate fix.