### PR TITLE
Add make target to run operator locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,11 @@ bundle: operator-sdk generate kustomize manifests ## Generate bundle manifests a
 build-release-yamls: generate kustomize ## Generate the crd install bundle for a specific release version.
 	VERSION=$(VERSION) ./hack/build-release-yamls.sh
 
+.PHONY: run-local
+run-local: build ## Run the bpfman-operator locally for development purposes.
+	kubectl scale deployment -n bpfman bpfman-operator --replicas=0
+	GO_LOG=debug bin/bpfman-operator
+
 ##@ Build
 
 .PHONY: build


### PR DESCRIPTION
  This change introduces a new run-local Makefile  target that allows developers to easily run the
  bpfman-operator locally for development and  debugging purposes. The target automatically scales down the cluster deployment to avoid conflicts and runs the operator with debug logging enabled.

  Changes:
  - Added run-local Makefile target that:
    - Scales down the cluster bpfman-operator
  deployment to 0 replicas
    - Runs the locally built operator with
  GO_LOG=debug for enhanced logging