### PR TITLE
Disable controller-runtime metrics server in bpfman-agent

### DIFF
--- a/cmd/bpfman-agent/main.go
+++ b/cmd/bpfman-agent/main.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	//+kubebuilder:scaffold:imports
@@ -349,7 +350,11 @@ func main() {
 		Scheme:                 scheme,
 		PprofBindAddress:       pprofAddr,
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         false,
+		Metrics: metricsserver.Options{
+			// Disable controller-runtime metrics server.
+			BindAddress: "0",
+		},
+		LeaderElection: false,
 		// Specify that Secrets's should not be cached.
 		Client: client.Options{
 			Cache: &client.CacheOptions{


### PR DESCRIPTION
The bpfman-agent uses hostNetwork: true and the controller-runtime was
attempting to bind its default metrics server to port 8080 on the
host. This caused port conflicts when other services were already
using port 8080 on specific nodes, resulting in 'address already in
use' errors.

This issue was intermittent and node-specific - some nodes would start
the daemon successfully while others would fail, depending on whether
something else was already bound to port 8080 on that particular node.

Since the metrics decoupling work in PR 443, metrics are now served
exclusively via the metrics-proxy DaemonSet, which communicates with
the agent through a Unix socket at /var/run/bpfman-agent/metrics.sock.
The controller-runtime metrics server on port 8080 is no longer
needed.

Fix by setting Metrics.BindAddress to '0' to disable the
controller-runtime metrics server entirely, eliminating the host port
binding conflict. Metrics collection continues to work through the
metrics-proxy.

[1] https://github.com/bpfman/bpfman-operator/pull/443

Signed-off-by: Andrew McDermott <amcdermo@redhat.com>
