### PR TITLE
Add Config CRD description and sample to OLM bundle

### DIFF
--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -989,12 +989,32 @@ metadata:
             ],
             "updateCount": 2
           }
+        },
+        {
+          "apiVersion": "bpfman.io/v1alpha1",
+          "kind": "Config",
+          "metadata": {
+            "name": "bpfman-config"
+          },
+          "spec": {
+            "agent": {
+              "healthProbePort": 8175,
+              "image": "quay.io/bpfman/bpfman-agent:latest",
+              "logLevel": "info"
+            },
+            "configuration": "[database]\nmax_retries = 30\nmillisec_delay = 10000\n[signing]\nallow_unsigned = true\nverify_enabled = true\n",
+            "daemon": {
+              "image": "quay.io/bpfman/bpfman:latest",
+              "logLevel": "info"
+            },
+            "namespace": "bpfman"
+          }
         }
       ]
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:latest
-    createdAt: "2026-03-26T13:54:10Z"
+    createdAt: "2026-03-27T11:48:36Z"
     description: The bpfman Operator is designed to manage eBPF programs for applications.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -1060,7 +1080,9 @@ spec:
       kind: ClusterBpfApplicationState
       name: clusterbpfapplicationstates.bpfman.io
       version: v1alpha1
-    - kind: Config
+    - description: Config is the Schema for the bpfman operator configuration API
+      displayName: Bpfman Config
+      kind: Config
       name: configs.bpfman.io
       version: v1alpha1
   description: "The bpfman Operator is a Kubernetes Operator for deploying [bpfman](https://bpfman.netlify.app/),

--- a/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -66,6 +66,11 @@ spec:
         kind: BpfApplicationState
         name: bpfapplicationstates.bpfman.io
         version: v1alpha1
+      - description: Config is the Schema for the bpfman operator configuration API
+        displayName: Bpfman Config
+        kind: Config
+        name: configs.bpfman.io
+        version: v1alpha1
   description:
     "The bpfman Operator is a Kubernetes Operator for deploying [bpfman](https://bpfman.netlify.app/),
     a system daemon\nfor managing eBPF programs. It deploys bpfman itself along with

--- a/config/samples/bpfman.io_v1alpha1_config.yaml
+++ b/config/samples/bpfman.io_v1alpha1_config.yaml
@@ -1,0 +1,20 @@
+apiVersion: bpfman.io/v1alpha1
+kind: Config
+metadata:
+  name: bpfman-config
+spec:
+  agent:
+    healthProbePort: 8175
+    image: quay.io/bpfman/bpfman-agent:latest
+    logLevel: info
+  configuration: |
+    [database]
+    max_retries = 30
+    millisec_delay = 10000
+    [signing]
+    allow_unsigned = true
+    verify_enabled = true
+  daemon:
+    image: quay.io/bpfman/bpfman:latest
+    logLevel: info
+  namespace: bpfman

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - bpfman.io_v1alpha1_clusterbpfapplication.yaml
   - bpfman.io_v1alpha1_bpfapplicationstate.yaml
   - bpfman.io_v1alpha1_clusterbpfapplicationstate.yaml
+  - bpfman.io_v1alpha1_config.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
## Summary

- Add description and display name for the Config CRD in the CSV owned CRDs list
- Add a Config sample CR derived from the operator's default-config output
- Regenerate the OLM bundle

The community-operators CI flagged the Config CRD as having an empty
description and no example annotation. This addresses both warnings so
the bundle validates cleanly with `operator-sdk bundle validate
--select-optional suite=operatorframework`.

## Test plan

- [x] `operator-sdk bundle validate ./bundle` passes
- [x] `operator-sdk bundle validate ./bundle --select-optional suite=operatorframework` passes