### PR TITLE
Daemonset: Move bidirectional mount from /run/bpfman to /run/bpfman/csi

### DIFF
--- a/config/bpfman-deployment/daemonset.yaml
+++ b/config/bpfman-deployment/daemonset.yaml
@@ -78,7 +78,6 @@ spec:
               mountPath: /run/bpfman-sock
             - name: runtime
               mountPath: /run/bpfman
-              mountPropagation: Bidirectional
             # This mount is needed to attach tracepoint programs
             - name: host-debug
               mountPath: /sys/kernel/debug
@@ -92,6 +91,7 @@ spec:
               mountPropagation: Bidirectional
             - mountPath: /run/bpfman/csi
               name: socket-dir
+              mountPropagation: Bidirectional
             - mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
               name: mountpoint-dir


### PR DESCRIPTION
The bidirectional mount in /run/bpfman caused issues because /run/bpfman/csi was mounted inside there, resulting in an *exponentially* increasing number of mounts on the host system (double the number of mounts for every restart of the container). Moving the bidirectional statement from /run/bpfman to /run/bpfman/csi should fix this while preserving the requirement for bidirectional mounts for CSI.

Reported-at: https://github.com/bpfman/bpfman-operator/issues/468