### PR TITLE
Makefile: Target run-local, ignore scaling issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ build-release-yamls: generate kustomize ## Generate the crd install bundle for a
 
 .PHONY: run-local
 run-local: build ## Run the bpfman-operator locally for development purposes.
-	kubectl scale deployment -n bpfman bpfman-operator --replicas=0
+	kubectl scale deployment -n bpfman bpfman-operator --replicas=0 || true
 	GO_LOG=debug bin/bpfman-operator
 
 ##@ Build


### PR DESCRIPTION
Small fix - ignore issue when scaling with run-local. This happens e.g. if the operator deployment isn't present and as such scaling won't work