### PR TITLE
docs: add script to run kubectl explain on all crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,10 @@ vendors: ## Refresh vendors directory.
 	@echo "### Checking vendors"
 	go mod tidy && go mod vendor
 
+.PHONY: explain
+explain: ## Run "kubectl explain" on all CRDs.
+	CRD_1="BpfApplication" CRD_2="ClusterBpfApplication" CRD_3="BpfApplicationState" CRD_4="ClusterBpfApplicationState" OUTPUT_DIR="../docs/crds" ./hack/crd_explain_txt.sh
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/docs/crds/BpfApplication.txt
+++ b/docs/crds/BpfApplication.txt
@@ -1,0 +1,1575 @@
+$ kubectl explain BpfApplication
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+DESCRIPTION:
+    BpfApplication is the schema for the namespace scoped BPF Applications API.
+    This API allows applications to use bpfman to load and attach one or more
+    eBPF programs on a Kubernetes cluster.
+    
+    
+    The bpfApplication.status field reports the overall status of the
+    BpfApplication CRD. A given BpfApplication CRD can result in loading and
+    attaching multiple eBPF programs on multiple nodes, so this status is just a
+    summary. More granular per-node status details can be found in the
+    corresponding BpfApplicationState CRD that bpfman creates for each node.
+    
+FIELDS:
+  apiVersion	<string>
+    APIVersion defines the versioned schema of this representation of an object.
+    Servers should convert recognized schemas to the latest internal value, and
+    may reject unrecognized values. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+  kind	<string>
+    Kind is a string value representing the REST resource this object
+    represents. Servers may infer this from the endpoint the client submits
+    requests to. Cannot be updated. In CamelCase. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+  metadata	<ObjectMeta>
+    Standard object's metadata. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  spec	<Object>
+    spec defines the desired state of the BpfApplication. The BpfApplication
+    describes the set of one or more namespace scoped eBPF programs that should
+    be loaded for a given application and attributes for how they should be
+    loaded. eBPF programs that are grouped together under the same
+    BpfApplication instance can share maps and global data between the eBPF
+    programs loaded on the same Kubernetes Node.
+
+  status	<Object>
+    status reflects the status of a BPF Application and indicates if all the
+    eBPF programs for a given instance loaded successfully or not.
+
+$ kubectl explain BpfApplication.spec
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: spec <Object>
+
+
+DESCRIPTION:
+    spec defines the desired state of the BpfApplication. The BpfApplication
+    describes the set of one or more namespace scoped eBPF programs that should
+    be loaded for a given application and attributes for how they should be
+    loaded. eBPF programs that are grouped together under the same
+    BpfApplication instance can share maps and global data between the eBPF
+    programs loaded on the same Kubernetes Node.
+    
+FIELDS:
+  byteCode	<Object> -required-
+    bytecode is a required field and configures where the eBPF program's
+    bytecode should be loaded from. The image must contain one or more
+    eBPF programs.
+
+  globalData	<map[string]string>
+    globalData is an optional field that allows the user to set global variables
+    when the program is loaded. This allows the same compiled bytecode to be
+    deployed by different BPF Applications to behave differently based on
+    globalData configuration values.  It uses an array of raw bytes. This is a
+    very low level primitive. The caller is responsible for formatting the byte
+    string appropriately considering such things as size, endianness, alignment
+    and packing of data structures.
+
+  mapOwnerSelector	<Object>
+    mapOwnerSelector is an optional field used to share maps across
+    applications. eBPF programs loaded with the same ClusterBpfApplication or
+    BpfApplication instance do not need to use this field. This label selector
+    allows maps from a different ClusterBpfApplication or BpfApplication
+    instance to be used by this instance.
+    TODO: mapOwnerSelector is currently not supported due to recent code rework.
+
+  nodeSelector	<Object> -required-
+    nodeSelector is a required field and allows the user to specify which
+    Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+    standard metav1.LabelSelector semantics and make it empty.
+
+  programs	<[]Object>
+    programs is a required field and is the list of eBPF programs in a BPF
+    Application CRD that should be loaded in kernel memory. At least one entry
+    is required. eBPF programs in this list will be loaded on the system based
+    the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+    cannot be triggered until an attachment point is provided. The different
+    program types have different ways of attaching. The attachment points can be
+    added at creation time or modified (added or removed) at a later time to
+    activate or deactivate the eBPF program as desired.
+    CAUTION: When programs are added or removed from the list, that requires all
+    programs in the list to be reloaded, which could be temporarily service
+    effecting. For this reason, modifying the list is currently not allowed.
+
+$ kubectl explain BpfApplication.spec.byteCode
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: byteCode <Object>
+
+
+DESCRIPTION:
+    bytecode is a required field and configures where the eBPF program's
+    bytecode should be loaded from. The image must contain one or more
+    eBPF programs.
+    
+FIELDS:
+  image	<Object>
+    image is an optional field and used to specify details on how to retrieve an
+    eBPF program packaged in a OCI container image from a given registry.
+
+  path	<string>
+    path is an optional field and used to specify a bytecode object file via
+    filepath on a Kubernetes node.
+
+$ kubectl explain BpfApplication.spec.byteCode.image
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: image <Object>
+
+
+DESCRIPTION:
+    image is an optional field and used to specify details on how to retrieve an
+    eBPF program packaged in a OCI container image from a given registry.
+    
+FIELDS:
+  imagePullPolicy	<string>
+  enum: Always, Never, IfNotPresent
+    pullPolicy is an optional field that describes a policy for if/when to pull
+    a bytecode image. Defaults to IfNotPresent. Allowed values are:
+      Always, IfNotPresent and Never
+    
+    
+    When set to Always, the given image will be pulled even if the image is
+    already present on the node.
+    
+    
+    When set to IfNotPresent, the given image will only be pulled if it is not
+    present on the node.
+    
+    
+    When set to Never, the given image will never be pulled and must be
+    loaded on the node by some other means.
+
+  imagePullSecret	<Object>
+    imagePullSecret is an optional field and indicates the secret which contains
+    the credentials to access the image repository.
+
+  url	<string> -required-
+    url is a required field and is a valid container image URL used to reference
+    a remote bytecode image. url must not be an empty string, must not exceed
+    525 characters in length and must be a valid URL.
+
+$ kubectl explain BpfApplication.spec.byteCode.image.imagePullSecret
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: imagePullSecret <Object>
+
+
+DESCRIPTION:
+    imagePullSecret is an optional field and indicates the secret which contains
+    the credentials to access the image repository.
+    
+FIELDS:
+  name	<string> -required-
+    name is a required field and is the name of the secret which contains the
+    credentials to access the image repository.
+
+  namespace	<string> -required-
+    namespace is a required field and is the namespace of the secret which
+    contains the credentials to access the image repository.
+
+$ kubectl explain BpfApplication.spec.mapOwnerSelector
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: mapOwnerSelector <Object>
+
+
+DESCRIPTION:
+    mapOwnerSelector is an optional field used to share maps across
+    applications. eBPF programs loaded with the same ClusterBpfApplication or
+    BpfApplication instance do not need to use this field. This label selector
+    allows maps from a different ClusterBpfApplication or BpfApplication
+    instance to be used by this instance.
+    TODO: mapOwnerSelector is currently not supported due to recent code rework.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.mapOwnerSelector.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.spec.nodeSelector
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: nodeSelector <Object>
+
+
+DESCRIPTION:
+    nodeSelector is a required field and allows the user to specify which
+    Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+    standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.nodeSelector.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.spec.programs
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: programs <[]Object>
+
+
+DESCRIPTION:
+    programs is a required field and is the list of eBPF programs in a BPF
+    Application CRD that should be loaded in kernel memory. At least one entry
+    is required. eBPF programs in this list will be loaded on the system based
+    the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+    cannot be triggered until an attachment point is provided. The different
+    program types have different ways of attaching. The attachment points can be
+    added at creation time or modified (added or removed) at a later time to
+    activate or deactivate the eBPF program as desired.
+    CAUTION: When programs are added or removed from the list, that requires all
+    programs in the list to be reloaded, which could be temporarily service
+    effecting. For this reason, modifying the list is currently not allowed.
+    BpfApplicationProgram defines the desired state of BpfApplication
+    
+FIELDS:
+  name	<string> -required-
+    name is a required field and is the name of the function that is the entry
+    point for the eBPF program. name must not be an empty string, must not
+    exceed 64 characters in length, must start with alpha characters and must
+    only contain alphanumeric characters.
+
+  tc	<Object>
+    tc is an optional field, but required when the type field is set to TC. tc
+    defines the desired state of the application's TC programs. TC programs are
+    attached to network devices (interfaces). The program can be attached on
+    either packet ingress or egress, so the program will be called on every
+    incoming or outgoing packet seen by the network device. The TC attachment
+    point is in Linux's Traffic Control (tc) subsystem, which is after the
+    Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+    with enhanced performance and better support for running multiple programs
+    on a given network device. This makes TC useful for packet classification
+    actions.
+
+  tcx	<Object>
+    tcx is an optional field, but required when the type field is set to TCX.
+    tcx defines the desired state of the application's TCX programs. TCX
+    programs are attached to network devices (interfaces). The program can be
+    attached on either packet ingress or egress, so the program will be called
+    on every incoming or outgoing packet seen by the network device. The TCX
+    attachment point is in Linux's Traffic Control (tc) subsystem, which is
+    after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+    packet classification actions. TCX is a newer implementation of TC with
+    enhanced performance and better support for running multiple programs on a
+    given network device.
+
+  type	<string> -required-
+  enum: XDP, TC, TCX, UProbe, ....
+    type is a required field used to specify the type of the eBPF program.
+    
+    
+    Allowed values are:
+      TC, TCX, UProbe, URetProbe, XDP
+    
+    
+    When set to TC, the eBPF program can attach to network devices (interfaces).
+    The program can be attached on either packet ingress or egress, so the
+    program will be called on every incoming or outgoing packet seen by the
+    network device. When using the TC program type, the tc field is required.
+    See tc for more details on TC programs.
+    
+    
+    When set to TCX, the eBPF program can attach to network devices
+    (interfaces). The program can be attached on either packet ingress or
+    egress, so the program will be called on every incoming or outgoing packet
+    seen by the network device. When using the TCX program type, the tcx field
+    is required. See tcx for more details on TCX programs.
+    
+    
+    When set to UProbe, the program can attach in user-space. The UProbe is
+    attached to a binary, library or function name, and optionally an offset in
+    the code. When using the UProbe program type, the uprobe field is required.
+    See uprobe for more details on UProbe programs.
+    
+    
+    When set to URetProbe, the program can attach in user-space.
+    The URetProbe is attached to the return of a binary, library or function
+    name, and optionally an offset in the code.  When using the URetProbe
+    program type, the uretprobe field is required. See uretprobe for more
+    details on URetProbe programs.
+    
+    
+    When set to XDP, the eBPF program can attach to network devices (interfaces)
+    and will be called on every incoming packet received by the network device.
+    When using the XDP program type, the xdp field is required. See xdp for more
+    details on XDP programs.
+
+  uprobe	<Object>
+    uprobe is an optional field, but required when the type field is set to
+    UProbe. uprobe defines the desired state of the application's UProbe
+    programs. UProbe programs are user-space probes. A target must be provided,
+    which is the library name or absolute path to a binary or library where the
+    probe is attached. Optionally, a function name can also be provided to
+    provide finer granularity on where the probe is attached. They can be
+    attached at any point in the binary, library or function using the optional
+    offset field. However, caution must be taken when using the offset, ensuring
+    the offset is still in the desired bytecode.
+
+  uretprobe	<Object>
+    uretprobe is an optional field, but required when the type field is set to
+    URetProbe. uretprobe defines the desired state of the application's
+    URetProbe programs. URetProbe programs are user-space probes. A target must
+    be provided, which is the library name or absolute path to a binary or
+    library where the probe is attached. Optionally, a function name can also be
+    provided to provide finer granularity on where the probe is attached. They
+    are attached to the return point of the binary, library or function, but can
+    be set anywhere using the optional offset field. However, caution must be
+    taken when using the offset, ensuring the offset is still in the desired
+    bytecode.
+
+  xdp	<Object>
+    xdp is an optional field, but required when the type field is set to XDP.
+    xdp defines the desired state of the application's XDP programs. XDP program
+    can be attached to network devices (interfaces) and will be called on every
+    incoming packet received by the network device. The XDP attachment point is
+    just after the packet has been received off the wire, but before the Linux
+    kernel has allocated an sk_buff, which is used to pass the packet through
+    the kernel networking stack.
+
+$ kubectl explain BpfApplication.spec.programs.tc
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: tc <Object>
+
+
+DESCRIPTION:
+    tc is an optional field, but required when the type field is set to TC. tc
+    defines the desired state of the application's TC programs. TC programs are
+    attached to network devices (interfaces). The program can be attached on
+    either packet ingress or egress, so the program will be called on every
+    incoming or outgoing packet seen by the network device. The TC attachment
+    point is in Linux's Traffic Control (tc) subsystem, which is after the
+    Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+    with enhanced performance and better support for running multiple programs
+    on a given network device. This makes TC useful for packet classification
+    actions.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    TC program should be attached. The TC program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TC program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TC program to be
+    attached or detached.
+    
+    
+    The attachment point for a TC program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TC program can also be installed into a set of network namespaces.
+
+$ kubectl explain BpfApplication.spec.programs.tc.links
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    TC program should be attached. The TC program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TC program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TC program to be
+    attached or detached.
+    
+    
+    The attachment point for a TC program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TC program can also be installed into a set of network namespaces.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is a required field and specifies the direction of traffic.
+    Allowed values are:
+       Ingress, Egress
+    
+    
+    When set to Ingress, the TC program is triggered when packets are received
+    by the interface.
+    
+    
+    When set to Egress, the TC program is triggered when packets are to be
+    transmitted by the interface.
+
+  interfaceSelector	<Object> -required-
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TC program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+
+  networkNamespaces	<Object> -required-
+    networkNamespaces is a required field that identifies the set of network
+    namespaces in which to attach the eBPF program.
+
+  priority	<integer>
+    priority is an optional field and determines the execution order of the TC
+    program relative to other TC programs attached to the same attachment point.
+    It must be a value between 0 and 1000, where lower values indicate higher
+    precedence. For TC programs on the same attachment point with the same
+    direction and priority, the most recently attached program has a lower
+    precedence. If not provided, priority will default to 1000.
+
+  proceedOn	<[]string>
+    proceedOn is an optional field and allows the user to call other TC programs
+    in a chain, or not call the next program in a chain based on the exit code
+    of a TC program. Allowed values, which are the possible exit codes from a TC
+    eBPF program, are:
+      UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+      Trap, DispatcherReturn
+    
+    
+    Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+    using the default values, if a TC program returns Pipe, the next TC
+    program in the chain will be called. If a TC program returns Stolen, the
+    next TC program in the chain will NOT be called.
+
+$ kubectl explain BpfApplication.spec.programs.tc.links.interfaceSelector
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfaceSelector <Object>
+
+
+DESCRIPTION:
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TC program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+    
+FIELDS:
+  interfaces	<[]string>
+    interfaces is an optional field and is a list of network interface names to
+    attach the eBPF program. The interface names in the list are case-sensitive.
+
+  interfacesDiscoveryConfig	<Object>
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+
+  primaryNodeInterface	<boolean>
+    primaryNodeInterface is and optional field and indicates to attach the eBPF
+    program to the primary interface on the Kubernetes node. Only 'true' is
+    accepted.
+
+$ kubectl explain BpfApplication.spec.programs.tc.links.interfaceSelector.interfacesDiscoveryConfig
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfacesDiscoveryConfig <Object>
+
+
+DESCRIPTION:
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+    
+FIELDS:
+  allowedInterfaces	<[]string>
+    allowedInterfaces is an optional field that contains a list of interface
+    names that are allowed to be discovered. If empty, the agent will fetch all
+    the interfaces in the system, excepting the ones listed in
+    excludeInterfaces. if non-empty, only entries in the list will be considered
+    for discovery. If an entry enclosed by slashes, such as `/br-/` or
+    `/veth*/`, then the entry is considered as a regular expression for
+    matching. Otherwise, the interface names in the list are case-sensitive.
+    This field is only taken into consideration if interfaceAutoDiscovery is set
+    to true.
+
+  excludeInterfaces	<[]string>
+    excludeInterfaces is an optional field that contains a list of interface
+    names that are excluded from interface discovery. The interface names in
+    the list are case-sensitive. By default, the list contains the loopback
+    interface, "lo". This field is only taken into consideration if
+    interfaceAutoDiscovery is set to true.
+
+  interfaceAutoDiscovery	<boolean>
+    interfaceAutoDiscovery is an optional field. When enabled, the agent
+    monitors the creation and deletion of interfaces and automatically
+    attached eBPF programs to the newly discovered interfaces.
+    CAUTION: This has the potential to attach a given eBPF program to a large
+    number of interfaces. Use with caution.
+
+$ kubectl explain BpfApplication.spec.programs.tc.links.networkNamespaces
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: networkNamespaces <Object>
+
+
+DESCRIPTION:
+    networkNamespaces is a required field that identifies the set of network
+    namespaces in which to attach the eBPF program.
+    
+FIELDS:
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain BpfApplication.spec.programs.tc.links.networkNamespaces.pods
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.programs.tc.links.networkNamespaces.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.spec.programs.tcx
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: tcx <Object>
+
+
+DESCRIPTION:
+    tcx is an optional field, but required when the type field is set to TCX.
+    tcx defines the desired state of the application's TCX programs. TCX
+    programs are attached to network devices (interfaces). The program can be
+    attached on either packet ingress or egress, so the program will be called
+    on every incoming or outgoing packet seen by the network device. The TCX
+    attachment point is in Linux's Traffic Control (tc) subsystem, which is
+    after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+    packet classification actions. TCX is a newer implementation of TC with
+    enhanced performance and better support for running multiple programs on a
+    given network device.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    TCX program should be attached. The TCX program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TCX program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TCX program to be
+    attached or detached.
+    
+    
+    The attachment point for a TCX program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TCX program can also be installed into a set of network namespaces.
+
+$ kubectl explain BpfApplication.spec.programs.tcx.links
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    TCX program should be attached. The TCX program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TCX program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TCX program to be
+    attached or detached.
+    
+    
+    The attachment point for a TCX program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TCX program can also be installed into a set of network namespaces.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is a required field and specifies the direction of traffic.
+    Allowed values are:
+       Ingress, Egress
+    
+    
+    When set to Ingress, the TC program is triggered when packets are received
+    by the interface.
+    
+    
+    When set to Egress, the TC program is triggered when packets are to be
+    transmitted by the interface.
+
+  interfaceSelector	<Object> -required-
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TCX program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+
+  networkNamespaces	<Object> -required-
+    networkNamespaces is a required field that identifies the set of network
+    namespaces in which to attach the eBPF program.
+
+  priority	<integer>
+    priority is an optional field and determines the execution order of the TCX
+    program relative to other TCX programs attached to the same attachment
+    point. It must be a value between 0 and 1000, where lower values indicate
+    higher precedence. For TCX programs on the same attachment point with the
+    same direction and priority, the most recently attached program has a lower
+    precedence. If not provided, priority will default to 1000.
+
+$ kubectl explain BpfApplication.spec.programs.tcx.links.interfaceSelector
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfaceSelector <Object>
+
+
+DESCRIPTION:
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TCX program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+    
+FIELDS:
+  interfaces	<[]string>
+    interfaces is an optional field and is a list of network interface names to
+    attach the eBPF program. The interface names in the list are case-sensitive.
+
+  interfacesDiscoveryConfig	<Object>
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+
+  primaryNodeInterface	<boolean>
+    primaryNodeInterface is and optional field and indicates to attach the eBPF
+    program to the primary interface on the Kubernetes node. Only 'true' is
+    accepted.
+
+$ kubectl explain BpfApplication.spec.programs.tcx.links.interfaceSelector.interfacesDiscoveryConfig
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfacesDiscoveryConfig <Object>
+
+
+DESCRIPTION:
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+    
+FIELDS:
+  allowedInterfaces	<[]string>
+    allowedInterfaces is an optional field that contains a list of interface
+    names that are allowed to be discovered. If empty, the agent will fetch all
+    the interfaces in the system, excepting the ones listed in
+    excludeInterfaces. if non-empty, only entries in the list will be considered
+    for discovery. If an entry enclosed by slashes, such as `/br-/` or
+    `/veth*/`, then the entry is considered as a regular expression for
+    matching. Otherwise, the interface names in the list are case-sensitive.
+    This field is only taken into consideration if interfaceAutoDiscovery is set
+    to true.
+
+  excludeInterfaces	<[]string>
+    excludeInterfaces is an optional field that contains a list of interface
+    names that are excluded from interface discovery. The interface names in
+    the list are case-sensitive. By default, the list contains the loopback
+    interface, "lo". This field is only taken into consideration if
+    interfaceAutoDiscovery is set to true.
+
+  interfaceAutoDiscovery	<boolean>
+    interfaceAutoDiscovery is an optional field. When enabled, the agent
+    monitors the creation and deletion of interfaces and automatically
+    attached eBPF programs to the newly discovered interfaces.
+    CAUTION: This has the potential to attach a given eBPF program to a large
+    number of interfaces. Use with caution.
+
+$ kubectl explain BpfApplication.spec.programs.tcx.links.networkNamespaces
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: networkNamespaces <Object>
+
+
+DESCRIPTION:
+    networkNamespaces is a required field that identifies the set of network
+    namespaces in which to attach the eBPF program.
+    
+FIELDS:
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain BpfApplication.spec.programs.tcx.links.networkNamespaces.pods
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.programs.tcx.links.networkNamespaces.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.spec.programs.uprobe
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: uprobe <Object>
+
+
+DESCRIPTION:
+    uprobe is an optional field, but required when the type field is set to
+    UProbe. uprobe defines the desired state of the application's UProbe
+    programs. UProbe programs are user-space probes. A target must be provided,
+    which is the library name or absolute path to a binary or library where the
+    probe is attached. Optionally, a function name can also be provided to
+    provide finer granularity on where the probe is attached. They can be
+    attached at any point in the binary, library or function using the optional
+    offset field. However, caution must be taken when using the offset, ensuring
+    the offset is still in the desired bytecode.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+
+$ kubectl explain BpfApplication.spec.programs.uprobe.links
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+    
+FIELDS:
+  containers	<Object> -required-
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+    uprobe.
+
+  function	<string>
+    function is an optional field and specifies the name of a user-space
+    function
+    to attach the UProbe or URetProbe program. If not provided, the eBPF program
+    will be triggered on the entry of the target. function must not be an empty
+    string, must not exceed 64 characters in length, must start with alpha
+    characters and must only contain alphanumeric characters.
+
+  offset	<integer>
+    offset is an optional field and the value is added to the address of the
+    attachment point function. If not provided, offset defaults to 0.
+
+  pid	<integer>
+    pid is an optional field and if provided, limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  target	<string> -required-
+    target is a required field and is the user-space library name or the
+    absolute path to a binary or library.
+
+$ kubectl explain BpfApplication.spec.programs.uprobe.links.containers
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: containers <Object>
+
+
+DESCRIPTION:
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+    uprobe.
+    
+FIELDS:
+  containerNames	<[]string>
+    containerNames is an optional field and is a list of container names in a
+    pod to attach the eBPF program. If no names are  specified, all containers
+    in the pod are selected.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain BpfApplication.spec.programs.uprobe.links.containers.pods
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.programs.uprobe.links.containers.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.spec.programs.uretprobe
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: uretprobe <Object>
+
+
+DESCRIPTION:
+    uretprobe is an optional field, but required when the type field is set to
+    URetProbe. uretprobe defines the desired state of the application's
+    URetProbe programs. URetProbe programs are user-space probes. A target must
+    be provided, which is the library name or absolute path to a binary or
+    library where the probe is attached. Optionally, a function name can also be
+    provided to provide finer granularity on where the probe is attached. They
+    are attached to the return point of the binary, library or function, but can
+    be set anywhere using the optional offset field. However, caution must be
+    taken when using the offset, ensuring the offset is still in the desired
+    bytecode.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+
+$ kubectl explain BpfApplication.spec.programs.uretprobe.links
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+    
+FIELDS:
+  containers	<Object> -required-
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+    uprobe.
+
+  function	<string>
+    function is an optional field and specifies the name of a user-space
+    function
+    to attach the UProbe or URetProbe program. If not provided, the eBPF program
+    will be triggered on the entry of the target. function must not be an empty
+    string, must not exceed 64 characters in length, must start with alpha
+    characters and must only contain alphanumeric characters.
+
+  offset	<integer>
+    offset is an optional field and the value is added to the address of the
+    attachment point function. If not provided, offset defaults to 0.
+
+  pid	<integer>
+    pid is an optional field and if provided, limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  target	<string> -required-
+    target is a required field and is the user-space library name or the
+    absolute path to a binary or library.
+
+$ kubectl explain BpfApplication.spec.programs.uretprobe.links.containers
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: containers <Object>
+
+
+DESCRIPTION:
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+    uprobe.
+    
+FIELDS:
+  containerNames	<[]string>
+    containerNames is an optional field and is a list of container names in a
+    pod to attach the eBPF program. If no names are  specified, all containers
+    in the pod are selected.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain BpfApplication.spec.programs.uretprobe.links.containers.pods
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.programs.uretprobe.links.containers.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.spec.programs.xdp
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: xdp <Object>
+
+
+DESCRIPTION:
+    xdp is an optional field, but required when the type field is set to XDP.
+    xdp defines the desired state of the application's XDP programs. XDP program
+    can be attached to network devices (interfaces) and will be called on every
+    incoming packet received by the network device. The XDP attachment point is
+    just after the packet has been received off the wire, but before the Linux
+    kernel has allocated an sk_buff, which is used to pass the packet through
+    the kernel networking stack.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    XDP program should be attached. The XDP program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The XDP program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the XDP program to be
+    attached or detached.
+    
+    
+    The attachment point for a XDP program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node.
+
+$ kubectl explain BpfApplication.spec.programs.xdp.links
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    XDP program should be attached. The XDP program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The XDP program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the XDP program to be
+    attached or detached.
+    
+    
+    The attachment point for a XDP program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node.
+    
+FIELDS:
+  interfaceSelector	<Object> -required-
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the XDP program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+
+  networkNamespaces	<Object> -required-
+    networkNamespaces is a required field that identifies the set of network
+    namespaces in which to attach the eBPF program.
+
+  priority	<integer>
+    priority is an optional field and determines the execution order of the XDP
+    program relative to other XDP programs attached to the same attachment
+    point. It must be a value between 0 and 1000, where lower values indicate
+    higher precedence. For XDP programs on the same attachment point with the
+    same priority, the most recently attached program has a lower precedence.
+    If not provided, priority will default to 1000.
+
+  proceedOn	<[]string>
+    proceedOn is an optional field and allows the user to call other XDP
+    programs in a chain, or not call the next program in a chain based on the
+    exit code of an XDP program. Allowed values, which are the possible exit
+    codes from an XDP eBPF program, are:
+      Aborted, Drop, Pass, TX, ReDirect,DispatcherReturn
+    
+    
+    Multiple values are supported. Default is Pass and DispatcherReturn. So
+    using the default values, if an XDP program returns Pass, the next XDP
+    program in the chain will be called. If an XDP program returns Drop, the
+    next XDP program in the chain will NOT be called.
+
+$ kubectl explain BpfApplication.spec.programs.xdp.links.interfaceSelector
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfaceSelector <Object>
+
+
+DESCRIPTION:
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the XDP program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+    
+FIELDS:
+  interfaces	<[]string>
+    interfaces is an optional field and is a list of network interface names to
+    attach the eBPF program. The interface names in the list are case-sensitive.
+
+  interfacesDiscoveryConfig	<Object>
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+
+  primaryNodeInterface	<boolean>
+    primaryNodeInterface is and optional field and indicates to attach the eBPF
+    program to the primary interface on the Kubernetes node. Only 'true' is
+    accepted.
+
+$ kubectl explain BpfApplication.spec.programs.xdp.links.interfaceSelector.interfacesDiscoveryConfig
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfacesDiscoveryConfig <Object>
+
+
+DESCRIPTION:
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+    
+FIELDS:
+  allowedInterfaces	<[]string>
+    allowedInterfaces is an optional field that contains a list of interface
+    names that are allowed to be discovered. If empty, the agent will fetch all
+    the interfaces in the system, excepting the ones listed in
+    excludeInterfaces. if non-empty, only entries in the list will be considered
+    for discovery. If an entry enclosed by slashes, such as `/br-/` or
+    `/veth*/`, then the entry is considered as a regular expression for
+    matching. Otherwise, the interface names in the list are case-sensitive.
+    This field is only taken into consideration if interfaceAutoDiscovery is set
+    to true.
+
+  excludeInterfaces	<[]string>
+    excludeInterfaces is an optional field that contains a list of interface
+    names that are excluded from interface discovery. The interface names in
+    the list are case-sensitive. By default, the list contains the loopback
+    interface, "lo". This field is only taken into consideration if
+    interfaceAutoDiscovery is set to true.
+
+  interfaceAutoDiscovery	<boolean>
+    interfaceAutoDiscovery is an optional field. When enabled, the agent
+    monitors the creation and deletion of interfaces and automatically
+    attached eBPF programs to the newly discovered interfaces.
+    CAUTION: This has the potential to attach a given eBPF program to a large
+    number of interfaces. Use with caution.
+
+$ kubectl explain BpfApplication.spec.programs.xdp.links.networkNamespaces
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: networkNamespaces <Object>
+
+
+DESCRIPTION:
+    networkNamespaces is a required field that identifies the set of network
+    namespaces in which to attach the eBPF program.
+    
+FIELDS:
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain BpfApplication.spec.programs.xdp.links.networkNamespaces.pods
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain BpfApplication.spec.programs.xdp.links.networkNamespaces.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain BpfApplication.status
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: status <Object>
+
+
+DESCRIPTION:
+    status reflects the status of a BPF Application and indicates if all the
+    eBPF programs for a given instance loaded successfully or not.
+    
+FIELDS:
+  conditions	<[]Object>
+    conditions contains the summary state for all eBPF programs defined in the
+    BPF Application instance for all the Kubernetes nodes in the cluster.
+
+$ kubectl explain BpfApplication.status.conditions
+GROUP:      bpfman.io
+KIND:       BpfApplication
+VERSION:    v1alpha1
+
+FIELD: conditions <[]Object>
+
+
+DESCRIPTION:
+    conditions contains the summary state for all eBPF programs defined in the
+    BPF Application instance for all the Kubernetes nodes in the cluster.
+    Condition contains details for one aspect of the current state of this API
+    Resource.
+    ---
+    This struct is intended for direct use as an array at the field path
+    .status.conditions.  For example,
+    
+    
+    	type FooStatus struct{
+    	    // Represents the observations of a foo's current state.
+    	    // Known .status.conditions.type are: "Available", "Progressing", and
+    "Degraded"
+    	    // +patchMergeKey=type
+    	    // +patchStrategy=merge
+    	    // +listType=map
+    	    // +listMapKey=type
+    	    Conditions []metav1.Condition `json:"conditions,omitempty"
+    patchStrategy:"merge" patchMergeKey:"type"
+    protobuf:"bytes,1,rep,name=conditions"`
+    
+    
+    	    // other fields
+    	}
+    
+FIELDS:
+  lastTransitionTime	<string> -required-
+    lastTransitionTime is the last time the condition transitioned from one
+    status to another.
+    This should be when the underlying condition changed.  If that is not known,
+    then using the time when the API field changed is acceptable.
+
+  message	<string> -required-
+    message is a human readable message indicating details about the transition.
+    This may be an empty string.
+
+  observedGeneration	<integer>
+    observedGeneration represents the .metadata.generation that the condition
+    was set based upon.
+    For instance, if .metadata.generation is currently 12, but the
+    .status.conditions[x].observedGeneration is 9, the condition is out of date
+    with respect to the current state of the instance.
+
+  reason	<string> -required-
+    reason contains a programmatic identifier indicating the reason for the
+    condition's last transition.
+    Producers of specific condition types may define expected values and
+    meanings for this field,
+    and whether the values are considered a guaranteed API.
+    The value should be a CamelCase string.
+    This field may not be empty.
+
+  status	<string> -required-
+  enum: True, False, Unknown
+    status of the condition, one of True, False, Unknown.
+
+  type	<string> -required-
+    type of condition in CamelCase or in foo.example.com/CamelCase.
+    ---
+    Many .condition.type values are consistent across resources like Available,
+    but because arbitrary conditions can be
+    useful (see .node.status.conditions), the ability to deconflict is
+    important.
+    The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+

--- a/docs/crds/BpfApplicationState.txt
+++ b/docs/crds/BpfApplicationState.txt
@@ -1,0 +1,592 @@
+$ kubectl explain BpfApplicationState
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+DESCRIPTION:
+    BpfApplicationState contains the state of a BpfApplication instance for a
+    given Kubernetes node. When a user creates a BpfApplication instance, bpfman
+    creates a BpfApplicationState instance for each node in a Kubernetes
+    cluster.
+    
+FIELDS:
+  apiVersion	<string>
+    APIVersion defines the versioned schema of this representation of an object.
+    Servers should convert recognized schemas to the latest internal value, and
+    may reject unrecognized values. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+  kind	<string>
+    Kind is a string value representing the REST resource this object
+    represents. Servers may infer this from the endpoint the client submits
+    requests to. Cannot be updated. In CamelCase. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+  metadata	<ObjectMeta>
+    Standard object's metadata. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  status	<Object>
+    status reflects the status of a BpfApplication instance for the given node.
+    appLoadStatus and conditions provide an overall status for the given node,
+    while each item in the programs list provides a per eBPF program status for
+    the given node.
+
+$ kubectl explain BpfApplicationState.status
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: status <Object>
+
+
+DESCRIPTION:
+    status reflects the status of a BpfApplication instance for the given node.
+    appLoadStatus and conditions provide an overall status for the given node,
+    while each item in the programs list provides a per eBPF program status for
+    the given node.
+    
+FIELDS:
+  appLoadStatus	<string> -required-
+    appLoadStatus reflects the status of loading the eBPF application on the
+    given node.
+    
+    
+    NotLoaded is a temporary state that is assigned when a
+    ClusterBpfApplicationState is created and the initial reconcile is being
+    processed.
+    
+    
+    LoadSuccess is returned if all the programs have been loaded with no
+    errors.
+    
+    
+    LoadError is returned if one or more programs encountered an error and
+    were not loaded.
+    
+    
+    NotSelected is returned if this application did not select to run on this
+    Kubernetes node.
+    
+    
+    UnloadSuccess is returned when all the programs were successfully
+    unloaded.
+    
+    
+    UnloadError is returned if one or more programs encountered an error when
+    being unloaded.
+
+  conditions	<[]Object>
+    conditions contains the summary state of the BpfApplication for the given
+    Kubernetes node. If one or more programs failed to load or attach to the
+    designated attachment point, the condition will report the error. If more
+    than one error has occurred, condition will contain the first error
+    encountered.
+
+  node	<string> -required-
+    node is the name of the Kubernets node for this BpfApplicationState.
+
+  programs	<[]Object>
+    programs is a list of eBPF programs contained in the parent BpfApplication
+    instance. Each entry in the list contains the derived program attributes as
+    well as the attach status for each program on the given Kubernetes node.
+
+  updateCount	<integer> -required-
+    UpdateCount tracks the number of times the BpfApplicationState object has
+    been updated. The bpfman agent initializes it to 1 when it creates the
+    object, and then increments it before each subsequent update. It serves
+    as a lightweight sequence number to verify that the API server is serving
+    the most recent version of the object before beginning a new Reconcile
+    operation.
+
+$ kubectl explain BpfApplicationState.status.conditions
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: conditions <[]Object>
+
+
+DESCRIPTION:
+    conditions contains the summary state of the BpfApplication for the given
+    Kubernetes node. If one or more programs failed to load or attach to the
+    designated attachment point, the condition will report the error. If more
+    than one error has occurred, condition will contain the first error
+    encountered.
+    Condition contains details for one aspect of the current state of this API
+    Resource.
+    ---
+    This struct is intended for direct use as an array at the field path
+    .status.conditions.  For example,
+    
+    
+    	type FooStatus struct{
+    	    // Represents the observations of a foo's current state.
+    	    // Known .status.conditions.type are: "Available", "Progressing", and
+    "Degraded"
+    	    // +patchMergeKey=type
+    	    // +patchStrategy=merge
+    	    // +listType=map
+    	    // +listMapKey=type
+    	    Conditions []metav1.Condition `json:"conditions,omitempty"
+    patchStrategy:"merge" patchMergeKey:"type"
+    protobuf:"bytes,1,rep,name=conditions"`
+    
+    
+    	    // other fields
+    	}
+    
+FIELDS:
+  lastTransitionTime	<string> -required-
+    lastTransitionTime is the last time the condition transitioned from one
+    status to another.
+    This should be when the underlying condition changed.  If that is not known,
+    then using the time when the API field changed is acceptable.
+
+  message	<string> -required-
+    message is a human readable message indicating details about the transition.
+    This may be an empty string.
+
+  observedGeneration	<integer>
+    observedGeneration represents the .metadata.generation that the condition
+    was set based upon.
+    For instance, if .metadata.generation is currently 12, but the
+    .status.conditions[x].observedGeneration is 9, the condition is out of date
+    with respect to the current state of the instance.
+
+  reason	<string> -required-
+    reason contains a programmatic identifier indicating the reason for the
+    condition's last transition.
+    Producers of specific condition types may define expected values and
+    meanings for this field,
+    and whether the values are considered a guaranteed API.
+    The value should be a CamelCase string.
+    This field may not be empty.
+
+  status	<string> -required-
+  enum: True, False, Unknown
+    status of the condition, one of True, False, Unknown.
+
+  type	<string> -required-
+    type of condition in CamelCase or in foo.example.com/CamelCase.
+    ---
+    Many .condition.type values are consistent across resources like Available,
+    but because arbitrary conditions can be
+    useful (see .node.status.conditions), the ability to deconflict is
+    important.
+    The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+
+$ kubectl explain BpfApplicationState.status.programs
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: programs <[]Object>
+
+
+DESCRIPTION:
+    programs is a list of eBPF programs contained in the parent BpfApplication
+    instance. Each entry in the list contains the derived program attributes as
+    well as the attach status for each program on the given Kubernetes node.
+    
+FIELDS:
+  name	<string> -required-
+    name is the name of the function that is the entry point for the eBPF
+    program
+
+  programId	<integer>
+    programId is the id of the program in the kernel.  Not set until the
+    program is loaded.
+
+  programLinkStatus	<string> -required-
+    programLinkStatus reflects whether all links requested for the program
+    are in the correct state.
+
+  tc	<Object>
+    tc contains the attachment data for a TC program when type is set to TC.
+
+  tcx	<Object>
+    tcx contains the attachment data for a TCX program when type is set to TCX.
+
+  type	<string> -required-
+  enum: XDP, TC, TCX, UProbe, ....
+    type specifies the provisioned eBPF program type for this program entry.
+    Type will be one of:
+      TC, TCX, UProbe, URetProbe, XDP
+    
+    
+    When set to TC, the tc object will be populated with the eBPF program data
+    associated with a TC program.
+    
+    
+    When set to TCX, the tcx object will be populated with the eBPF program
+    data associated with a TCX program.
+    
+    
+    When set to UProbe, the uprobe object will be populated with the eBPF
+    program data associated with a UProbe program.
+    
+    
+    When set to URetProbe, the uretprobe object will be populated with the eBPF
+    program data associated with a URetProbe program.
+    
+    
+    When set to XDP, the xdp object will be populated with the eBPF program data
+    associated with a URetProbe program.
+
+  uprobe	<Object>
+    uprobe contains the attachment data for a UProbe program when type is set to
+    UProbe.
+
+  uretprobe	<Object>
+    uretprobe contains the attachment data for a URetProbe program when type is
+    set to URetProbe.
+
+  xdp	<Object>
+    xdp contains the attachment data for an XDP program when type is set to XDP.
+
+$ kubectl explain BpfApplicationState.status.programs.tc
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: tc <Object>
+
+
+DESCRIPTION:
+    tc contains the attachment data for a TC program when type is set to TC.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the TC program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain BpfApplicationState.status.programs.tc.links
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the TC program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is the provisioned direction of traffic, Ingress or Egress, the TC
+    program should be attached for a given network device.
+
+  interfaceName	<string> -required-
+    interfaceName is the name of the interface the TC program should be
+    attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  netnsPath	<string> -required-
+    netnsPath is the path to the network namespace inside of which the TC
+    program should be attached.
+
+  priority	<integer> -required-
+    priority is the provisioned priority of the TC program in relation to other
+    programs of the same type with the same attach point. It is a value from 0
+    to 1000, where lower values have higher precedence.
+
+  proceedOn	<[]string> -required-
+    proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+    user to call other TC programs in a chain, or not call the next program in a
+    chain based on the exit code of a TC program .Multiple values are supported.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain BpfApplicationState.status.programs.tcx
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: tcx <Object>
+
+
+DESCRIPTION:
+    tcx contains the attachment data for a TCX program when type is set to TCX.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the TCX program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain BpfApplicationState.status.programs.tcx.links
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the TCX program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is the provisioned direction of traffic, Ingress or Egress, the
+    TCX program should be attached for a given network device.
+
+  interfaceName	<string> -required-
+    interfaceName is the name of the interface the TCX program should be
+    attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  netnsPath	<string> -required-
+    netnsPath is the path to the network namespace inside of which the TCX
+    program should be attached.
+
+  priority	<integer> -required-
+    priority is the provisioned priority of the TCX program in relation to other
+    programs of the same type with the same attach point. It is a value from 0
+    to 1000, where lower values have higher precedence.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain BpfApplicationState.status.programs.uprobe
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: uprobe <Object>
+
+
+DESCRIPTION:
+    uprobe contains the attachment data for a UProbe program when type is set to
+    UProbe.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain BpfApplicationState.status.programs.uprobe.links
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  containerPid	<integer>
+    If containers is provisioned in the BpfApplication instance, containerPid is
+    the derived PID of the container the UProbe or URetProbe this attachment
+    point is attached.
+
+  function	<string>
+    function is the provisioned name of the user-space function the UProbe
+    program should be attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  offset	<integer>
+    offset is the provisioned offset, whose value is added to the address of the
+    attachment point function.
+
+  pid	<integer>
+    pid is the provisioned pid. If set, pid limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  target	<string> -required-
+    target is the provisioned user-space library name or the absolute path to a
+    binary or library.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain BpfApplicationState.status.programs.uretprobe
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: uretprobe <Object>
+
+
+DESCRIPTION:
+    uretprobe contains the attachment data for a URetProbe program when type is
+    set to URetProbe.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain BpfApplicationState.status.programs.uretprobe.links
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  containerPid	<integer>
+    If containers is provisioned in the BpfApplication instance, containerPid is
+    the derived PID of the container the UProbe or URetProbe this attachment
+    point is attached.
+
+  function	<string>
+    function is the provisioned name of the user-space function the UProbe
+    program should be attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  offset	<integer>
+    offset is the provisioned offset, whose value is added to the address of the
+    attachment point function.
+
+  pid	<integer>
+    pid is the provisioned pid. If set, pid limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  target	<string> -required-
+    target is the provisioned user-space library name or the absolute path to a
+    binary or library.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain BpfApplicationState.status.programs.xdp
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: xdp <Object>
+
+
+DESCRIPTION:
+    xdp contains the attachment data for an XDP program when type is set to XDP.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the XDP program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain BpfApplicationState.status.programs.xdp.links
+GROUP:      bpfman.io
+KIND:       BpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the XDP program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  interfaceName	<string> -required-
+    interfaceName is the name of the interface the XDP program should be
+    attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  netnsPath	<string> -required-
+    netnsPath is the path to the network namespace inside of which the XDP
+    program should be attached.
+
+  priority	<integer> -required-
+    priority is the provisioned priority of the XDP program in relation to other
+    programs of the same type with the same attach point. It is a value from 0
+    to 1000, where lower values have higher precedence.
+
+  proceedOn	<[]string> -required-
+    proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+    user to call other TC programs in a chain, or not call the next program in a
+    chain based on the exit code of a TC program .Multiple values are supported.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+

--- a/docs/crds/ClusterBpfApplication.txt
+++ b/docs/crds/ClusterBpfApplication.txt
@@ -1,0 +1,1982 @@
+$ kubectl explain ClusterBpfApplication
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+DESCRIPTION:
+    ClusterBpfApplication is the schema for the cluster scoped BPF Applications
+    API. This API allows applications to use bpfman to load and attach one or
+    more eBPF programs on a Kubernetes cluster.
+    
+    
+    The clusterBpfApplication.status field reports the overall status of the
+    ClusterBpfApplication CRD. A given ClusterBpfApplication CRD can result in
+    loading and attaching multiple eBPF programs on multiple nodes, so this
+    status is just a summary. More granular per-node status details can be
+    found in the corresponding ClusterBpfApplicationState CRD that bpfman
+    creates for each node.
+    
+FIELDS:
+  apiVersion	<string>
+    APIVersion defines the versioned schema of this representation of an object.
+    Servers should convert recognized schemas to the latest internal value, and
+    may reject unrecognized values. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+  kind	<string>
+    Kind is a string value representing the REST resource this object
+    represents. Servers may infer this from the endpoint the client submits
+    requests to. Cannot be updated. In CamelCase. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+  metadata	<ObjectMeta>
+    Standard object's metadata. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  spec	<Object>
+    spec defines the desired state of the ClusterBpfApplication. The
+    ClusterBpfApplication describes the set of one or more cluster scoped eBPF
+    programs that should be loaded for a given application and attributes for
+    how they should be loaded. eBPF programs that are grouped together under the
+    same ClusterBpfApplication instance can share maps and global data between
+    the eBPF programs loaded on the same Kubernetes Node.
+
+  status	<Object>
+    status reflects the status of a BPF Application and indicates if all the
+    eBPF programs for a given instance loaded successfully or not.
+
+$ kubectl explain ClusterBpfApplication.spec
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: spec <Object>
+
+
+DESCRIPTION:
+    spec defines the desired state of the ClusterBpfApplication. The
+    ClusterBpfApplication describes the set of one or more cluster scoped eBPF
+    programs that should be loaded for a given application and attributes for
+    how they should be loaded. eBPF programs that are grouped together under the
+    same ClusterBpfApplication instance can share maps and global data between
+    the eBPF programs loaded on the same Kubernetes Node.
+    
+FIELDS:
+  byteCode	<Object> -required-
+    bytecode is a required field and configures where the eBPF program's
+    bytecode should be loaded from. The image must contain one or more
+    eBPF programs.
+
+  globalData	<map[string]string>
+    globalData is an optional field that allows the user to set global variables
+    when the program is loaded. This allows the same compiled bytecode to be
+    deployed by different BPF Applications to behave differently based on
+    globalData configuration values.  It uses an array of raw bytes. This is a
+    very low level primitive. The caller is responsible for formatting the byte
+    string appropriately considering such things as size, endianness, alignment
+    and packing of data structures.
+
+  mapOwnerSelector	<Object>
+    mapOwnerSelector is an optional field used to share maps across
+    applications. eBPF programs loaded with the same ClusterBpfApplication or
+    BpfApplication instance do not need to use this field. This label selector
+    allows maps from a different ClusterBpfApplication or BpfApplication
+    instance to be used by this instance.
+    TODO: mapOwnerSelector is currently not supported due to recent code rework.
+
+  nodeSelector	<Object> -required-
+    nodeSelector is a required field and allows the user to specify which
+    Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+    standard metav1.LabelSelector semantics and make it empty.
+
+  programs	<[]Object> -required-
+    programs is a required field and is the list of eBPF programs in a BPF
+    Application CRD that should be loaded in kernel memory. At least one entry
+    is required. eBPF programs in this list will be loaded on the system based
+    the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+    cannot be triggered until an attachment point is provided. The different
+    program types have different ways of attaching. The attachment points can be
+    added at creation time or modified (added or removed) at a later time to
+    activate or deactivate the eBPF program as desired.
+    CAUTION: When programs are added or removed from the list, that requires all
+    programs in the list to be reloaded, which could be temporarily service
+    effecting. For this reason, modifying the list is currently not allowed.
+
+$ kubectl explain ClusterBpfApplication.spec.byteCode
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: byteCode <Object>
+
+
+DESCRIPTION:
+    bytecode is a required field and configures where the eBPF program's
+    bytecode should be loaded from. The image must contain one or more
+    eBPF programs.
+    
+FIELDS:
+  image	<Object>
+    image is an optional field and used to specify details on how to retrieve an
+    eBPF program packaged in a OCI container image from a given registry.
+
+  path	<string>
+    path is an optional field and used to specify a bytecode object file via
+    filepath on a Kubernetes node.
+
+$ kubectl explain ClusterBpfApplication.spec.byteCode.image
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: image <Object>
+
+
+DESCRIPTION:
+    image is an optional field and used to specify details on how to retrieve an
+    eBPF program packaged in a OCI container image from a given registry.
+    
+FIELDS:
+  imagePullPolicy	<string>
+  enum: Always, Never, IfNotPresent
+    pullPolicy is an optional field that describes a policy for if/when to pull
+    a bytecode image. Defaults to IfNotPresent. Allowed values are:
+      Always, IfNotPresent and Never
+    
+    
+    When set to Always, the given image will be pulled even if the image is
+    already present on the node.
+    
+    
+    When set to IfNotPresent, the given image will only be pulled if it is not
+    present on the node.
+    
+    
+    When set to Never, the given image will never be pulled and must be
+    loaded on the node by some other means.
+
+  imagePullSecret	<Object>
+    imagePullSecret is an optional field and indicates the secret which contains
+    the credentials to access the image repository.
+
+  url	<string> -required-
+    url is a required field and is a valid container image URL used to reference
+    a remote bytecode image. url must not be an empty string, must not exceed
+    525 characters in length and must be a valid URL.
+
+$ kubectl explain ClusterBpfApplication.spec.byteCode.image.imagePullSecret
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: imagePullSecret <Object>
+
+
+DESCRIPTION:
+    imagePullSecret is an optional field and indicates the secret which contains
+    the credentials to access the image repository.
+    
+FIELDS:
+  name	<string> -required-
+    name is a required field and is the name of the secret which contains the
+    credentials to access the image repository.
+
+  namespace	<string> -required-
+    namespace is a required field and is the namespace of the secret which
+    contains the credentials to access the image repository.
+
+$ kubectl explain ClusterBpfApplication.spec.mapOwnerSelector
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: mapOwnerSelector <Object>
+
+
+DESCRIPTION:
+    mapOwnerSelector is an optional field used to share maps across
+    applications. eBPF programs loaded with the same ClusterBpfApplication or
+    BpfApplication instance do not need to use this field. This label selector
+    allows maps from a different ClusterBpfApplication or BpfApplication
+    instance to be used by this instance.
+    TODO: mapOwnerSelector is currently not supported due to recent code rework.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.mapOwnerSelector.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.spec.nodeSelector
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: nodeSelector <Object>
+
+
+DESCRIPTION:
+    nodeSelector is a required field and allows the user to specify which
+    Kubernetes nodes to deploy the eBPF programs. To select all nodes use
+    standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.nodeSelector.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.spec.programs
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: programs <[]Object>
+
+
+DESCRIPTION:
+    programs is a required field and is the list of eBPF programs in a BPF
+    Application CRD that should be loaded in kernel memory. At least one entry
+    is required. eBPF programs in this list will be loaded on the system based
+    the nodeSelector. Even if an eBPF program is loaded in kernel memory, it
+    cannot be triggered until an attachment point is provided. The different
+    program types have different ways of attaching. The attachment points can be
+    added at creation time or modified (added or removed) at a later time to
+    activate or deactivate the eBPF program as desired.
+    CAUTION: When programs are added or removed from the list, that requires all
+    programs in the list to be reloaded, which could be temporarily service
+    effecting. For this reason, modifying the list is currently not allowed.
+    
+FIELDS:
+  fentry	<Object>
+    fentry is an optional field, but required when the type field is set to
+    FEntry. fentry defines the desired state of the application's FEntry
+    programs. FEntry programs are attached to the entry of a Linux kernel
+    function or to another eBPF program function. They are attached to the first
+    instruction, before control passes to the function. FEntry programs are
+    similar to KProbe programs, but have higher performance.
+
+  fexit	<Object>
+    fexit is an optional field, but required when the type field is set to
+    FExit. fexit defines the desired state of the application's FExit programs.
+    FExit programs are attached to the exit of a Linux kernel function or to
+    another eBPF program function. The program is invoked when the function
+    returns, independent of where in the function that occurs. FExit programs
+    are similar to KRetProbe programs, but get invoked with the input arguments
+    and the return values. They also have higher performance over KRetProbe
+    programs.
+
+  kprobe	<Object>
+    kprobe is an optional field, but required when the type field is set to
+    KProbe. kprobe defines the desired state of the application's Kprobe
+    programs. KProbe programs are attached to a Linux kernel function. Unlike
+    FEntry programs, which must always be attached at the entry point of a Linux
+    kernel function, KProbe programs can be attached at any point in the
+    function using the optional offset field. However, caution must be taken
+    when using the offset, ensuring the offset is still in the function
+    bytecode. FEntry programs have less overhead than KProbe programs.
+
+  kretprobe	<Object>
+    kretprobe is an optional field, but required when the type field is set to
+    KRetProbe. kretprobe defines the desired state of the application's
+    KRetProbe programs. KRetProbe programs are attached to the exit of a Linux
+    kernel function. FExit programs have less overhead than KRetProbe programs
+    and FExit programs have access to both the input arguments as well as the
+    return values. KRetProbes only have access to the return values.
+
+  name	<string> -required-
+    name is a required field and is the name of the function that is the entry
+    point for the eBPF program. name must not be an empty string, must not
+    exceed 64 characters in length, must start with alpha characters and must
+    only contain alphanumeric characters.
+
+  tc	<Object>
+    tc is an optional field, but required when the type field is set to TC. tc
+    defines the desired state of the application's TC programs. TC programs are
+    attached to network devices (interfaces). The program can be attached on
+    either packet ingress or egress, so the program will be called on every
+    incoming or outgoing packet seen by the network device. The TC attachment
+    point is in Linux's Traffic Control (tc) subsystem, which is after the
+    Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+    with enhanced performance and better support for running multiple programs
+    on a given network device. This makes TC useful for packet classification
+    actions.
+
+  tcx	<Object>
+    tcx is an optional field, but required when the type field is set to TCX.
+    tcx defines the desired state of the application's TCX programs. TCX
+    programs are attached to network devices (interfaces). The program can be
+    attached on either packet ingress or egress, so the program will be called
+    on every incoming or outgoing packet seen by the network device. The TCX
+    attachment point is in Linux's Traffic Control (tc) subsystem, which is
+    after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+    packet classification actions. TCX is a newer implementation of TC with
+    enhanced performance and better support for running multiple programs on a
+    given network device.
+
+  tracepoint	<Object>
+    tracepoint is an optional field, but required when the type field is set to
+    Tracepoint. tracepoint defines the desired state of the application's
+    Tracepoint programs. Whereas KProbes attach to dynamically to any Linux
+    kernel function, Tracepoint programs are programs that can only be attached
+    at predefined locations in the Linux kernel. Use the following command to
+    see the available attachment points:
+     `sudo find /sys/kernel/debug/tracing/events -type d`
+    While KProbes are more flexible in where in the kernel the probe can be
+    attached, the functions and data structure rely on the kernel your system is
+    running. Tracepoints tend to be more stable across kernel versions and are
+    better for portability.
+
+  type	<string> -required-
+  enum: XDP, TC, TCX, FEntry, ....
+    type is a required field used to specify the type of the eBPF program.
+    
+    
+    Allowed values are:
+      FEntry, FExit, KProbe, KRetProbe, TC, TCX, TracePoint, UProbe, URetProbe,
+      XDP
+    
+    
+    When set to FEntry, the program is attached to the entry of a Linux kernel
+    function or to another eBPF program function. When using the FEntry program
+    type, the fentry field is required. See fentry for more details on FEntry
+    programs.
+    
+    
+    When set to FExit, the program is attached to the exit of a Linux kernel
+    function or to another eBPF program function. When using the FExit program
+    type, the fexit field is required. See fexit for more details on FExit
+    programs.
+    
+    
+    When set to KProbe, the program is attached to entry of a Linux kernel
+    function. When using the KProbe program type, the kprobe field is required.
+    See kprobe for more details on KProbe programs.
+    
+    
+    When set to KRetProbe, the program is attached to exit of a Linux kernel
+    function. When using the KRetProbe program type, the kretprobe field is
+    required. See kretprobe for more details on KRetProbe programs.
+    
+    
+    When set to TC, the eBPF program can attach to network devices (interfaces).
+    The program can be attached on either packet ingress or egress, so the
+    program will be called on every incoming or outgoing packet seen by the
+    network device. When using the TC program type, the tc field is required.
+    See tc for more details on TC programs.
+    
+    
+    When set to TCX, the eBPF program can attach to network devices
+    (interfaces). The program can be attached on either packet ingress or
+    egress, so the program will be called on every incoming or outgoing packet
+    seen by the network device. When using the TCX program type, the tcx field
+    is required. See tcx for more details on TCX programs.
+    
+    
+    When set to Tracepoint, the program can attach to one of the predefined set
+    of Linux kernel functions. When using the Tracepoint program type, the
+    tracepoint field is required. See tracepoint for more details on Tracepoint
+    programs.
+    
+    
+    When set to UProbe, the program can attach in user-space. The UProbe is
+    attached to a binary, library or function name, and optionally an offset in
+    the code. When using the UProbe program type, the uprobe field is required.
+    See uprobe for more details on UProbe programs.
+    
+    
+    When set to URetProbe, the program can attach in user-space.
+    The URetProbe is attached to the return of a binary, library or function
+    name, and optionally an offset in the code.  When using the URetProbe
+    program type, the uretprobe field is required. See uretprobe for more
+    details on URetProbe programs.
+    
+    
+    When set to XDP, the eBPF program can attach to network devices (interfaces)
+    and will be called on every incoming packet received by the network device.
+    When using the XDP program type, the xdp field is required. See xdp for more
+    details on XDP programs.
+
+  uprobe	<Object>
+    uprobe is an optional field, but required when the type field is set to
+    UProbe. uprobe defines the desired state of the application's UProbe
+    programs. UProbe programs are user-space probes. A target must be provided,
+    which is the library name or absolute path to a binary or library where the
+    probe is attached. Optionally, a function name can also be provided to
+    provide finer granularity on where the probe is attached. They can be
+    attached at any point in the binary, library or function using the optional
+    offset field. However, caution must be taken when using the offset, ensuring
+    the offset is still in the desired bytecode.
+
+  uretprobe	<Object>
+    uretprobe is an optional field, but required when the type field is set to
+    URetProbe. uretprobe defines the desired state of the application's
+    URetProbe programs. URetProbe programs are user-space probes. A target must
+    be provided, which is the library name or absolute path to a binary or
+    library where the probe is attached. Optionally, a function name can also be
+    provided to provide finer granularity on where the probe is attached. They
+    are attached to the return point of the binary, library or function, but can
+    be set anywhere using the optional offset field. However, caution must be
+    taken when using the offset, ensuring the offset is still in the desired
+    bytecode.
+
+  xdp	<Object>
+    xdp is an optional field, but required when the type field is set to XDP.
+    xdp defines the desired state of the application's XDP programs. XDP program
+    can be attached to network devices (interfaces) and will be called on every
+    incoming packet received by the network device. The XDP attachment point is
+    just after the packet has been received off the wire, but before the Linux
+    kernel has allocated an sk_buff, which is used to pass the packet through
+    the kernel networking stack.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.fentry
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: fentry <Object>
+
+
+DESCRIPTION:
+    fentry is an optional field, but required when the type field is set to
+    FEntry. fentry defines the desired state of the application's FEntry
+    programs. FEntry programs are attached to the entry of a Linux kernel
+    function or to another eBPF program function. They are attached to the first
+    instruction, before control passes to the function. FEntry programs are
+    similar to KProbe programs, but have higher performance.
+    
+FIELDS:
+  function	<string> -required-
+    function is a required field and specifies the name of the Linux kernel
+    function to attach the FEntry program. function must not be an empty string,
+    must not exceed 64 characters in length, must start with alpha characters
+    and must only contain alphanumeric characters.
+
+  links	<[]Object>
+    links is an optional field and is a flag to indicate if the FEntry program
+    should be attached. The attachment point for a FEntry program is a Linux
+    kernel function. Unlike other eBPF program types, an FEntry program must be
+    provided with the target function at load time. The links field is optional,
+    but unlike other program types where it represents a list of attachment
+    points, for FEntry programs it contains at most one entry that determines
+    whether the program should be attached to the specified function. To attach
+    the program, add an entry to links with mode set to Attach. To detach it,
+    remove the entry from links.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.fentry.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is a flag to indicate if the FEntry program
+    should be attached. The attachment point for a FEntry program is a Linux
+    kernel function. Unlike other eBPF program types, an FEntry program must be
+    provided with the target function at load time. The links field is optional,
+    but unlike other program types where it represents a list of attachment
+    points, for FEntry programs it contains at most one entry that determines
+    whether the program should be attached to the specified function. To attach
+    the program, add an entry to links with mode set to Attach. To detach it,
+    remove the entry from links.
+    
+FIELDS:
+  mode	<string> -required-
+  enum: Attach
+    mode is a required field. When set to Attach, the FEntry program will
+    attempt to be attached. To detach the FEntry program, remove the link entry.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.fexit
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: fexit <Object>
+
+
+DESCRIPTION:
+    fexit is an optional field, but required when the type field is set to
+    FExit. fexit defines the desired state of the application's FExit programs.
+    FExit programs are attached to the exit of a Linux kernel function or to
+    another eBPF program function. The program is invoked when the function
+    returns, independent of where in the function that occurs. FExit programs
+    are similar to KRetProbe programs, but get invoked with the input arguments
+    and the return values. They also have higher performance over KRetProbe
+    programs.
+    
+FIELDS:
+  function	<string> -required-
+    function is a required field and specifies the name of the Linux kernel
+    function to attach the FExit program. function must not be an empty string,
+    must not exceed 64 characters in length, must start with alpha characters
+    and must only contain alphanumeric characters.
+
+  links	<[]Object>
+    links is an optional field and is a flag to indicate if the FExit program
+    should be attached. The attachment point for a FExit program is a Linux
+    kernel function. Unlike other eBPF program types, an FExit program must be
+    provided with the target function at load time. The links field is optional,
+    but unlike other program types where it represents a list of attachment
+    points, for FExit programs it contains at most one entry that determines
+    whether the program should be attached to the specified function. To attach
+    the program, add an entry to links with mode set to Attach. To detach it,
+    remove the entry from links.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.fexit.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is a flag to indicate if the FExit program
+    should be attached. The attachment point for a FExit program is a Linux
+    kernel function. Unlike other eBPF program types, an FExit program must be
+    provided with the target function at load time. The links field is optional,
+    but unlike other program types where it represents a list of attachment
+    points, for FExit programs it contains at most one entry that determines
+    whether the program should be attached to the specified function. To attach
+    the program, add an entry to links with mode set to Attach. To detach it,
+    remove the entry from links.
+    
+FIELDS:
+  mode	<string> -required-
+  enum: Attach
+    mode is a required field. When set to Attach, the FExit program will
+    attempt to be attached. To detach the FExit program, remove the link entry.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.kprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: kprobe <Object>
+
+
+DESCRIPTION:
+    kprobe is an optional field, but required when the type field is set to
+    KProbe. kprobe defines the desired state of the application's Kprobe
+    programs. KProbe programs are attached to a Linux kernel function. Unlike
+    FEntry programs, which must always be attached at the entry point of a Linux
+    kernel function, KProbe programs can be attached at any point in the
+    function using the optional offset field. However, caution must be taken
+    when using the offset, ensuring the offset is still in the function
+    bytecode. FEntry programs have less overhead than KProbe programs.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    KProbe program should be attached. The eBPF program is loaded in kernel
+    memory when the BPF Application CRD is created and the selected Kubernetes
+    nodes are active. The eBPF program will not be triggered until the program
+    has also been attached to an attachment point described in this list. Items
+    may be added or removed from the list at any point, causing the eBPF program
+    to be attached or detached.
+    
+    
+    The attachment point for a KProbe program is a Linux kernel function. By
+    default, the eBPF program is triggered at the entry of the attachment point,
+    but the attachment point can be adjusted using an optional offset.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.kprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    KProbe program should be attached. The eBPF program is loaded in kernel
+    memory when the BPF Application CRD is created and the selected Kubernetes
+    nodes are active. The eBPF program will not be triggered until the program
+    has also been attached to an attachment point described in this list. Items
+    may be added or removed from the list at any point, causing the eBPF program
+    to be attached or detached.
+    
+    
+    The attachment point for a KProbe program is a Linux kernel function. By
+    default, the eBPF program is triggered at the entry of the attachment point,
+    but the attachment point can be adjusted using an optional offset.
+    
+FIELDS:
+  function	<string> -required-
+    function is a required field and specifies the name of the Linux kernel
+    function to attach the KProbe program. function must not be an empty string,
+    must not exceed 64 characters in length, must start with alpha characters
+    and must only contain alphanumeric characters.
+
+  offset	<integer>
+    offset is an optional field and the value is added to the address of the
+    attachment point function. If not provided, offset defaults to 0.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.kretprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: kretprobe <Object>
+
+
+DESCRIPTION:
+    kretprobe is an optional field, but required when the type field is set to
+    KRetProbe. kretprobe defines the desired state of the application's
+    KRetProbe programs. KRetProbe programs are attached to the exit of a Linux
+    kernel function. FExit programs have less overhead than KRetProbe programs
+    and FExit programs have access to both the input arguments as well as the
+    return values. KRetProbes only have access to the return values.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    KRetProbe program should be attached. The eBPF program is loaded in kernel
+    memory when the BPF Application CRD is created and the selected Kubernetes
+    nodes are active. The eBPF program will not be triggered until the program
+    has also been attached to an attachment point described in this list. Items
+    may be added or removed from the list at any point, causing the eBPF program
+    to be attached or detached.
+    
+    
+    The attachment point for a KRetProbe program is a Linux kernel function.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.kretprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    KRetProbe program should be attached. The eBPF program is loaded in kernel
+    memory when the BPF Application CRD is created and the selected Kubernetes
+    nodes are active. The eBPF program will not be triggered until the program
+    has also been attached to an attachment point described in this list. Items
+    may be added or removed from the list at any point, causing the eBPF program
+    to be attached or detached.
+    
+    
+    The attachment point for a KRetProbe program is a Linux kernel function.
+    
+FIELDS:
+  function	<string> -required-
+    function is a required field and specifies the name of the Linux kernel
+    function to attach the KRetProbe program. function must not be an empty
+    string, must not exceed 64 characters in length, must start with alpha
+    characters and must only contain alphanumeric characters.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: tc <Object>
+
+
+DESCRIPTION:
+    tc is an optional field, but required when the type field is set to TC. tc
+    defines the desired state of the application's TC programs. TC programs are
+    attached to network devices (interfaces). The program can be attached on
+    either packet ingress or egress, so the program will be called on every
+    incoming or outgoing packet seen by the network device. The TC attachment
+    point is in Linux's Traffic Control (tc) subsystem, which is after the
+    Linux kernel has allocated an sk_buff. TCX is newer implementation of TC
+    with enhanced performance and better support for running multiple programs
+    on a given network device. This makes TC useful for packet classification
+    actions.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    TC program should be attached. The TC program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TC program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TC program to be
+    attached or detached.
+    
+    
+    The attachment point for a TC program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TC program can also be installed into a set of network namespaces.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    TC program should be attached. The TC program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TC program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TC program to be
+    attached or detached.
+    
+    
+    The attachment point for a TC program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TC program can also be installed into a set of network namespaces.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is a required field and specifies the direction of traffic.
+    Allowed values are:
+       Ingress, Egress
+    
+    
+    When set to Ingress, the TC program is triggered when packets are received
+    by the interface.
+    
+    
+    When set to Egress, the TC program is triggered when packets are to be
+    transmitted by the interface.
+
+  interfaceSelector	<Object> -required-
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TC program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+
+  networkNamespaces	<Object>
+    networkNamespaces is an optional field that identifies the set of network
+    namespaces in which to attach the eBPF program. If networkNamespaces is not
+    specified, the eBPF program will be attached in the root network namespace.
+
+  priority	<integer>
+    priority is an optional field and determines the execution order of the TC
+    program relative to other TC programs attached to the same attachment point.
+    It must be a value between 0 and 1000, where lower values indicate higher
+    precedence. For TC programs on the same attachment point with the same
+    direction and priority, the most recently attached program has a lower
+    precedence. If not provided, priority will default to 1000.
+
+  proceedOn	<[]string>
+    proceedOn is an optional field and allows the user to call other TC programs
+    in a chain, or not call the next program in a chain based on the exit code
+    of a TC program. Allowed values, which are the possible exit codes from a TC
+    eBPF program, are:
+      UnSpec, OK, ReClassify, Shot, Pipe, Stolen, Queued, Repeat, ReDirect,
+      Trap, DispatcherReturn
+    
+    
+    Multiple values are supported. Default is OK, Pipe and DispatcherReturn. So
+    using the default values, if a TC program returns Pipe, the next TC
+    program in the chain will be called. If a TC program returns Stolen, the
+    next TC program in the chain will NOT be called.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc.links.interfaceSelector
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfaceSelector <Object>
+
+
+DESCRIPTION:
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TC program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+    
+FIELDS:
+  interfaces	<[]string>
+    interfaces is an optional field and is a list of network interface names to
+    attach the eBPF program. The interface names in the list are case-sensitive.
+
+  interfacesDiscoveryConfig	<Object>
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+
+  primaryNodeInterface	<boolean>
+    primaryNodeInterface is and optional field and indicates to attach the eBPF
+    program to the primary interface on the Kubernetes node. Only 'true' is
+    accepted.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc.links.interfaceSelector.interfacesDiscoveryConfig
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfacesDiscoveryConfig <Object>
+
+
+DESCRIPTION:
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+    
+FIELDS:
+  allowedInterfaces	<[]string>
+    allowedInterfaces is an optional field that contains a list of interface
+    names that are allowed to be discovered. If empty, the agent will fetch all
+    the interfaces in the system, excepting the ones listed in
+    excludeInterfaces. if non-empty, only entries in the list will be considered
+    for discovery. If an entry enclosed by slashes, such as `/br-/` or
+    `/veth*/`, then the entry is considered as a regular expression for
+    matching. Otherwise, the interface names in the list are case-sensitive.
+    This field is only taken into consideration if interfaceAutoDiscovery is set
+    to true.
+
+  excludeInterfaces	<[]string>
+    excludeInterfaces is an optional field that contains a list of interface
+    names that are excluded from interface discovery. The interface names in
+    the list are case-sensitive. By default, the list contains the loopback
+    interface, "lo". This field is only taken into consideration if
+    interfaceAutoDiscovery is set to true.
+
+  interfaceAutoDiscovery	<boolean>
+    interfaceAutoDiscovery is an optional field. When enabled, the agent
+    monitors the creation and deletion of interfaces and automatically
+    attached eBPF programs to the newly discovered interfaces.
+    CAUTION: This has the potential to attach a given eBPF program to a large
+    number of interfaces. Use with caution.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc.links.networkNamespaces
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: networkNamespaces <Object>
+
+
+DESCRIPTION:
+    networkNamespaces is an optional field that identifies the set of network
+    namespaces in which to attach the eBPF program. If networkNamespaces is not
+    specified, the eBPF program will be attached in the root network namespace.
+    
+FIELDS:
+  namespace	<string>
+    namespace is an optional field and indicates the target network namespace.
+    If not provided, the default network namespace is used.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc.links.networkNamespaces.pods
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tc.links.networkNamespaces.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: tcx <Object>
+
+
+DESCRIPTION:
+    tcx is an optional field, but required when the type field is set to TCX.
+    tcx defines the desired state of the application's TCX programs. TCX
+    programs are attached to network devices (interfaces). The program can be
+    attached on either packet ingress or egress, so the program will be called
+    on every incoming or outgoing packet seen by the network device. The TCX
+    attachment point is in Linux's Traffic Control (tc) subsystem, which is
+    after the Linux kernel has allocated an sk_buff. This makes TCX useful for
+    packet classification actions. TCX is a newer implementation of TC with
+    enhanced performance and better support for running multiple programs on a
+    given network device.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    TCX program should be attached. The TCX program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TCX program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TCX program to be
+    attached or detached.
+    
+    
+    The attachment point for a TCX program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TCX program can also be installed into a set of network namespaces.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    TCX program should be attached. The TCX program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The TCX program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the TCX program to be
+    attached or detached.
+    
+    
+    The attachment point for a TCX program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    TCX program can also be installed into a set of network namespaces.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is a required field and specifies the direction of traffic.
+    Allowed values are:
+       Ingress, Egress
+    
+    
+    When set to Ingress, the TC program is triggered when packets are received
+    by the interface.
+    
+    
+    When set to Egress, the TC program is triggered when packets are to be
+    transmitted by the interface.
+
+  interfaceSelector	<Object> -required-
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TCX program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+
+  networkNamespaces	<Object>
+    networkNamespaces is an optional field that identifies the set of network
+    namespaces in which to attach the eBPF program. If networkNamespaces is not
+    specified, the eBPF program will be attached in the root network namespace.
+
+  priority	<integer>
+    priority is an optional field and determines the execution order of the TCX
+    program relative to other TCX programs attached to the same attachment
+    point. It must be a value between 0 and 1000, where lower values indicate
+    higher precedence. For TCX programs on the same attachment point with the
+    same direction and priority, the most recently attached program has a lower
+    precedence. If not provided, priority will default to 1000.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx.links.interfaceSelector
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfaceSelector <Object>
+
+
+DESCRIPTION:
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the TCX program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+    
+FIELDS:
+  interfaces	<[]string>
+    interfaces is an optional field and is a list of network interface names to
+    attach the eBPF program. The interface names in the list are case-sensitive.
+
+  interfacesDiscoveryConfig	<Object>
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+
+  primaryNodeInterface	<boolean>
+    primaryNodeInterface is and optional field and indicates to attach the eBPF
+    program to the primary interface on the Kubernetes node. Only 'true' is
+    accepted.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx.links.interfaceSelector.interfacesDiscoveryConfig
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfacesDiscoveryConfig <Object>
+
+
+DESCRIPTION:
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+    
+FIELDS:
+  allowedInterfaces	<[]string>
+    allowedInterfaces is an optional field that contains a list of interface
+    names that are allowed to be discovered. If empty, the agent will fetch all
+    the interfaces in the system, excepting the ones listed in
+    excludeInterfaces. if non-empty, only entries in the list will be considered
+    for discovery. If an entry enclosed by slashes, such as `/br-/` or
+    `/veth*/`, then the entry is considered as a regular expression for
+    matching. Otherwise, the interface names in the list are case-sensitive.
+    This field is only taken into consideration if interfaceAutoDiscovery is set
+    to true.
+
+  excludeInterfaces	<[]string>
+    excludeInterfaces is an optional field that contains a list of interface
+    names that are excluded from interface discovery. The interface names in
+    the list are case-sensitive. By default, the list contains the loopback
+    interface, "lo". This field is only taken into consideration if
+    interfaceAutoDiscovery is set to true.
+
+  interfaceAutoDiscovery	<boolean>
+    interfaceAutoDiscovery is an optional field. When enabled, the agent
+    monitors the creation and deletion of interfaces and automatically
+    attached eBPF programs to the newly discovered interfaces.
+    CAUTION: This has the potential to attach a given eBPF program to a large
+    number of interfaces. Use with caution.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx.links.networkNamespaces
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: networkNamespaces <Object>
+
+
+DESCRIPTION:
+    networkNamespaces is an optional field that identifies the set of network
+    namespaces in which to attach the eBPF program. If networkNamespaces is not
+    specified, the eBPF program will be attached in the root network namespace.
+    
+FIELDS:
+  namespace	<string>
+    namespace is an optional field and indicates the target network namespace.
+    If not provided, the default network namespace is used.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx.links.networkNamespaces.pods
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tcx.links.networkNamespaces.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tracepoint
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: tracepoint <Object>
+
+
+DESCRIPTION:
+    tracepoint is an optional field, but required when the type field is set to
+    Tracepoint. tracepoint defines the desired state of the application's
+    Tracepoint programs. Whereas KProbes attach to dynamically to any Linux
+    kernel function, Tracepoint programs are programs that can only be attached
+    at predefined locations in the Linux kernel. Use the following command to
+    see the available attachment points:
+     `sudo find /sys/kernel/debug/tracing/events -type d`
+    While KProbes are more flexible in where in the kernel the probe can be
+    attached, the functions and data structure rely on the kernel your system is
+    running. Tracepoints tend to be more stable across kernel versions and are
+    better for portability.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    Tracepoint program should be attached. The Tracepoint program is loaded in
+    kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The Tracepoint program will not be triggered
+    until the program has also been attached to an attachment point described in
+    this list. Items may be added or removed from the list at any point, causing
+    the Tracepoint program to be attached or detached.
+    
+    
+    The attachment point for a Tracepoint program is a one of a predefined set
+    of Linux kernel functions.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.tracepoint.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    Tracepoint program should be attached. The Tracepoint program is loaded in
+    kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The Tracepoint program will not be triggered
+    until the program has also been attached to an attachment point described in
+    this list. Items may be added or removed from the list at any point, causing
+    the Tracepoint program to be attached or detached.
+    
+    
+    The attachment point for a Tracepoint program is a one of a predefined set
+    of Linux kernel functions.
+    
+FIELDS:
+  name	<string> -required-
+    name is a required field and specifies the name of the Linux kernel
+    Tracepoint to attach the eBPF program. name must not be an empty string,
+    must not exceed 64 characters in length, must start with alpha characters
+    and must only contain alphanumeric characters.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: uprobe <Object>
+
+
+DESCRIPTION:
+    uprobe is an optional field, but required when the type field is set to
+    UProbe. uprobe defines the desired state of the application's UProbe
+    programs. UProbe programs are user-space probes. A target must be provided,
+    which is the library name or absolute path to a binary or library where the
+    probe is attached. Optionally, a function name can also be provided to
+    provide finer granularity on where the probe is attached. They can be
+    attached at any point in the binary, library or function using the optional
+    offset field. However, caution must be taken when using the offset, ensuring
+    the offset is still in the desired bytecode.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+    
+FIELDS:
+  containers	<Object>
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+
+  function	<string>
+    function is an optional field and specifies the name of a user-space
+    function
+    to attach the UProbe or URetProbe program. If not provided, the eBPF program
+    will be triggered on the entry of the target. function must not be an empty
+    string, must not exceed 64 characters in length, must start with alpha
+    characters and must only contain alphanumeric characters.
+
+  offset	<integer>
+    offset is an optional field and the value is added to the address of the
+    attachment point function.
+
+  pid	<integer>
+    pid is an optional field and if provided, limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  target	<string> -required-
+    target is a required field and is the user-space library name or the
+    absolute path to a binary or library.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uprobe.links.containers
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: containers <Object>
+
+
+DESCRIPTION:
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+    
+FIELDS:
+  containerNames	<[]string>
+    containerNames is an optional field and is a list of container names in a
+    pod to attach the eBPF program. If no names are specified, all containers
+    in the pod are selected.
+
+  namespace	<string>
+    namespace is an optional field and indicates the target Kubernetes
+    namespace. If not provided, all Kubernetes namespaces are included.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uprobe.links.containers.pods
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uprobe.links.containers.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uretprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: uretprobe <Object>
+
+
+DESCRIPTION:
+    uretprobe is an optional field, but required when the type field is set to
+    URetProbe. uretprobe defines the desired state of the application's
+    URetProbe programs. URetProbe programs are user-space probes. A target must
+    be provided, which is the library name or absolute path to a binary or
+    library where the probe is attached. Optionally, a function name can also be
+    provided to provide finer granularity on where the probe is attached. They
+    are attached to the return point of the binary, library or function, but can
+    be set anywhere using the optional offset field. However, caution must be
+    taken when using the offset, ensuring the offset is still in the desired
+    bytecode.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uretprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    UProbe or URetProbe program should be attached. The eBPF program is loaded
+    in kernel memory when the BPF Application CRD is created and the selected
+    Kubernetes nodes are active. The eBPF program will not be triggered until
+    the program has also been attached to an attachment point described in this
+    list. Items may be added or removed from the list at any point, causing the
+    eBPF program to be attached or detached.
+    
+    
+    The attachment point for a UProbe and URetProbe program is a user-space
+    binary or function. By default, the eBPF program is triggered at the entry
+    of the attachment point, but the attachment point can be adjusted using an
+    optional function name and/or offset. Optionally, the eBPF program can be
+    installed in a set of containers or limited to a specified PID.
+    
+FIELDS:
+  containers	<Object>
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+
+  function	<string>
+    function is an optional field and specifies the name of a user-space
+    function
+    to attach the UProbe or URetProbe program. If not provided, the eBPF program
+    will be triggered on the entry of the target. function must not be an empty
+    string, must not exceed 64 characters in length, must start with alpha
+    characters and must only contain alphanumeric characters.
+
+  offset	<integer>
+    offset is an optional field and the value is added to the address of the
+    attachment point function.
+
+  pid	<integer>
+    pid is an optional field and if provided, limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  target	<string> -required-
+    target is a required field and is the user-space library name or the
+    absolute path to a binary or library.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uretprobe.links.containers
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: containers <Object>
+
+
+DESCRIPTION:
+    containers is an optional field that identifies the set of containers in
+    which to attach the UProbe or URetProbe program. If containers is not
+    specified, the eBPF program will be attached in the bpfman container.
+    
+FIELDS:
+  containerNames	<[]string>
+    containerNames is an optional field and is a list of container names in a
+    pod to attach the eBPF program. If no names are specified, all containers
+    in the pod are selected.
+
+  namespace	<string>
+    namespace is an optional field and indicates the target Kubernetes
+    namespace. If not provided, all Kubernetes namespaces are included.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uretprobe.links.containers.pods
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.uretprobe.links.containers.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: xdp <Object>
+
+
+DESCRIPTION:
+    xdp is an optional field, but required when the type field is set to XDP.
+    xdp defines the desired state of the application's XDP programs. XDP program
+    can be attached to network devices (interfaces) and will be called on every
+    incoming packet received by the network device. The XDP attachment point is
+    just after the packet has been received off the wire, but before the Linux
+    kernel has allocated an sk_buff, which is used to pass the packet through
+    the kernel networking stack.
+    
+FIELDS:
+  links	<[]Object>
+    links is an optional field and is the list of attachment points to which the
+    XDP program should be attached. The XDP program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The XDP program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the XDP program to be
+    attached or detached.
+    
+    
+    The attachment point for an XDP program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    XDP program can also be installed into a set of network namespaces.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is an optional field and is the list of attachment points to which the
+    XDP program should be attached. The XDP program is loaded in kernel memory
+    when the BPF Application CRD is created and the selected Kubernetes nodes
+    are active. The XDP program will not be triggered until the program has also
+    been attached to an attachment point described in this list. Items may be
+    added or removed from the list at any point, causing the XDP program to be
+    attached or detached.
+    
+    
+    The attachment point for an XDP program is a network interface (or device).
+    The interface can be specified by name, by allowing bpfman to discover each
+    interface, or by setting the primaryNodeInterface flag, which instructs
+    bpfman to use the primary interface of a Kubernetes node. Optionally, the
+    XDP program can also be installed into a set of network namespaces.
+    
+FIELDS:
+  interfaceSelector	<Object> -required-
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the XDP program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+
+  networkNamespaces	<Object>
+    networkNamespaces identifies the set of network namespaces in which to
+    attach the eBPF program. If networkNamespaces is not specified, the eBPF
+    program will be attached in the root network namespace.
+
+  priority	<integer>
+    priority is an optional field and determines the execution order of the XDP
+    program relative to other XDP programs attached to the same attachment
+    point. It must be a value between 0 and 1000, where lower values indicate
+    higher precedence. For XDP programs on the same attachment point with the
+    same priority, the most recently attached program has a lower precedence. If
+    not provided, priority will default to 1000.
+
+  proceedOn	<[]string>
+    proceedOn is an optional field and allows the user to call other XDP
+    programs in a chain, or not call the next program in a chain based on the
+    exit code of an XDP program. Allowed values, which are the possible exit
+    codes from an XDP eBPF program, are:
+      Aborted, Drop, Pass, TX, ReDirect, DispatcherReturn
+    
+    
+    Multiple values are supported. Default is Pass and DispatcherReturn. So
+    using the default values, if an XDP program returns Pass, the next XDP
+    program in the chain will be called. If an XDP program returns Drop, the
+    next XDP program in the chain will NOT be called.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp.links.interfaceSelector
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfaceSelector <Object>
+
+
+DESCRIPTION:
+    interfaceSelector is a required field and is used to determine the network
+    interface (or interfaces) the XDP program is attached. Interface list is set
+    by providing a list of interface names, enabling auto discovery, or setting
+    the primaryNodeInterface flag, but only one option is allowed.
+    
+FIELDS:
+  interfaces	<[]string>
+    interfaces is an optional field and is a list of network interface names to
+    attach the eBPF program. The interface names in the list are case-sensitive.
+
+  interfacesDiscoveryConfig	<Object>
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+
+  primaryNodeInterface	<boolean>
+    primaryNodeInterface is and optional field and indicates to attach the eBPF
+    program to the primary interface on the Kubernetes node. Only 'true' is
+    accepted.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp.links.interfaceSelector.interfacesDiscoveryConfig
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: interfacesDiscoveryConfig <Object>
+
+
+DESCRIPTION:
+    interfacesDiscoveryConfig is an optional field that is used to control if
+    and how to automatically discover interfaces. If the agent should
+    automatically discover and attach eBPF programs to interfaces, use the
+    fields under interfacesDiscoveryConfig to control what is allow and excluded
+    from discovery.
+    
+FIELDS:
+  allowedInterfaces	<[]string>
+    allowedInterfaces is an optional field that contains a list of interface
+    names that are allowed to be discovered. If empty, the agent will fetch all
+    the interfaces in the system, excepting the ones listed in
+    excludeInterfaces. if non-empty, only entries in the list will be considered
+    for discovery. If an entry enclosed by slashes, such as `/br-/` or
+    `/veth*/`, then the entry is considered as a regular expression for
+    matching. Otherwise, the interface names in the list are case-sensitive.
+    This field is only taken into consideration if interfaceAutoDiscovery is set
+    to true.
+
+  excludeInterfaces	<[]string>
+    excludeInterfaces is an optional field that contains a list of interface
+    names that are excluded from interface discovery. The interface names in
+    the list are case-sensitive. By default, the list contains the loopback
+    interface, "lo". This field is only taken into consideration if
+    interfaceAutoDiscovery is set to true.
+
+  interfaceAutoDiscovery	<boolean>
+    interfaceAutoDiscovery is an optional field. When enabled, the agent
+    monitors the creation and deletion of interfaces and automatically
+    attached eBPF programs to the newly discovered interfaces.
+    CAUTION: This has the potential to attach a given eBPF program to a large
+    number of interfaces. Use with caution.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp.links.networkNamespaces
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: networkNamespaces <Object>
+
+
+DESCRIPTION:
+    networkNamespaces identifies the set of network namespaces in which to
+    attach the eBPF program. If networkNamespaces is not specified, the eBPF
+    program will be attached in the root network namespace.
+    
+FIELDS:
+  namespace	<string>
+    namespace is an optional field and indicates the target network namespace.
+    If not provided, the default network namespace is used.
+
+  pods	<Object> -required-
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp.links.networkNamespaces.pods
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: pods <Object>
+
+
+DESCRIPTION:
+    pods is a required field and indicates the target pods. To select all pods
+    use the standard metav1.LabelSelector semantics and make it empty.
+    
+FIELDS:
+  matchExpressions	<[]Object>
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+
+  matchLabels	<map[string]string>
+    matchLabels is a map of {key,value} pairs. A single {key,value} in the
+    matchLabels
+    map is equivalent to an element of matchExpressions, whose key field is
+    "key", the
+    operator is "In", and the values array contains only "value". The
+    requirements are ANDed.
+
+$ kubectl explain ClusterBpfApplication.spec.programs.xdp.links.networkNamespaces.pods.matchExpressions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: matchExpressions <[]Object>
+
+
+DESCRIPTION:
+    matchExpressions is a list of label selector requirements. The requirements
+    are ANDed.
+    A label selector requirement is a selector that contains values, a key, and
+    an operator that
+    relates the key and values.
+    
+FIELDS:
+  key	<string> -required-
+    key is the label key that the selector applies to.
+
+  operator	<string> -required-
+    operator represents a key's relationship to a set of values.
+    Valid operators are In, NotIn, Exists and DoesNotExist.
+
+  values	<[]string>
+    values is an array of string values. If the operator is In or NotIn,
+    the values array must be non-empty. If the operator is Exists or
+    DoesNotExist,
+    the values array must be empty. This array is replaced during a strategic
+    merge patch.
+
+$ kubectl explain ClusterBpfApplication.status
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: status <Object>
+
+
+DESCRIPTION:
+    status reflects the status of a BPF Application and indicates if all the
+    eBPF programs for a given instance loaded successfully or not.
+    
+FIELDS:
+  conditions	<[]Object>
+    conditions contains the summary state for all eBPF programs defined in the
+    BPF Application instance for all the Kubernetes nodes in the cluster.
+
+$ kubectl explain ClusterBpfApplication.status.conditions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplication
+VERSION:    v1alpha1
+
+FIELD: conditions <[]Object>
+
+
+DESCRIPTION:
+    conditions contains the summary state for all eBPF programs defined in the
+    BPF Application instance for all the Kubernetes nodes in the cluster.
+    Condition contains details for one aspect of the current state of this API
+    Resource.
+    ---
+    This struct is intended for direct use as an array at the field path
+    .status.conditions.  For example,
+    
+    
+    	type FooStatus struct{
+    	    // Represents the observations of a foo's current state.
+    	    // Known .status.conditions.type are: "Available", "Progressing", and
+    "Degraded"
+    	    // +patchMergeKey=type
+    	    // +patchStrategy=merge
+    	    // +listType=map
+    	    // +listMapKey=type
+    	    Conditions []metav1.Condition `json:"conditions,omitempty"
+    patchStrategy:"merge" patchMergeKey:"type"
+    protobuf:"bytes,1,rep,name=conditions"`
+    
+    
+    	    // other fields
+    	}
+    
+FIELDS:
+  lastTransitionTime	<string> -required-
+    lastTransitionTime is the last time the condition transitioned from one
+    status to another.
+    This should be when the underlying condition changed.  If that is not known,
+    then using the time when the API field changed is acceptable.
+
+  message	<string> -required-
+    message is a human readable message indicating details about the transition.
+    This may be an empty string.
+
+  observedGeneration	<integer>
+    observedGeneration represents the .metadata.generation that the condition
+    was set based upon.
+    For instance, if .metadata.generation is currently 12, but the
+    .status.conditions[x].observedGeneration is 9, the condition is out of date
+    with respect to the current state of the instance.
+
+  reason	<string> -required-
+    reason contains a programmatic identifier indicating the reason for the
+    condition's last transition.
+    Producers of specific condition types may define expected values and
+    meanings for this field,
+    and whether the values are considered a guaranteed API.
+    The value should be a CamelCase string.
+    This field may not be empty.
+
+  status	<string> -required-
+  enum: True, False, Unknown
+    status of the condition, one of True, False, Unknown.
+
+  type	<string> -required-
+    type of condition in CamelCase or in foo.example.com/CamelCase.
+    ---
+    Many .condition.type values are consistent across resources like Available,
+    but because arbitrary conditions can be
+    useful (see .node.status.conditions), the ability to deconflict is
+    important.
+    The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+

--- a/docs/crds/ClusterBpfApplicationState.txt
+++ b/docs/crds/ClusterBpfApplicationState.txt
@@ -1,0 +1,909 @@
+$ kubectl explain ClusterBpfApplicationState
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+DESCRIPTION:
+    ClusterBpfApplicationState contains the state of a ClusterBpfApplication
+    instance for a given Kubernetes node. When a user creates a
+    ClusterBpfApplication instance, bpfman creates a ClusterBpfApplicationState
+    instance for each node in a Kubernetes cluster.
+    
+FIELDS:
+  apiVersion	<string>
+    APIVersion defines the versioned schema of this representation of an object.
+    Servers should convert recognized schemas to the latest internal value, and
+    may reject unrecognized values. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+
+  kind	<string>
+    Kind is a string value representing the REST resource this object
+    represents. Servers may infer this from the endpoint the client submits
+    requests to. Cannot be updated. In CamelCase. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+
+  metadata	<ObjectMeta>
+    Standard object's metadata. More info:
+    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+
+  status	<Object>
+    status reflects the status of a ClusterBpfApplication instance for the given
+    node. appLoadStatus and conditions provide an overall status for the given
+    node, while each item in the programs list provides a per eBPF program
+    status for the given node.
+
+$ kubectl explain ClusterBpfApplicationState.status
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: status <Object>
+
+
+DESCRIPTION:
+    status reflects the status of a ClusterBpfApplication instance for the given
+    node. appLoadStatus and conditions provide an overall status for the given
+    node, while each item in the programs list provides a per eBPF program
+    status for the given node.
+    
+FIELDS:
+  appLoadStatus	<string> -required-
+    appLoadStatus reflects the status of loading the eBPF application on the
+    given node.
+    
+    
+    NotLoaded is a temporary state that is assigned when a
+    ClusterBpfApplicationState is created and the initial reconcile is being
+    processed.
+    
+    
+    LoadSuccess is returned if all the programs have been loaded with no errors.
+    
+    
+    LoadError is returned if one or more programs encountered an error and were
+    not loaded.
+    
+    
+    NotSelected is returned if this application did not select to run on this
+    Kubernetes node.
+    
+    
+    UnloadSuccess is returned when all the programs were successfully unloaded.
+    
+    
+    UnloadError is returned if one or more programs encountered an error when
+    being unloaded.
+
+  conditions	<[]Object>
+    conditions contains the summary state of the ClusterBpfApplication for the
+    given Kubernetes node. If one or more programs failed to load or attach to
+    the designated attachment point, the condition will report the error. If
+    more than one error has occurred, condition will contain the first error
+    encountered.
+
+  node	<string> -required-
+    node is the name of the Kubernetes node for this ClusterBpfApplicationState.
+
+  programs	<[]Object>
+    programs is a list of eBPF programs contained in the parent
+    ClusterBpfApplication instance. Each entry in the list contains the derived
+    program attributes as well as the attach status for each program on the
+    given Kubernetes node.
+
+  updateCount	<integer> -required-
+    UpdateCount tracks the number of times the BpfApplicationState object has
+    been updated. The bpfman agent initializes it to 1 when it creates the
+    object, and then increments it before each subsequent update. It serves
+    as a lightweight sequence number to verify that the API server is serving
+    the most recent version of the object before beginning a new Reconcile
+    operation.
+
+$ kubectl explain ClusterBpfApplicationState.status.conditions
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: conditions <[]Object>
+
+
+DESCRIPTION:
+    conditions contains the summary state of the ClusterBpfApplication for the
+    given Kubernetes node. If one or more programs failed to load or attach to
+    the designated attachment point, the condition will report the error. If
+    more than one error has occurred, condition will contain the first error
+    encountered.
+    Condition contains details for one aspect of the current state of this API
+    Resource.
+    ---
+    This struct is intended for direct use as an array at the field path
+    .status.conditions.  For example,
+    
+    
+    	type FooStatus struct{
+    	    // Represents the observations of a foo's current state.
+    	    // Known .status.conditions.type are: "Available", "Progressing", and
+    "Degraded"
+    	    // +patchMergeKey=type
+    	    // +patchStrategy=merge
+    	    // +listType=map
+    	    // +listMapKey=type
+    	    Conditions []metav1.Condition `json:"conditions,omitempty"
+    patchStrategy:"merge" patchMergeKey:"type"
+    protobuf:"bytes,1,rep,name=conditions"`
+    
+    
+    	    // other fields
+    	}
+    
+FIELDS:
+  lastTransitionTime	<string> -required-
+    lastTransitionTime is the last time the condition transitioned from one
+    status to another.
+    This should be when the underlying condition changed.  If that is not known,
+    then using the time when the API field changed is acceptable.
+
+  message	<string> -required-
+    message is a human readable message indicating details about the transition.
+    This may be an empty string.
+
+  observedGeneration	<integer>
+    observedGeneration represents the .metadata.generation that the condition
+    was set based upon.
+    For instance, if .metadata.generation is currently 12, but the
+    .status.conditions[x].observedGeneration is 9, the condition is out of date
+    with respect to the current state of the instance.
+
+  reason	<string> -required-
+    reason contains a programmatic identifier indicating the reason for the
+    condition's last transition.
+    Producers of specific condition types may define expected values and
+    meanings for this field,
+    and whether the values are considered a guaranteed API.
+    The value should be a CamelCase string.
+    This field may not be empty.
+
+  status	<string> -required-
+  enum: True, False, Unknown
+    status of the condition, one of True, False, Unknown.
+
+  type	<string> -required-
+    type of condition in CamelCase or in foo.example.com/CamelCase.
+    ---
+    Many .condition.type values are consistent across resources like Available,
+    but because arbitrary conditions can be
+    useful (see .node.status.conditions), the ability to deconflict is
+    important.
+    The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+
+$ kubectl explain ClusterBpfApplicationState.status.programs
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: programs <[]Object>
+
+
+DESCRIPTION:
+    programs is a list of eBPF programs contained in the parent
+    ClusterBpfApplication instance. Each entry in the list contains the derived
+    program attributes as well as the attach status for each program on the
+    given Kubernetes node.
+    
+FIELDS:
+  fentry	<Object>
+    fentry contains the attachment data for an FEntry program when type is set
+    to FEntry.
+
+  fexit	<Object>
+    fexit contains the attachment data for an FExit program when type is set to
+    FExit.
+
+  kprobe	<Object>
+    kprobe contains the attachment data for a KProbe program when type is set to
+    KProbe.
+
+  kretprobe	<Object>
+    kretprobe contains the attachment data for a KRetProbe program when type is
+    set to KRetProbe.
+
+  name	<string> -required-
+    name is the name of the function that is the entry point for the eBPF
+    program
+
+  programId	<integer>
+    programId is the id of the program in the kernel.  Not set until the
+    program is loaded.
+
+  programLinkStatus	<string> -required-
+    programLinkStatus reflects whether all links requested for the program
+    are in the correct state.
+
+  tc	<Object>
+    tc contains the attachment data for a TC program when type is set to TC.
+
+  tcx	<Object>
+    tcx contains the attachment data for a TCX program when type is set to TCX.
+
+  tracepoint	<Object>
+    tracepoint contains the attachment data for a Tracepoint program when type
+    is set to Tracepoint.
+
+  type	<string> -required-
+  enum: FEntry, FExit, KProbe, KRetProbe, ....
+    type specifies the provisioned eBPF program type for this program entry.
+    Type will be one of:
+      FEntry, FExit, KProbe, KRetProbe, TC, TCX, Tracepoint, UProbe,
+      URetProbe, XDP
+    
+    
+    When set to FEntry, the fentry object will be populated with the eBPF
+    program data associated with an FEntry program.
+    
+    
+    When set to FExit, the fexit object will be populated with the eBPF program
+    data associated with an FExit program.
+    
+    
+    When set to KProbe, the kprobe object will be populated with the eBPF
+    program data associated with a KProbe program.
+    
+    
+    When set to KRetProbe, the kretprobe object will be populated with the
+    eBPF program data associated with a KRetProbe program.
+    
+    
+    When set to TC, the tc object will be populated with the eBPF program data
+    associated with a TC program.
+    
+    
+    When set to TCX, the tcx object will be populated with the eBPF program
+    data associated with a TCX program.
+    
+    
+    When set to Tracepoint, the tracepoint object will be populated with the
+    eBPF program data associated with a Tracepoint program.
+    
+    
+    When set to UProbe, the uprobe object will be populated with the eBPF
+    program data associated with a UProbe program.
+    
+    
+    When set to URetProbe, the uretprobe object will be populated with the eBPF
+    program data associated with a URetProbe program.
+    
+    
+    When set to XDP, the xdp object will be populated with the eBPF program data
+    associated with a URetProbe program.
+
+  uprobe	<Object>
+    uprobe contains the attachment data for a UProbe program when type is set to
+    UProbe.
+
+  uretprobe	<Object>
+    uretprobe contains the attachment data for a URetProbe program when type is
+    set to URetProbe.
+
+  xdp	<Object>
+    xdp contains the attachment data for an XDP program when type is set to XDP.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.fentry
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: fentry <Object>
+
+
+DESCRIPTION:
+    fentry contains the attachment data for an FEntry program when type is set
+    to FEntry.
+    
+FIELDS:
+  function	<string> -required-
+    function is a required field and specifies the name of the Linux kernel
+    function to attach the FEntry program. function must not be an empty string,
+    must not exceed 64 characters in length, must start with alpha characters
+    and must only contain alphanumeric characters.
+
+  links	<[]Object>
+    links is a list of attachment points for the FEntry program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.fentry.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the FEntry program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.fexit
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: fexit <Object>
+
+
+DESCRIPTION:
+    fexit contains the attachment data for an FExit program when type is set to
+    FExit.
+    
+FIELDS:
+  function	<string> -required-
+    function is a required field and specifies the name of the Linux kernel
+    function to attach the FExit program. function must not be an empty string,
+    must not exceed 64 characters in length, must start with alpha characters
+    and must only contain alphanumeric characters.
+
+  links	<[]Object>
+    links is a list of attachment points for the FExit program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.fexit.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the FExit program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.kprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: kprobe <Object>
+
+
+DESCRIPTION:
+    kprobe contains the attachment data for a KProbe program when type is set to
+    KProbe.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the KProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.kprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the KProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  function	<string> -required-
+    function is the provisioned name of the Linux kernel function the KProbe
+    program should be attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  offset	<integer>
+    offset is the provisioned offset, whose value is added to the address of the
+    attachment point function.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.kretprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: kretprobe <Object>
+
+
+DESCRIPTION:
+    kretprobe contains the attachment data for a KRetProbe program when type is
+    set to KRetProbe.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the KRetProbe program. Each entry
+    in the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.kretprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the KRetProbe program. Each entry
+    in the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  function	<string> -required-
+    function is the provisioned name of the Linux kernel function the KRetProbe
+    program should be attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.tc
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: tc <Object>
+
+
+DESCRIPTION:
+    tc contains the attachment data for a TC program when type is set to TC.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the TC program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.tc.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the TC program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is the provisioned direction of traffic, Ingress or Egress, the TC
+    program should be attached for a given network device.
+
+  interfaceName	<string> -required-
+    interfaceName is the name of the interface the TC program should be
+    attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  netnsPath	<string>
+    netnsPath is the optional path to the network namespace inside of which the
+    TC program should be attached.
+
+  priority	<integer> -required-
+    priority is the provisioned priority of the TC program in relation to other
+    programs of the same type with the same attach point. It is a value from 0
+    to 1000, where lower values have higher precedence.
+
+  proceedOn	<[]string> -required-
+    proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+    user to call other TC programs in a chain, or not call the next program in a
+    chain based on the exit code of a TC program .Multiple values are supported.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.tcx
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: tcx <Object>
+
+
+DESCRIPTION:
+    tcx contains the attachment data for a TCX program when type is set to TCX.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the TCX program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.tcx.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the TCX program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  direction	<string> -required-
+  enum: Ingress, Egress
+    direction is the provisioned direction of traffic, Ingress or Egress, the TC
+    program should be attached for a given network device.
+
+  interfaceName	<string> -required-
+    interfaceName is the name of the interface the TCX program should be
+    attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  netnsPath	<string>
+    netnsPath is the optional path to the network namespace inside of which the
+    TCX program should be attached.
+
+  priority	<integer> -required-
+    priority is the provisioned priority of the TCX program in relation to other
+    programs of the same type with the same attach point. It is a value from 0
+    to 1000, where lower values have higher precedence.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.tracepoint
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: tracepoint <Object>
+
+
+DESCRIPTION:
+    tracepoint contains the attachment data for a Tracepoint program when type
+    is set to Tracepoint.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the Tracepoint program. Each entry
+    in the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.tracepoint.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the Tracepoint program. Each entry
+    in the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  name	<string> -required-
+    The name of a kernel tracepoint to attach the bpf program to.
+    name is the provisioned name of the Linux kernel tracepoint function the
+    Tracepoint program should be attached.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.uprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: uprobe <Object>
+
+
+DESCRIPTION:
+    uprobe contains the attachment data for a UProbe program when type is set to
+    UProbe.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.uprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  containerPid	<integer>
+    If containers is provisioned in the ClusterBpfApplication instance,
+    containerPid is the derived PID of the container the UProbe or URetProbe
+    this
+    attachment point is attached.
+
+  function	<string>
+    function is the provisioned name of the user-space function the UProbe
+    program should be attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  offset	<integer>
+    offset is the provisioned offset, whose value is added to the address of the
+    attachment point function.
+
+  pid	<integer>
+    pid is the provisioned pid. If set, pid limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  target	<string> -required-
+    target is the provisioned user-space library name or the absolute path to a
+    binary or library.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.uretprobe
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: uretprobe <Object>
+
+
+DESCRIPTION:
+    uretprobe contains the attachment data for a URetProbe program when type is
+    set to URetProbe.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.uretprobe.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the UProbe program. Each entry in
+    the list includes a linkStatus, which indicates if the attachment was
+    successful or not on this node, a linkId, which is the kernel ID for the
+    link if successfully attached, and other attachment specific data.
+    
+FIELDS:
+  containerPid	<integer>
+    If containers is provisioned in the ClusterBpfApplication instance,
+    containerPid is the derived PID of the container the UProbe or URetProbe
+    this
+    attachment point is attached.
+
+  function	<string>
+    function is the provisioned name of the user-space function the UProbe
+    program should be attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  offset	<integer>
+    offset is the provisioned offset, whose value is added to the address of the
+    attachment point function.
+
+  pid	<integer>
+    pid is the provisioned pid. If set, pid limits the execution of the UProbe
+    or URetProbe to the provided process identification number (PID). If pid is
+    not provided, the UProbe or URetProbe executes for all PIDs.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  target	<string> -required-
+    target is the provisioned user-space library name or the absolute path to a
+    binary or library.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.xdp
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: xdp <Object>
+
+
+DESCRIPTION:
+    xdp contains the attachment data for an XDP program when type is set to XDP.
+    
+FIELDS:
+  links	<[]Object>
+    links is a list of attachment points for the XDP program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+
+$ kubectl explain ClusterBpfApplicationState.status.programs.xdp.links
+GROUP:      bpfman.io
+KIND:       ClusterBpfApplicationState
+VERSION:    v1alpha1
+
+FIELD: links <[]Object>
+
+
+DESCRIPTION:
+    links is a list of attachment points for the XDP program. Each entry in the
+    list includes a linkStatus, which indicates if the attachment was successful
+    or not on this node, a linkId, which is the kernel ID for the link if
+    successfully attached, and other attachment specific data.
+    
+FIELDS:
+  interfaceName	<string> -required-
+    interfaceName is the name of the interface the XDP program should be
+    attached.
+
+  linkId	<integer>
+    linkId is an identifier for the link assigned by bpfman. This field is
+    empty until the program is successfully attached and bpfman returns the
+    id.
+
+  linkStatus	<string> -required-
+    linkStatus reflects whether the attachment has been reconciled
+    successfully, and if not, why.
+
+  netnsPath	<string>
+    netnsPath is the optional path to the network namespace inside of which the
+    XDP program should be attached.
+
+  priority	<integer> -required-
+    priority is the provisioned priority of the XDP program in relation to other
+    programs of the same type with the same attach point. It is a value from 0
+    to 1000, where lower values have higher precedence.
+
+  proceedOn	<[]string> -required-
+    proceedOn is the provisioned list of proceedOn values. proceedOn allows the
+    user to call other TC programs in a chain, or not call the next program in a
+    chain based on the exit code of a TC program .Multiple values are supported.
+
+  shouldAttach	<boolean> -required-
+    shouldAttach reflects whether the attachment should exist.
+
+  uuid	<string> -required-
+    uuid is an Unique identifier for the attach point assigned by bpfman agent.
+

--- a/hack/crd_explain_txt.sh
+++ b/hack/crd_explain_txt.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# This script can be called from the base source directory of the repository,
+# or from within the "hack/" subdirectory where the script lives. Otherwise
+# bail because the output is dumped to a known location and calling from any
+# other directories will cause issues.
+CALL_POPD=false
+if [[ "$PWD" != */hack ]]; then
+    pushd hack &>/dev/null || exit
+fi
+
+DEBUG=${DEBUG:-false}
+OUTPUT_DIR=${OUTPUT_DIR:-""}
+CRD_1=${CRD_1:-""}
+CRD_2=${CRD_2:-""}
+CRD_3=${CRD_3:-""}
+CRD_4=${CRD_4:-""}
+CRD_5=${CRD_5:-""}
+CRD_6=${CRD_6:-""}
+CRD_7=${CRD_7:-""}
+CRD_8=${CRD_8:-""}
+
+CRD_LIST=(
+  ${CRD_1}
+  ${CRD_2}
+  ${CRD_3}
+  ${CRD_4}
+  ${CRD_5}
+  ${CRD_6}
+  ${CRD_7}
+  ${CRD_8}
+)
+
+process-command() {
+  local object=$1
+  local filename=$2
+  local -a subObject=()
+
+  # DEBUG
+  if [[ "$DEBUG" == true ]]; then
+    echo "\$ kubectl explain $object"
+  fi
+
+  # Run the "kubectl explain" command and dump output to file.
+  echo "\$ kubectl explain $object" >> ${filename}
+  cmdOutput=$(kubectl explain $object)
+  echo "${cmdOutput}" >> ${filename}
+  echo "" >> ${filename}
+
+  # Find Sub-Objects, which will be the token before "<Object>".
+  # - "<Objects>" may be a list of objects, like "<[]Object>", so
+  #   search for *"Object>".
+  # - Ignore "<Object>" when the string is in the header, which will
+  #   look like "FIELD: status <Object>"
+  # Read the ${cmdOutput} line by line and store any Sub-Objects
+  # found in the array ${subObject}.
+  # Then recursively call this function to repeat the process.
+  local substring="Object>"
+  local substringIgnore="FIELD:"
+  while IFS= read -r line; do
+    # Skip lines that don't contain the substring
+    [[ "$line" != *"$substring"* ]] && continue
+
+    # Split line into words
+    read -ra words <<< "$line"
+
+    # Search through words to find matches of the substring
+    for ((i=0; i<${#words[@]}; i++)); do
+        if [[ "${words[i]}" == *"$substring" ]]; then
+            # Check if two words before is "FIELD:"
+            if (( i >= 2 )) && [[ "${words[i-2]}" == "$substringIgnore" ]]; then
+                continue  # skip this occurrence
+            fi
+
+            # Check if we have a word before to extract
+            if (( i >= 1 )); then
+                subObject+=("${words[i-1]}")
+            fi
+        fi
+    done
+  done <<< "${cmdOutput}"
+
+  for i in "${!subObject[@]}"
+  do
+    process-command "${object}.${subObject[$i]}" ${filename}
+  done
+}
+
+# Main
+
+echo ""
+echo "WARNING: Script runs \"kubectl explain\" commands against cluster specified in ~/.kube/config."
+echo "         Ensure Kubernetes cluster is running latest code."
+echo ""
+
+# Test for kubectl or oc
+#kubectl version  &>/dev/null
+if [ $? != 0 ]; then
+  oc version  &>/dev/null
+  if [ $? != 0 ]; then
+    echo "ERROR: Either \`kubectl\` or \`oc\` must be installed. Exiting ..."
+    echo
+    exit 1
+  fi
+
+  alias kubectl="oc"
+fi
+
+# Test for Cluster
+kubectl get nodes &>/dev/null
+if [ $? != 0 ]; then
+  echo "ERROR: Kubernetes Cluster not detected. Exiting ..."
+  echo
+  exit 1
+fi
+
+# Loop through each Custom Resource Definition defined in the list
+for i in "${!CRD_LIST[@]}"
+do
+  if [[ ${CRD_LIST[$i]} != "" ]]; then
+    filename="${OUTPUT_DIR}/${CRD_LIST[$i]}.txt"
+
+    rm -f ${filename} || true
+    process-command ${CRD_LIST[$i]} ${filename}
+
+    # DEBUG
+    if [[ "$DEBUG" == true ]]; then
+      echo ""
+    fi
+  fi
+done
+
+if [[ "$CALL_POPD" == true ]]; then
+    popd &>/dev/null || exit
+fi


### PR DESCRIPTION
Add a script that given the root CRD name, will run `kubectl explain` on all <Object> and sub-<Object> fields and pipe the output to a txt file that is checked in. Also add `make explain` to the Makefile to automate the running of the script. This serves two purposes:
1) Documents the CRDs in an easily readable format for users of the CRD.
2) Currently needs to be manually run, but shows how changes to the API effect the CRDs. This could be automated in the github workflow if the CRDs are loaded into a Kubernetes cluster in github actions.