### PR TITLE
Update OLM CSV description to reflect `Config` CR

### DIFF
--- a/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/bpfman-operator.clusterserviceversion.yaml
@@ -1014,7 +1014,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/bpfman/bpfman-operator:latest
-    createdAt: "2026-03-27T11:48:36Z"
+    createdAt: "2026-04-30T15:50:43Z"
     description: The bpfman Operator is designed to manage eBPF programs for applications.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -1085,22 +1085,42 @@ spec:
       kind: Config
       name: configs.bpfman.io
       version: v1alpha1
-  description: "The bpfman Operator is a Kubernetes Operator for deploying [bpfman](https://bpfman.netlify.app/),
-    a system daemon\nfor managing eBPF programs. It deploys bpfman itself along with
-    CRDs to make deploying\neBPF programs in Kubernetes much easier.\n\n## Quick Start\n\nTo
-    get bpfman up and running quickly simply click 'install' to deploy the bpfman-operator
-    in the bpfman namespace via operator-hub.\n## Configuration\n\nThe `bpfman-config`
-    configmap is automatically created in the `bpfman` namespace and used to configure
-    the bpfman deployment.\n\nTo edit the config simply run\n\n```bash\nkubectl edit
-    cm bpfman-config\n```\n\nThe following fields are adjustable\n\n- `bpfman.agent.image`:
-    The image used for the bpfman-agent`\n- `bpfman.image`: The image used for bpfman`\n-
-    `bpfman.log.level`: the log level for bpfman, currently supports `debug`, `info`,
-    `warn`, `error`, and `fatal`, defaults to `info`\n- `bpfman.agent.log.level`:
-    the log level for the bpfman-agent currently supports `info`, `debug`, and `trace`
-    \n\nThe bpfman operator deploys eBPF programs via CRDs. The following CRDs are
-    currently available, \n\n- BpfApplication\n- ClusterBpfApplication\n - BpfApplicationState\n-
-    ClusterBpfApplicationState\n\n ## More information\n\nPlease checkout the [bpfman
-    community website](https://bpfman.io/) for more information."
+  description: |-
+    The bpfman Operator is a Kubernetes Operator for deploying [bpfman](https://bpfman.io/), a system daemon
+    for managing eBPF programs. It deploys bpfman itself along with CRDs to make deploying
+    eBPF programs in Kubernetes much easier.
+
+    ## Quick Start
+
+    To get bpfman up and running quickly simply click 'install' to deploy the bpfman-operator in the bpfman namespace via operator-hub.
+    ## Configuration
+
+    A default `Config` CR is automatically created in the cluster when the operator starts.
+    To edit the configuration run
+
+    ```bash
+    kubectl edit config bpfman-config
+    ```
+
+    The following fields are adjustable under `spec`
+
+    - `agent.image`: The image used for the bpfman-agent
+    - `agent.logLevel`: The log level for the bpfman-agent, supports `info`, `debug`, and `trace`
+    - `daemon.image`: The image used for bpfman
+    - `daemon.logLevel`: The log level for bpfman, supports `debug`, `info`, `warn`, `error`, and `fatal`, defaults to `info`
+    - `configuration`: The content of the bpfman.toml configuration file
+    - `namespace`: The namespace where bpfman resources are deployed
+
+    The bpfman operator deploys eBPF programs via CRDs. The following CRDs are currently available
+
+    - BpfApplication
+    - ClusterBpfApplication
+    - BpfApplicationState
+    - ClusterBpfApplicationState
+
+    ## More information
+
+    Please checkout the [bpfman community website](https://bpfman.io/) for more information.
   displayName: Bpfman Operator
   icon:
   - base64data: |

--- a/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/bpfman-operator.clusterserviceversion.yaml
@@ -72,22 +72,23 @@ spec:
         name: configs.bpfman.io
         version: v1alpha1
   description:
-    "The bpfman Operator is a Kubernetes Operator for deploying [bpfman](https://bpfman.netlify.app/),
+    "The bpfman Operator is a Kubernetes Operator for deploying [bpfman](https://bpfman.io/),
     a system daemon\nfor managing eBPF programs. It deploys bpfman itself along with
     CRDs to make deploying\neBPF programs in Kubernetes much easier.\n\n##
     Quick Start\n\nTo get bpfman up and running quickly simply click 'install'
     to deploy the bpfman-operator in the bpfman namespace via operator-hub.\n##
-    Configuration\n\nThe `bpfman-config` configmap is automatically created in the `bpfman`
-    namespace and used to configure the bpfman deployment.\n\nTo edit the config simply
-    run\n\n```bash\nkubectl edit cm bpfman-config\n```\n\nThe following fields are adjustable\n\n-
-    `bpfman.agent.image`: The image used for the bpfman-agent`\n- `bpfman.image`: The 
-    image used for bpfman`\n- `bpfman.log.level`: the log level for bpfman, currently 
-    supports `debug`, `info`, `warn`, `error`, and `fatal`, defaults to `info`\n- 
-    `bpfman.agent.log.level`: the log level for the bpfman-agent currently supports 
-    `info`, `debug`, and `trace` \n\nThe bpfman operator deploys eBPF programs via CRDs. 
-    The following CRDs are currently available, \n\n- BpfApplication\n- ClusterBpfApplication\n
-    - BpfApplicationState\n- ClusterBpfApplicationState\n\n
-    ## More information\n\nPlease checkout the [bpfman community website](https://bpfman.io/) 
+    Configuration\n\nA default `Config` CR is automatically created in the cluster
+    when the operator starts.\nTo edit the configuration run\n\n```bash\nkubectl edit
+    config bpfman-config\n```\n\nThe following fields are adjustable under `spec`\n\n-
+    `agent.image`: The image used for the bpfman-agent\n- `agent.logLevel`: The log
+    level for the bpfman-agent, supports `info`, `debug`, and `trace`\n- `daemon.image`:
+    The image used for bpfman\n- `daemon.logLevel`: The log level for bpfman, supports
+    `debug`, `info`, `warn`, `error`, and `fatal`, defaults to `info`\n- `configuration`:
+    The content of the bpfman.toml configuration file\n- `namespace`: The namespace
+    where bpfman resources are deployed\n\nThe bpfman operator deploys eBPF programs
+    via CRDs. The following CRDs are currently available\n\n- BpfApplication\n-
+    ClusterBpfApplication\n- BpfApplicationState\n- ClusterBpfApplicationState\n\n##
+    More information\n\nPlease checkout the [bpfman community website](https://bpfman.io/)
     for more information."
   displayName: Bpfman Operator
   icon:


### PR DESCRIPTION
Update the operator description in both the bundle and base CSV manifests to document the `Config` CR instead of the removed `bpfman-config` configmap. Update configuration field names to match the current `Config` spec (`agent.image`, `agent.logLevel`, `daemon.image`, `daemon.logLevel`, `configuration`, `namespace`). Fix the bpfman project URL from netlify to bpfman.io.

Co-Authored-By: Claude

<img width="958" height="1278" alt="image" src="https://github.com/user-attachments/assets/c0fef1e5-7c15-4bab-8756-583950be0285" />