### PR TITLE
Add `IMAGE_ORG` variable to `Makefile` and add `DEVELOPMENT.md`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,71 @@
+# Development
+
+This guide covers deploying the bpfman-operator using OLM on an OpenShift cluster.
+
+## Prerequisites
+
+- Access to an OpenShift cluster via `kubectl`/`oc`
+- A container image registry (quay.io by default)
+- `docker` or `podman` available locally
+
+## Configuration
+
+All image references are derived from a small set of Makefile variables that can be overridden via environment variables or on the `make` command line:
+
+| Variable | Default | Description |
+|---|---|---|
+| `IMAGE_ORG` | `bpfman` | Registry namespace under `quay.io` |
+| `IMAGE_TAG` | `latest` | Tag for `bpfman`, `bpfman-agent`, and `bpfman-operator` images |
+| `VERSION` | contents of `VERSION` file | Operator and bundle version |
+| `BUNDLE_IMG` | `quay.io/<IMAGE_ORG>/bpfman-operator-bundle:v<VERSION>` | OLM bundle image |
+| `CATALOG_IMG` | `quay.io/<IMAGE_ORG>/bpfman-operator-catalog:v<VERSION>` | OLM catalog image |
+
+For example, to use a personal registry namespace:
+
+```sh
+make bundle-deploy-openshift IMAGE_ORG=myuser IMAGE_TAG=dev
+```
+
+## Bundle Deployment
+
+The bundle deployment builds all operator images, generates and pushes an OLM bundle, then installs the operator via `operator-sdk run bundle`.
+
+```sh
+make bundle-deploy-openshift
+```
+
+This target will:
+
+1. Build `bpfman-operator` and `bpfman-agent` container images.
+2. Push the images to the registry.
+3. Generate the OLM bundle manifests.
+4. Build and push the bundle image.
+5. Run the bundle in the `bpfman` namespace on the current cluster.
+
+To remove the bundle deployment:
+
+```sh
+make bundle-undeploy
+```
+
+## Catalog Deployment
+
+The catalog deployment performs the same steps as the bundle deployment and additionally builds an OLM catalog image and applies a `CatalogSource` to the cluster. This makes the operator available through the OperatorHub UI.
+
+```sh
+make catalog-deploy
+```
+
+This target will:
+
+1. Build `bpfman-operator` and `bpfman-agent` container images.
+2. Push the images to the registry.
+3. Generate the OLM bundle manifests.
+4. Build and push both the bundle and catalog images.
+5. Apply the `bpfmanoperator-dev-catalog` CatalogSource to the cluster.
+
+To remove the catalog deployment:
+
+```sh
+make catalog-undeploy
+```

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,13 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+IMAGE_ORG ?= bpfman
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # bpfman.io/bpfman-operator-bundle:$VERSION and bpfman.io/bpfman-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/bpfman/bpfman-operator
+IMAGE_TAG_BASE ?= quay.io/$(IMAGE_ORG)/bpfman-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -51,9 +52,9 @@ endif
 IMAGE_TAG ?= latest
 # Default upstream image references. Override via environment or .envrc
 # for local development (for example, to point at a private registry).
-BPFMAN_IMG ?= quay.io/bpfman/bpfman:$(IMAGE_TAG)
-BPFMAN_AGENT_IMG ?= quay.io/bpfman/bpfman-agent:$(IMAGE_TAG)
-BPFMAN_OPERATOR_IMG ?= quay.io/bpfman/bpfman-operator:$(IMAGE_TAG)
+BPFMAN_IMG ?= quay.io/$(IMAGE_ORG)/bpfman:$(IMAGE_TAG)
+BPFMAN_AGENT_IMG ?= quay.io/$(IMAGE_ORG)/bpfman-agent:$(IMAGE_TAG)
+BPFMAN_OPERATOR_IMG ?= quay.io/$(IMAGE_ORG)/bpfman-operator:$(IMAGE_TAG)
 KIND_CLUSTER_NAME ?= bpfman-deployment
 KIND_REGISTRY_NAME ?= kind-registry
 KIND_REGISTRY_PORT ?= 5001
@@ -594,7 +595,7 @@ undeploy-openshift: kustomize ## Undeploy bpfman-operator from the Openshift clu
 
 # Deploy the catalog.
 .PHONY: catalog-deploy
-catalog-deploy: ## Deploy a catalog image.
+catalog-deploy: operator-sdk build-images push-images bundle bundle-build bundle-push catalog-build catalog-push ## Deploy a catalog image.
 	$(SED) -e 's~<IMAGE>~$(CATALOG_IMG)~' ./config/catalog/catalog.yaml | kubectl apply -f -
 
 # Undeploy the catalog.


### PR DESCRIPTION
Introduce `IMAGE_ORG` to parameterize the registry organization across `IMAGE_TAG_BASE`, `BPFMAN_IMG`, `BPFMAN_AGENT_IMG`, and `BPFMAN_OPERATOR_IMG`. Add build/push prerequisites to the `catalog-deploy` target.

Add `DEVELOPMENT.md` documenting the OLM bundle and catalog deployment workflows, configurable variables, and cleanup commands.

Co-Authored-By: Claude