### PR TITLE
Add setup-envtest to tools.go for vendoring

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -177,7 +177,15 @@ jobs:
         run: make verify
 
       - name: Check clean vendors
-        run: go mod vendor
+        run: |
+          go mod tidy
+          go mod vendor
+          if [ -n "$(git status --porcelain vendor go.mod go.sum)" ]; then
+            echo "vendor/, go.mod or go.sum is out of sync with 'go mod tidy && go mod vendor':"
+            git status --porcelain vendor go.mod go.sum
+            git diff -- vendor go.mod go.sum
+            exit 1
+          fi
 
       - name: Verify generated bundle manifest
         run: |

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,6 @@ REGISTER_GEN ?= $(LOCALBIN)/register-gen
 INFORMER_GEN ?= $(LOCALBIN)/informer-gen
 LISTER_GEN ?= $(LOCALBIN)/lister-gen
 CLIENT_GEN ?= $(LOCALBIN)/client-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
 CM_VERIFIER ?= $(LOCALBIN)/cm-verifier
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 KIND ?= $(LOCALBIN)/kind
@@ -210,11 +209,6 @@ $(LISTER_GEN): $(LOCALBIN)
 client-gen: $(CLIENT_GEN) ## Download client-gen locally if necessary.
 $(CLIENT_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/client-gen || GOBIN=$(LOCALBIN) go install k8s.io/code-generator/cmd/client-gen@$(K8S_CODEGEN_VERSION)
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: opm
 OPM = ./bin/opm
@@ -323,8 +317,8 @@ lint: prereqs ## Run linter (golangci-lint).
 # 	./hack/verify-golint.sh
 
 .PHONY: test
-test: fmt envtest ## Run Unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+test: fmt ## Run Unit tests.
+	KUBEBUILDER_ASSETS="$(shell go run sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 
 .PHONY: test-integration

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,14 @@ lint: prereqs ## Run linter (golangci-lint).
 
 .PHONY: test
 test: fmt ## Run Unit tests.
-	KUBEBUILDER_ASSETS="$(shell go run sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	@set -e ; \
+	KUBEBUILDER_ASSETS="$$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" ; \
+	if [ -z "$$KUBEBUILDER_ASSETS" ]; then \
+		echo "setup-envtest produced an empty KUBEBUILDER_ASSETS path" >&2 ; \
+		exit 1 ; \
+	fi ; \
+	echo KUBEBUILDER_ASSETS=\"$$KUBEBUILDER_ASSETS\" go test ./... -coverprofile cover.out ; \
+	KUBEBUILDER_ASSETS="$$KUBEBUILDER_ASSETS" go test ./... -coverprofile cover.out
 
 
 .PHONY: test-integration

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/code-generator v0.34.3
 	k8s.io/cri-api v0.35.0
 	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260125163108-a19ec76a3c5d
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -58,6 +59,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/safchain/ethtool v0.5.10 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/urfave/cli/v2 v2.27.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
-github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
@@ -205,13 +205,13 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
-github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
-github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
+github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=
+github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
-github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
+github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20240605201059-cefcda60d938 h1:3Y0E8q6pFb8PgzW0N52jVZBollMeW1kI13iU/vXPCnc=
@@ -467,6 +467,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260125163108-a19ec76a3c5d h1:6T4i0BkeMiYtoW7vbOUcStoSK9GYghRaXGPgpBWVj9k=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260125163108-a19ec76a3c5d/go.mod h1:ps7VOLAkxwg0wlBVhTgPru3FFcrV23/AIPpRoRFpgSo=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.30.0 h1:2Xi1KFEfSMm0XDcvKnUt15ZfgRPCT0OnCBbpgh8DztY=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
+)

--- a/vendor/github.com/spf13/afero/.editorconfig
+++ b/vendor/github.com/spf13/afero/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/vendor/github.com/spf13/afero/.gitignore
+++ b/vendor/github.com/spf13/afero/.gitignore
@@ -1,0 +1,2 @@
+sftpfs/file1
+sftpfs/test/

--- a/vendor/github.com/spf13/afero/.golangci.yaml
+++ b/vendor/github.com/spf13/afero/.golangci.yaml
@@ -1,0 +1,48 @@
+version: "2"
+
+run:
+  timeout: 10m
+
+linters:
+  enable:
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    # - revive
+    - staticcheck
+    - unused
+
+  disable:
+    - errcheck
+    # - staticcheck
+
+  settings:
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false # report any unused nolint directives
+      require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+  exclusions:
+    paths:
+      - gcsfs/internal/stiface
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+
+  exclusions:
+    paths:
+      - gcsfs/internal/stiface

--- a/vendor/github.com/spf13/afero/LICENSE.txt
+++ b/vendor/github.com/spf13/afero/LICENSE.txt
@@ -1,0 +1,174 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/vendor/github.com/spf13/afero/README.md
+++ b/vendor/github.com/spf13/afero/README.md
@@ -1,0 +1,474 @@
+<img src="https://cloud.githubusercontent.com/assets/173412/11490338/d50e16dc-97a5-11e5-8b12-019a300d0fcb.png" alt="afero logo-sm"/>
+
+
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/spf13/afero/ci.yaml?branch=master&amp;style=flat-square)](https://github.com/spf13/afero/actions?query=workflow%3ACI)
+[![GoDoc](https://pkg.go.dev/badge/mod/github.com/spf13/afero)](https://pkg.go.dev/mod/github.com/spf13/afero)
+[![Go Report Card](https://goreportcard.com/badge/github.com/spf13/afero)](https://goreportcard.com/report/github.com/spf13/afero)
+![Go Version](https://img.shields.io/badge/go%20version-%3E=1.23-61CFDD.svg?style=flat-square")
+
+
+# Afero: The Universal Filesystem Abstraction for Go
+
+Afero is a powerful and extensible filesystem abstraction system for Go. It provides a single, unified API for interacting with diverse filesystems—including the local disk, memory, archives, and network storage.
+
+Afero acts as a drop-in replacement for the standard `os` package, enabling you to write modular code that is agnostic to the underlying storage, dramatically simplifies testing, and allows for sophisticated architectural patterns through filesystem composition.
+
+## Why Afero?
+
+Afero elevates filesystem interaction beyond simple file reading and writing, offering solutions for testability, flexibility, and advanced architecture.
+
+🔑 **Key Features:**
+
+*   **Universal API:** Write your code once. Run it against the local OS, in-memory storage, ZIP/TAR archives, or remote systems (SFTP, GCS).
+*   **Ultimate Testability:** Utilize `MemMapFs`, a fully concurrent-safe, read/write in-memory filesystem. Write fast, isolated, and reliable unit tests without touching the physical disk or worrying about cleanup.
+*   **Powerful Composition:** Afero's hidden superpower. Layer filesystems on top of each other to create sophisticated behaviors:
+    *   **Sandboxing:** Use `CopyOnWriteFs` to create temporary scratch spaces that isolate changes from the base filesystem.
+    *   **Caching:** Use `CacheOnReadFs` to automatically layer a fast cache (like memory) over a slow backend (like a network drive).
+    *   **Security Jails:** Use `BasePathFs` to restrict application access to a specific subdirectory (chroot).
+*   **`os` Package Compatibility:** Afero mirrors the functions in the standard `os` package, making adoption and refactoring seamless.
+*   **`io/fs` Compatibility:** Fully compatible with the Go standard library's `io/fs` interfaces.
+
+## Installation
+
+```bash
+go get github.com/spf13/afero
+```
+
+```go
+import "github.com/spf13/afero"
+```
+
+## Quick Start: The Power of Abstraction
+
+The core of Afero is the `afero.Fs` interface. By designing your functions to accept this interface rather than calling `os.*` functions directly, your code instantly becomes more flexible and testable.
+
+### 1. Refactor Your Code
+
+Change functions that rely on the `os` package to accept `afero.Fs`.
+
+```go
+// Before: Coupled to the OS and difficult to test
+// func ProcessConfiguration(path string) error {
+//     data, err := os.ReadFile(path)
+//     ...
+// }
+
+import "github.com/spf13/afero"
+
+// After: Decoupled, flexible, and testable
+func ProcessConfiguration(fs afero.Fs, path string) error {
+    // Use Afero utility functions which mirror os/ioutil
+    data, err := afero.ReadFile(fs, path)
+    // ... process the data
+    return err
+}
+```
+
+### 2. Usage in Production
+
+In your production environment, inject the `OsFs` backend, which wraps the standard operating system calls.
+
+```go
+func main() {
+    // Use the real OS filesystem
+    AppFs := afero.NewOsFs()
+    ProcessConfiguration(AppFs, "/etc/myapp.conf")
+}
+```
+
+### 3. Usage in Testing
+
+In your tests, inject `MemMapFs`. This provides a blazing-fast, isolated, in-memory filesystem that requires no disk I/O and no cleanup.
+
+```go
+func TestProcessConfiguration(t *testing.T) {
+    // Use the in-memory filesystem
+    AppFs := afero.NewMemMapFs()
+    
+    // Pre-populate the memory filesystem for the test
+    configPath := "/test/config.json"
+    afero.WriteFile(AppFs, configPath, []byte(`{"feature": true}`), 0644)
+
+    // Run the test entirely in memory
+    err := ProcessConfiguration(AppFs, configPath)
+    if err != nil {
+        t.Fatal(err)
+    }
+}
+```
+
+## Afero's Superpower: Composition
+
+Afero's most unique feature is its ability to combine filesystems. This allows you to build complex behaviors out of simple components, keeping your application logic clean.
+
+### Example 1: Sandboxing with Copy-on-Write
+
+Create a temporary environment where an application can "modify" system files without affecting the actual disk.
+
+```go
+// 1. The base layer is the real OS, made read-only for safety.
+baseFs := afero.NewReadOnlyFs(afero.NewOsFs())
+
+// 2. The overlay layer is a temporary in-memory filesystem for changes.
+overlayFs := afero.NewMemMapFs()
+
+// 3. Combine them. Reads fall through to the base; writes only hit the overlay.
+sandboxFs := afero.NewCopyOnWriteFs(baseFs, overlayFs)
+
+// The application can now "modify" /etc/hosts, but the changes are isolated in memory.
+afero.WriteFile(sandboxFs, "/etc/hosts", []byte("127.0.0.1 sandboxed-app"), 0644)
+
+// The real /etc/hosts on disk is untouched.
+```
+
+### Example 2: Caching a Slow Filesystem
+
+Improve performance by layering a fast cache (like memory) over a slow backend (like a network drive or cloud storage).
+
+```go
+import "time"
+
+// Assume 'remoteFs' is a slow backend (e.g., SFTP or GCS)
+var remoteFs afero.Fs 
+
+// 'cacheFs' is a fast in-memory backend
+cacheFs := afero.NewMemMapFs()
+
+// Create the caching layer. Cache items for 5 minutes upon first read.
+cachedFs := afero.NewCacheOnReadFs(remoteFs, cacheFs, 5*time.Minute)
+
+// The first read is slow (fetches from remote, then caches)
+data1, _ := afero.ReadFile(cachedFs, "data.json")
+
+// The second read is instant (serves from memory cache)
+data2, _ := afero.ReadFile(cachedFs, "data.json")
+```
+
+### Example 3: Security Jails (chroot)
+
+Restrict an application component's access to a specific subdirectory.
+
+```go
+osFs := afero.NewOsFs()
+
+// Create a filesystem rooted at /home/user/public
+// The application cannot access anything above this directory.
+jailedFs := afero.NewBasePathFs(osFs, "/home/user/public")
+
+// To the application, this is reading "/"
+// In reality, it's reading "/home/user/public/"
+dirInfo, err := afero.ReadDir(jailedFs, "/")
+
+// Attempts to access parent directories fail
+_, err = jailedFs.Open("../secrets.txt") // Returns an error
+```
+
+## Real-World Use Cases
+
+### Build Cloud-Agnostic Applications
+
+Write applications that seamlessly work with different storage backends:
+
+```go
+type DocumentProcessor struct {
+    fs afero.Fs
+}
+
+func NewDocumentProcessor(fs afero.Fs) *DocumentProcessor {
+    return &DocumentProcessor{fs: fs}
+}
+
+func (p *DocumentProcessor) Process(inputPath, outputPath string) error {
+    // This code works whether fs is local disk, cloud storage, or memory
+    content, err := afero.ReadFile(p.fs, inputPath)
+    if err != nil {
+        return err
+    }
+    
+    processed := processContent(content)
+    return afero.WriteFile(p.fs, outputPath, processed, 0644)
+}
+
+// Use with local filesystem
+processor := NewDocumentProcessor(afero.NewOsFs())
+
+// Use with Google Cloud Storage
+processor := NewDocumentProcessor(gcsFS)
+
+// Use with in-memory filesystem for testing
+processor := NewDocumentProcessor(afero.NewMemMapFs())
+```
+
+### Treating Archives as Filesystems
+
+Read files directly from `.zip` or `.tar` archives without unpacking them to disk first.
+
+```go
+import (
+    "archive/zip"
+    "github.com/spf13/afero/zipfs"
+)
+
+// Assume 'zipReader' is a *zip.Reader initialized from a file or memory
+var zipReader *zip.Reader 
+
+// Create a read-only ZipFs
+archiveFS := zipfs.New(zipReader)
+
+// Read a file from within the archive using the standard Afero API
+content, err := afero.ReadFile(archiveFS, "/docs/readme.md")
+```
+
+### Serving Any Filesystem over HTTP
+
+Use `HttpFs` to expose any Afero filesystem—even one created dynamically in memory—through a standard Go web server.
+
+```go
+import (
+    "net/http"
+    "github.com/spf13/afero"
+)
+
+func main() {
+    memFS := afero.NewMemMapFs()
+    afero.WriteFile(memFS, "index.html", []byte("<h1>Hello from Memory!</h1>"), 0644)
+
+    // Wrap the memory filesystem to make it compatible with http.FileServer.
+    httpFS := afero.NewHttpFs(memFS)
+
+    http.Handle("/", http.FileServer(httpFS.Dir("/")))
+    http.ListenAndServe(":8080", nil)
+}
+```
+
+### Testing Made Simple
+
+One of Afero's greatest strengths is making filesystem-dependent code easily testable:
+
+```go
+func SaveUserData(fs afero.Fs, userID string, data []byte) error {
+    filename := fmt.Sprintf("users/%s.json", userID)
+    return afero.WriteFile(fs, filename, data, 0644)
+}
+
+func TestSaveUserData(t *testing.T) {
+    // Create a clean, fast, in-memory filesystem for testing
+    testFS := afero.NewMemMapFs()
+    
+    userData := []byte(`{"name": "John", "email": "john@example.com"}`)
+    err := SaveUserData(testFS, "123", userData)
+    
+    if err != nil {
+        t.Fatalf("SaveUserData failed: %v", err)
+    }
+    
+    // Verify the file was saved correctly
+    saved, err := afero.ReadFile(testFS, "users/123.json")
+    if err != nil {
+        t.Fatalf("Failed to read saved file: %v", err)
+    }
+    
+    if string(saved) != string(userData) {
+        t.Errorf("Data mismatch: got %s, want %s", saved, userData)
+    }
+}
+```
+
+**Benefits of testing with Afero:**
+- ⚡ **Fast** - No disk I/O, tests run in memory
+- 🔄 **Reliable** - Each test starts with a clean slate
+- 🧹 **No cleanup** - Memory is automatically freed
+- 🔒 **Safe** - Can't accidentally modify real files
+- 🏃 **Parallel** - Tests can run concurrently without conflicts
+
+## Backend Reference
+
+| Type | Backend | Constructor | Description | Status |
+| :--- | :--- | :--- | :--- | :--- |
+| **Core** | **OsFs** | `afero.NewOsFs()` | Interacts with the real operating system filesystem. Use in production. | ✅ Official |
+| | **MemMapFs** | `afero.NewMemMapFs()` | A fast, atomic, concurrent-safe, in-memory filesystem. Ideal for testing. | ✅ Official |
+| **Composition** | **CopyOnWriteFs**| `afero.NewCopyOnWriteFs(base, overlay)` | A read-only base with a writable overlay. Ideal for sandboxing. | ✅ Official |
+| | **CacheOnReadFs**| `afero.NewCacheOnReadFs(base, cache, ttl)` | Lazily caches files from a slow base into a fast layer on first read. | ✅ Official |
+| | **BasePathFs** | `afero.NewBasePathFs(source, path)` | Restricts operations to a subdirectory (chroot/jail). | ✅ Official |
+| | **ReadOnlyFs** | `afero.NewReadOnlyFs(source)` | Provides a read-only view, preventing any modifications. | ✅ Official |
+| | **RegexpFs** | `afero.NewRegexpFs(source, regexp)` | Filters a filesystem, only showing files that match a regex. | ✅ Official |
+| **Utility** | **HttpFs** | `afero.NewHttpFs(source)` | Wraps any Afero filesystem to be served via `http.FileServer`. | ✅ Official |
+| **Archives** | **ZipFs** | `zipfs.New(zipReader)` | Read-only access to files within a ZIP archive. | ✅ Official |
+| | **TarFs** | `tarfs.New(tarReader)` | Read-only access to files within a TAR archive. | ✅ Official |
+| **Network** | **GcsFs** | `gcsfs.NewGcsFs(...)` | Google Cloud Storage backend. | ⚡ Experimental |
+| | **SftpFs** | `sftpfs.New(...)` | SFTP backend. | ⚡ Experimental |
+| **3rd Party Cloud** | **S3Fs** | [`fclairamb/afero-s3`](https://github.com/fclairamb/afero-s3) | Production-ready S3 backend built on official AWS SDK. | 🔹 3rd Party |
+| | **MinioFs** | [`cpyun/afero-minio`](https://github.com/cpyun/afero-minio) | MinIO object storage backend with S3 compatibility. | 🔹 3rd Party |
+| | **DriveFs** | [`fclairamb/afero-gdrive`](https://github.com/fclairamb/afero-gdrive) | Google Drive backend with streaming support. | 🔹 3rd Party |
+| | **DropboxFs** | [`fclairamb/afero-dropbox`](https://github.com/fclairamb/afero-dropbox) | Dropbox backend with streaming support. | 🔹 3rd Party |
+| **3rd Party Specialized** | **GitFs** | [`tobiash/go-gitfs`](https://github.com/tobiash/go-gitfs) | Git repository filesystem (read-only, Afero compatible). | 🔹 3rd Party |
+| | **DockerFs** | [`unmango/aferox`](https://github.com/unmango/aferox) | Docker container filesystem access. | 🔹 3rd Party |
+| | **GitHubFs** | [`unmango/aferox`](https://github.com/unmango/aferox) | GitHub repository and releases filesystem. | 🔹 3rd Party |
+| | **FilterFs** | [`unmango/aferox`](https://github.com/unmango/aferox) | Filesystem filtering with predicates. | 🔹 3rd Party |
+| | **IgnoreFs** | [`unmango/aferox`](https://github.com/unmango/aferox) | .gitignore-aware filtering filesystem. | 🔹 3rd Party |
+| | **FUSEFs** | [`JakWai01/sile-fystem`](https://github.com/JakWai01/sile-fystem) | Generic FUSE implementation using any Afero backend. | 🔹 3rd Party |
+
+## Afero vs. `io/fs` (Go 1.16+)
+
+Go 1.16 introduced the `io/fs` package, which provides a standard abstraction for **read-only** filesystems.
+
+Afero complements `io/fs` by focusing on different needs:
+
+*   **Use `io/fs` when:** You only need to read files and want to conform strictly to the standard library interfaces.
+*   **Use Afero when:**
+    *   Your application needs to **create, write, modify, or delete** files.
+    *   You need to test complex read/write interactions (e.g., renaming, concurrent writes).
+    *   You need advanced compositional features (Copy-on-Write, Caching, etc.).
+
+Afero is fully compatible with `io/fs`. You can wrap any Afero filesystem to satisfy the `fs.FS` interface using `afero.NewIOFS`:
+
+```go
+import "io/fs"
+
+// Create an Afero filesystem (writable)
+var myAferoFs afero.Fs = afero.NewMemMapFs()
+
+// Convert it to a standard library fs.FS (read-only view)
+var myIoFs fs.FS = afero.NewIOFS(myAferoFs)
+```
+
+## Third-Party Backends & Ecosystem
+
+The Afero community has developed numerous backends and tools that extend the library's capabilities. Below are curated, well-maintained options organized by maturity and reliability.
+
+### Featured Community Backends
+
+These are mature, reliable backends that we can confidently recommend for production use:
+
+#### **Amazon S3** - [`fclairamb/afero-s3`](https://github.com/fclairamb/afero-s3)
+Production-ready S3 backend built on the official AWS SDK for Go.
+
+```go
+import "github.com/fclairamb/afero-s3"
+
+s3fs := s3.NewFs(bucket, session)
+```
+
+#### **MinIO** - [`cpyun/afero-minio`](https://github.com/cpyun/afero-minio)
+MinIO object storage backend providing S3-compatible object storage with deduplication and optimization features.
+
+```go
+import "github.com/cpyun/afero-minio"
+
+minioFs := miniofs.NewMinioFs(ctx, "minio://endpoint/bucket")
+```
+
+### Community & Specialized Backends
+
+#### Cloud Storage
+
+- **Google Drive** - [`fclairamb/afero-gdrive`](https://github.com/fclairamb/afero-gdrive)  
+  Streaming support; no write-seeking or POSIX permissions; no files listing cache
+
+- **Dropbox** - [`fclairamb/afero-dropbox`](https://github.com/fclairamb/afero-dropbox)  
+  Streaming support; no write-seeking or POSIX permissions
+
+#### Version Control Systems
+
+- **Git Repositories** - [`tobiash/go-gitfs`](https://github.com/tobiash/go-gitfs)  
+  Read-only filesystem abstraction for Git repositories. Works with bare repositories and provides filesystem view of any git reference. Uses go-git for repository access.
+
+#### Container and Remote Systems
+
+- **Docker Containers** - [`unmango/aferox`](https://github.com/unmango/aferox)  
+  Access Docker container filesystems as if they were local filesystems
+
+- **GitHub API** - [`unmango/aferox`](https://github.com/unmango/aferox)  
+  Turn GitHub repositories, releases, and assets into browsable filesystems
+
+#### FUSE Integration
+
+- **Generic FUSE** - [`JakWai01/sile-fystem`](https://github.com/JakWai01/sile-fystem)  
+  Mount any Afero filesystem as a FUSE filesystem, allowing any Afero backend to be used as a real mounted filesystem
+
+#### Specialized Filesystems
+
+- **FAT32 Support** - [`aligator/GoFAT`](https://github.com/aligator/GoFAT)  
+  Pure Go FAT filesystem implementation (currently read-only)
+
+### Interface Adapters & Utilities
+
+**Cross-Interface Compatibility:**
+- [`jfontan/go-billy-desfacer`](https://github.com/jfontan/go-billy-desfacer) - Adapter between Afero and go-billy interfaces (for go-git compatibility)
+- [`Maldris/go-billy-afero`](https://github.com/Maldris/go-billy-afero) - Alternative wrapper for using Afero with go-billy
+- [`c4milo/afero2billy`](https://github.com/c4milo/afero2billy) - Another Afero to billy filesystem adapter
+
+**Working Directory Management:**
+- [`carolynvs/aferox`](https://github.com/carolynvs/aferox) - Working directory-aware filesystem wrapper
+
+**Advanced Filtering:**
+- [`unmango/aferox`](https://github.com/unmango/aferox) includes multiple specialized filesystems:
+  - **FilterFs** - Predicate-based file filtering
+  - **IgnoreFs** - .gitignore-aware filtering
+  - **WriterFs** - Dump writes to io.Writer for debugging
+
+#### Developer Tools & Utilities
+
+**nhatthm Utility Suite** - Essential tools for Afero development:
+- [`nhatthm/aferocopy`](https://github.com/nhatthm/aferocopy) - Copy files between any Afero filesystems
+- [`nhatthm/aferomock`](https://github.com/nhatthm/aferomock) - Mocking toolkit for testing
+- [`nhatthm/aferoassert`](https://github.com/nhatthm/aferoassert) - Assertion helpers for filesystem testing
+
+### Ecosystem Showcase
+
+**Windows Virtual Drives** - [`balazsgrill/potatodrive`](https://github.com/balazsgrill/potatodrive)  
+Mount any Afero filesystem as a Windows drive letter. Brilliant demonstration of Afero's power!
+
+### Modern Asset Embedding (Go 1.16+)
+
+Instead of third-party tools, use Go's native `//go:embed` with Afero:
+
+```go
+import (
+    "embed"
+    "github.com/spf13/afero"
+)
+
+//go:embed assets/*
+var assetsFS embed.FS
+
+func main() {
+    // Convert embedded files to Afero filesystem
+    fs := afero.FromIOFS(assetsFS)
+    
+    // Use like any other Afero filesystem
+    content, _ := afero.ReadFile(fs, "assets/config.json")
+}
+```
+
+## Contributing
+
+We welcome contributions! The project is mature, but we are actively looking for contributors to help implement and stabilize network/cloud backends.
+
+* 🔥 **Microsoft Azure Blob Storage**  
+* 🔒 **Modern Encryption Backend** - Built on secure, contemporary crypto (not legacy EncFS)  
+* 🐙 **Canonical go-git Adapter** - Unified solution for Git integration  
+* 📡 **SSH/SCP Backend** - Secure remote file operations  
+*  Stabilization of existing experimental backends (GCS, SFTP)
+
+To contribute:
+1. Fork the repository
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request
+
+## 📄 License
+
+Afero is released under the Apache 2.0 license. See [LICENSE.txt](https://github.com/spf13/afero/blob/master/LICENSE.txt) for details.
+
+## 🔗 Additional Resources
+
+- [📖 Full API Documentation](https://pkg.go.dev/github.com/spf13/afero)
+- [🎯 Examples Repository](https://github.com/spf13/afero/tree/master/examples)
+- [📋 Release Notes](https://github.com/spf13/afero/releases)
+- [❓ GitHub Discussions](https://github.com/spf13/afero/discussions)
+
+---
+
+*Afero comes from the Latin roots Ad-Facere, meaning "to make" or "to do" - fitting for a library that empowers you to make and do amazing things with filesystems.*

--- a/vendor/github.com/spf13/afero/afero.go
+++ b/vendor/github.com/spf13/afero/afero.go
@@ -1,0 +1,111 @@
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+// Copyright 2013 tsuru authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package afero provides types and methods for interacting with the filesystem,
+// as an abstraction layer.
+
+// Afero also provides a few implementations that are mostly interoperable. One that
+// uses the operating system filesystem, one that uses memory to store files
+// (cross platform) and an interface that should be implemented if you want to
+// provide your own filesystem.
+
+package afero
+
+import (
+	"errors"
+	"io"
+	"os"
+	"time"
+)
+
+type Afero struct {
+	Fs
+}
+
+// File represents a file in the filesystem.
+type File interface {
+	io.Closer
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+	io.Writer
+	io.WriterAt
+
+	Name() string
+	Readdir(count int) ([]os.FileInfo, error)
+	Readdirnames(n int) ([]string, error)
+	Stat() (os.FileInfo, error)
+	Sync() error
+	Truncate(size int64) error
+	WriteString(s string) (ret int, err error)
+}
+
+// Fs is the filesystem interface.
+//
+// Any simulated or real filesystem should implement this interface.
+type Fs interface {
+	// Create creates a file in the filesystem, returning the file and an
+	// error, if any happens.
+	Create(name string) (File, error)
+
+	// Mkdir creates a directory in the filesystem, return an error if any
+	// happens.
+	Mkdir(name string, perm os.FileMode) error
+
+	// MkdirAll creates a directory path and all parents that does not exist
+	// yet.
+	MkdirAll(path string, perm os.FileMode) error
+
+	// Open opens a file, returning it or an error, if any happens.
+	Open(name string) (File, error)
+
+	// OpenFile opens a file using the given flags and the given mode.
+	OpenFile(name string, flag int, perm os.FileMode) (File, error)
+
+	// Remove removes a file identified by name, returning an error, if any
+	// happens.
+	Remove(name string) error
+
+	// RemoveAll removes a directory path and any children it contains. It
+	// does not fail if the path does not exist (return nil).
+	RemoveAll(path string) error
+
+	// Rename renames a file.
+	Rename(oldname, newname string) error
+
+	// Stat returns a FileInfo describing the named file, or an error, if any
+	// happens.
+	Stat(name string) (os.FileInfo, error)
+
+	// The name of this FileSystem
+	Name() string
+
+	// Chmod changes the mode of the named file to mode.
+	Chmod(name string, mode os.FileMode) error
+
+	// Chown changes the uid and gid of the named file.
+	Chown(name string, uid, gid int) error
+
+	// Chtimes changes the access and modification times of the named file
+	Chtimes(name string, atime time.Time, mtime time.Time) error
+}
+
+var (
+	ErrFileClosed        = errors.New("File is closed")
+	ErrOutOfRange        = errors.New("out of range")
+	ErrTooLarge          = errors.New("too large")
+	ErrFileNotFound      = os.ErrNotExist
+	ErrFileExists        = os.ErrExist
+	ErrDestinationExists = os.ErrExist
+)

--- a/vendor/github.com/spf13/afero/appveyor.yml
+++ b/vendor/github.com/spf13/afero/appveyor.yml
@@ -1,0 +1,10 @@
+# This currently does nothing. We have moved to GitHub action, but this is kept
+# until spf13 has disabled this project in AppVeyor.
+version: '{build}'
+clone_folder: C:\gopath\src\github.com\spf13\afero
+environment:
+  GOPATH: C:\gopath
+build_script:
+- cmd: >-
+    go version
+

--- a/vendor/github.com/spf13/afero/basepath.go
+++ b/vendor/github.com/spf13/afero/basepath.go
@@ -1,0 +1,222 @@
+package afero
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+var (
+	_ Lstater        = (*BasePathFs)(nil)
+	_ fs.ReadDirFile = (*BasePathFile)(nil)
+)
+
+// The BasePathFs restricts all operations to a given path within an Fs.
+// The given file name to the operations on this Fs will be prepended with
+// the base path before calling the base Fs.
+// Any file name (after filepath.Clean()) outside this base path will be
+// treated as non existing file.
+//
+// Note that it does not clean the error messages on return, so you may
+// reveal the real path on errors.
+type BasePathFs struct {
+	source Fs
+	path   string
+}
+
+type BasePathFile struct {
+	File
+	path string
+}
+
+func (f *BasePathFile) Name() string {
+	sourcename := f.File.Name()
+	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
+}
+
+func (f *BasePathFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if rdf, ok := f.File.(fs.ReadDirFile); ok {
+		return rdf.ReadDir(n)
+	}
+	return readDirFile{f.File}.ReadDir(n)
+}
+
+func NewBasePathFs(source Fs, path string) Fs {
+	return &BasePathFs{source: source, path: path}
+}
+
+// on a file outside the base path it returns the given file name and an error,
+// else the given file with the base path prepended
+func (b *BasePathFs) RealPath(name string) (path string, err error) {
+	if err := validateBasePathName(name); err != nil {
+		return name, err
+	}
+
+	bpath := filepath.Clean(b.path)
+	path = filepath.Clean(filepath.Join(bpath, name))
+	if !strings.HasPrefix(path, bpath) {
+		return name, os.ErrNotExist
+	}
+
+	return path, nil
+}
+
+func validateBasePathName(name string) error {
+	if runtime.GOOS != "windows" {
+		// Not much to do here;
+		// the virtual file paths all look absolute on *nix.
+		return nil
+	}
+
+	// On Windows a common mistake would be to provide an absolute OS path
+	// We could strip out the base part, but that would not be very portable.
+	if filepath.IsAbs(name) {
+		return os.ErrNotExist
+	}
+
+	return nil
+}
+
+func (b *BasePathFs) Chtimes(name string, atime, mtime time.Time) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "chtimes", Path: name, Err: err}
+	}
+	return b.source.Chtimes(name, atime, mtime)
+}
+
+func (b *BasePathFs) Chmod(name string, mode os.FileMode) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "chmod", Path: name, Err: err}
+	}
+	return b.source.Chmod(name, mode)
+}
+
+func (b *BasePathFs) Chown(name string, uid, gid int) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "chown", Path: name, Err: err}
+	}
+	return b.source.Chown(name, uid, gid)
+}
+
+func (b *BasePathFs) Name() string {
+	return "BasePathFs"
+}
+
+func (b *BasePathFs) Stat(name string) (fi os.FileInfo, err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return nil, &os.PathError{Op: "stat", Path: name, Err: err}
+	}
+	return b.source.Stat(name)
+}
+
+func (b *BasePathFs) Rename(oldname, newname string) (err error) {
+	if oldname, err = b.RealPath(oldname); err != nil {
+		return &os.PathError{Op: "rename", Path: oldname, Err: err}
+	}
+	if newname, err = b.RealPath(newname); err != nil {
+		return &os.PathError{Op: "rename", Path: newname, Err: err}
+	}
+	return b.source.Rename(oldname, newname)
+}
+
+func (b *BasePathFs) RemoveAll(name string) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "remove_all", Path: name, Err: err}
+	}
+	return b.source.RemoveAll(name)
+}
+
+func (b *BasePathFs) Remove(name string) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "remove", Path: name, Err: err}
+	}
+	return b.source.Remove(name)
+}
+
+func (b *BasePathFs) OpenFile(name string, flag int, mode os.FileMode) (f File, err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return nil, &os.PathError{Op: "openfile", Path: name, Err: err}
+	}
+	sourcef, err := b.source.OpenFile(name, flag, mode)
+	if err != nil {
+		return nil, err
+	}
+	return &BasePathFile{sourcef, b.path}, nil
+}
+
+func (b *BasePathFs) Open(name string) (f File, err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+	sourcef, err := b.source.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BasePathFile{File: sourcef, path: b.path}, nil
+}
+
+func (b *BasePathFs) Mkdir(name string, mode os.FileMode) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	return b.source.Mkdir(name, mode)
+}
+
+func (b *BasePathFs) MkdirAll(name string, mode os.FileMode) (err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	return b.source.MkdirAll(name, mode)
+}
+
+func (b *BasePathFs) Create(name string) (f File, err error) {
+	if name, err = b.RealPath(name); err != nil {
+		return nil, &os.PathError{Op: "create", Path: name, Err: err}
+	}
+	sourcef, err := b.source.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return &BasePathFile{File: sourcef, path: b.path}, nil
+}
+
+func (b *BasePathFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	name, err := b.RealPath(name)
+	if err != nil {
+		return nil, false, &os.PathError{Op: "lstat", Path: name, Err: err}
+	}
+	if lstater, ok := b.source.(Lstater); ok {
+		return lstater.LstatIfPossible(name)
+	}
+	fi, err := b.source.Stat(name)
+	return fi, false, err
+}
+
+func (b *BasePathFs) SymlinkIfPossible(oldname, newname string) error {
+	oldname, err := b.RealPath(oldname)
+	if err != nil {
+		return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: err}
+	}
+	newname, err = b.RealPath(newname)
+	if err != nil {
+		return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: err}
+	}
+	if linker, ok := b.source.(Linker); ok {
+		return linker.SymlinkIfPossible(oldname, newname)
+	}
+	return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: ErrNoSymlink}
+}
+
+func (b *BasePathFs) ReadlinkIfPossible(name string) (string, error) {
+	name, err := b.RealPath(name)
+	if err != nil {
+		return "", &os.PathError{Op: "readlink", Path: name, Err: err}
+	}
+	if reader, ok := b.source.(LinkReader); ok {
+		return reader.ReadlinkIfPossible(name)
+	}
+	return "", &os.PathError{Op: "readlink", Path: name, Err: ErrNoReadlink}
+}

--- a/vendor/github.com/spf13/afero/cacheOnReadFs.go
+++ b/vendor/github.com/spf13/afero/cacheOnReadFs.go
@@ -1,0 +1,315 @@
+package afero
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+// If the cache duration is 0, cache time will be unlimited, i.e. once
+// a file is in the layer, the base will never be read again for this file.
+//
+// For cache times greater than 0, the modification time of a file is
+// checked. Note that a lot of file system implementations only allow a
+// resolution of a second for timestamps... or as the godoc for os.Chtimes()
+// states: "The underlying filesystem may truncate or round the values to a
+// less precise time unit."
+//
+// This caching union will forward all write calls also to the base file
+// system first. To prevent writing to the base Fs, wrap it in a read-only
+// filter - Note: this will also make the overlay read-only, for writing files
+// in the overlay, use the overlay Fs directly, not via the union Fs.
+type CacheOnReadFs struct {
+	base      Fs
+	layer     Fs
+	cacheTime time.Duration
+}
+
+func NewCacheOnReadFs(base Fs, layer Fs, cacheTime time.Duration) Fs {
+	return &CacheOnReadFs{base: base, layer: layer, cacheTime: cacheTime}
+}
+
+type cacheState int
+
+const (
+	// not present in the overlay, unknown if it exists in the base:
+	cacheMiss cacheState = iota
+	// present in the overlay and in base, base file is newer:
+	cacheStale
+	// present in the overlay - with cache time == 0 it may exist in the base,
+	// with cacheTime > 0 it exists in the base and is same age or newer in the
+	// overlay
+	cacheHit
+	// happens if someone writes directly to the overlay without
+	// going through this union
+	cacheLocal
+)
+
+func (u *CacheOnReadFs) cacheStatus(name string) (state cacheState, fi os.FileInfo, err error) {
+	var lfi, bfi os.FileInfo
+	lfi, err = u.layer.Stat(name)
+	if err == nil {
+		if u.cacheTime == 0 {
+			return cacheHit, lfi, nil
+		}
+		if lfi.ModTime().Add(u.cacheTime).Before(time.Now()) {
+			bfi, err = u.base.Stat(name)
+			if err != nil {
+				return cacheLocal, lfi, nil
+			}
+			if bfi.ModTime().After(lfi.ModTime()) {
+				return cacheStale, bfi, nil
+			}
+		}
+		return cacheHit, lfi, nil
+	}
+
+	if err == syscall.ENOENT || os.IsNotExist(err) {
+		return cacheMiss, nil, nil
+	}
+
+	return cacheMiss, nil, err
+}
+
+func (u *CacheOnReadFs) copyToLayer(name string) error {
+	return copyToLayer(u.base, u.layer, name)
+}
+
+func (u *CacheOnReadFs) copyFileToLayer(name string, flag int, perm os.FileMode) error {
+	return copyFileToLayer(u.base, u.layer, name, flag, perm)
+}
+
+func (u *CacheOnReadFs) Chtimes(name string, atime, mtime time.Time) error {
+	st, _, err := u.cacheStatus(name)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case cacheLocal:
+	case cacheHit:
+		err = u.base.Chtimes(name, atime, mtime)
+	case cacheStale, cacheMiss:
+		if err := u.copyToLayer(name); err != nil {
+			return err
+		}
+		err = u.base.Chtimes(name, atime, mtime)
+	}
+	if err != nil {
+		return err
+	}
+	return u.layer.Chtimes(name, atime, mtime)
+}
+
+func (u *CacheOnReadFs) Chmod(name string, mode os.FileMode) error {
+	st, _, err := u.cacheStatus(name)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case cacheLocal:
+	case cacheHit:
+		err = u.base.Chmod(name, mode)
+	case cacheStale, cacheMiss:
+		if err := u.copyToLayer(name); err != nil {
+			return err
+		}
+		err = u.base.Chmod(name, mode)
+	}
+	if err != nil {
+		return err
+	}
+	return u.layer.Chmod(name, mode)
+}
+
+func (u *CacheOnReadFs) Chown(name string, uid, gid int) error {
+	st, _, err := u.cacheStatus(name)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case cacheLocal:
+	case cacheHit:
+		err = u.base.Chown(name, uid, gid)
+	case cacheStale, cacheMiss:
+		if err := u.copyToLayer(name); err != nil {
+			return err
+		}
+		err = u.base.Chown(name, uid, gid)
+	}
+	if err != nil {
+		return err
+	}
+	return u.layer.Chown(name, uid, gid)
+}
+
+func (u *CacheOnReadFs) Stat(name string) (os.FileInfo, error) {
+	st, fi, err := u.cacheStatus(name)
+	if err != nil {
+		return nil, err
+	}
+	switch st {
+	case cacheMiss:
+		return u.base.Stat(name)
+	default: // cacheStale has base, cacheHit and cacheLocal the layer os.FileInfo
+		return fi, nil
+	}
+}
+
+func (u *CacheOnReadFs) Rename(oldname, newname string) error {
+	st, _, err := u.cacheStatus(oldname)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case cacheLocal:
+	case cacheHit:
+		err = u.base.Rename(oldname, newname)
+	case cacheStale, cacheMiss:
+		if err := u.copyToLayer(oldname); err != nil {
+			return err
+		}
+		err = u.base.Rename(oldname, newname)
+	}
+	if err != nil {
+		return err
+	}
+	return u.layer.Rename(oldname, newname)
+}
+
+func (u *CacheOnReadFs) Remove(name string) error {
+	st, _, err := u.cacheStatus(name)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case cacheLocal:
+	case cacheHit, cacheStale, cacheMiss:
+		err = u.base.Remove(name)
+	}
+	if err != nil {
+		return err
+	}
+	return u.layer.Remove(name)
+}
+
+func (u *CacheOnReadFs) RemoveAll(name string) error {
+	st, _, err := u.cacheStatus(name)
+	if err != nil {
+		return err
+	}
+	switch st {
+	case cacheLocal:
+	case cacheHit, cacheStale, cacheMiss:
+		err = u.base.RemoveAll(name)
+	}
+	if err != nil {
+		return err
+	}
+	return u.layer.RemoveAll(name)
+}
+
+func (u *CacheOnReadFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	st, _, err := u.cacheStatus(name)
+	if err != nil {
+		return nil, err
+	}
+	switch st {
+	case cacheLocal, cacheHit:
+	default:
+		if err := u.copyFileToLayer(name, flag, perm); err != nil {
+			return nil, err
+		}
+	}
+	if flag&(os.O_WRONLY|syscall.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		bfi, err := u.base.OpenFile(name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		lfi, err := u.layer.OpenFile(name, flag, perm)
+		if err != nil {
+			bfi.Close() // oops, what if O_TRUNC was set and file opening in the layer failed...?
+			return nil, err
+		}
+		return &UnionFile{Base: bfi, Layer: lfi}, nil
+	}
+	return u.layer.OpenFile(name, flag, perm)
+}
+
+func (u *CacheOnReadFs) Open(name string) (File, error) {
+	st, fi, err := u.cacheStatus(name)
+	if err != nil {
+		return nil, err
+	}
+
+	switch st {
+	case cacheLocal:
+		return u.layer.Open(name)
+
+	case cacheMiss:
+		bfi, err := u.base.Stat(name)
+		if err != nil {
+			return nil, err
+		}
+		if bfi.IsDir() {
+			return u.base.Open(name)
+		}
+		if err := u.copyToLayer(name); err != nil {
+			return nil, err
+		}
+		return u.layer.Open(name)
+
+	case cacheStale:
+		if !fi.IsDir() {
+			if err := u.copyToLayer(name); err != nil {
+				return nil, err
+			}
+			return u.layer.Open(name)
+		}
+	case cacheHit:
+		if !fi.IsDir() {
+			return u.layer.Open(name)
+		}
+	}
+	// the dirs from cacheHit, cacheStale fall down here:
+	bfile, _ := u.base.Open(name)
+	lfile, err := u.layer.Open(name)
+	if err != nil && bfile == nil {
+		return nil, err
+	}
+	return &UnionFile{Base: bfile, Layer: lfile}, nil
+}
+
+func (u *CacheOnReadFs) Mkdir(name string, perm os.FileMode) error {
+	err := u.base.Mkdir(name, perm)
+	if err != nil {
+		return err
+	}
+	return u.layer.MkdirAll(name, perm) // yes, MkdirAll... we cannot assume it exists in the cache
+}
+
+func (u *CacheOnReadFs) Name() string {
+	return "CacheOnReadFs"
+}
+
+func (u *CacheOnReadFs) MkdirAll(name string, perm os.FileMode) error {
+	err := u.base.MkdirAll(name, perm)
+	if err != nil {
+		return err
+	}
+	return u.layer.MkdirAll(name, perm)
+}
+
+func (u *CacheOnReadFs) Create(name string) (File, error) {
+	bfh, err := u.base.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	lfh, err := u.layer.Create(name)
+	if err != nil {
+		// oops, see comment about OS_TRUNC above, should we remove? then we have to
+		// remember if the file did not exist before
+		bfh.Close()
+		return nil, err
+	}
+	return &UnionFile{Base: bfh, Layer: lfh}, nil
+}

--- a/vendor/github.com/spf13/afero/const_bsds.go
+++ b/vendor/github.com/spf13/afero/const_bsds.go
@@ -1,0 +1,23 @@
+// Copyright © 2016 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build aix || darwin || openbsd || freebsd || netbsd || dragonfly || zos
+// +build aix darwin openbsd freebsd netbsd dragonfly zos
+
+package afero
+
+import (
+	"syscall"
+)
+
+const BADFD = syscall.EBADF

--- a/vendor/github.com/spf13/afero/const_win_unix.go
+++ b/vendor/github.com/spf13/afero/const_win_unix.go
@@ -1,0 +1,22 @@
+// Copyright © 2016 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !darwin && !openbsd && !freebsd && !dragonfly && !netbsd && !aix && !zos
+// +build !darwin,!openbsd,!freebsd,!dragonfly,!netbsd,!aix,!zos
+
+package afero
+
+import (
+	"syscall"
+)
+
+const BADFD = syscall.EBADFD

--- a/vendor/github.com/spf13/afero/copyOnWriteFs.go
+++ b/vendor/github.com/spf13/afero/copyOnWriteFs.go
@@ -1,0 +1,332 @@
+package afero
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+var _ Lstater = (*CopyOnWriteFs)(nil)
+
+// The CopyOnWriteFs is a union filesystem: a read only base file system with
+// a possibly writeable layer on top. Changes to the file system will only
+// be made in the overlay: Changing an existing file in the base layer which
+// is not present in the overlay will copy the file to the overlay ("changing"
+// includes also calls to e.g. Chtimes(), Chmod() and Chown()).
+//
+// Reading directories is currently only supported via Open(), not OpenFile().
+type CopyOnWriteFs struct {
+	base  Fs
+	layer Fs
+}
+
+func NewCopyOnWriteFs(base Fs, layer Fs) Fs {
+	return &CopyOnWriteFs{base: base, layer: layer}
+}
+
+// Returns true if the file is not in the overlay
+func (u *CopyOnWriteFs) isBaseFile(name string) (bool, error) {
+	if _, err := u.layer.Stat(name); err == nil {
+		return false, nil
+	}
+	_, err := u.base.Stat(name)
+	if err != nil {
+		if oerr, ok := err.(*os.PathError); ok {
+			if oerr.Err == os.ErrNotExist || oerr.Err == syscall.ENOENT ||
+				oerr.Err == syscall.ENOTDIR {
+				return false, nil
+			}
+		}
+		if err == syscall.ENOENT {
+			return false, nil
+		}
+	}
+	return true, err
+}
+
+func (u *CopyOnWriteFs) copyToLayer(name string) error {
+	return copyToLayer(u.base, u.layer, name)
+}
+
+func (u *CopyOnWriteFs) Chtimes(name string, atime, mtime time.Time) error {
+	b, err := u.isBaseFile(name)
+	if err != nil {
+		return err
+	}
+	if b {
+		if err := u.copyToLayer(name); err != nil {
+			return err
+		}
+	}
+	return u.layer.Chtimes(name, atime, mtime)
+}
+
+func (u *CopyOnWriteFs) Chmod(name string, mode os.FileMode) error {
+	b, err := u.isBaseFile(name)
+	if err != nil {
+		return err
+	}
+	if b {
+		if err := u.copyToLayer(name); err != nil {
+			return err
+		}
+	}
+	return u.layer.Chmod(name, mode)
+}
+
+func (u *CopyOnWriteFs) Chown(name string, uid, gid int) error {
+	b, err := u.isBaseFile(name)
+	if err != nil {
+		return err
+	}
+	if b {
+		if err := u.copyToLayer(name); err != nil {
+			return err
+		}
+	}
+	return u.layer.Chown(name, uid, gid)
+}
+
+func (u *CopyOnWriteFs) Stat(name string) (os.FileInfo, error) {
+	fi, err := u.layer.Stat(name)
+	if err != nil {
+		isNotExist := u.isNotExist(err)
+		if isNotExist {
+			return u.base.Stat(name)
+		}
+		return nil, err
+	}
+	return fi, nil
+}
+
+func (u *CopyOnWriteFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	llayer, ok1 := u.layer.(Lstater)
+	lbase, ok2 := u.base.(Lstater)
+
+	if ok1 {
+		fi, b, err := llayer.LstatIfPossible(name)
+		if err == nil {
+			return fi, b, nil
+		}
+
+		if !u.isNotExist(err) {
+			return nil, b, err
+		}
+	}
+
+	if ok2 {
+		fi, b, err := lbase.LstatIfPossible(name)
+		if err == nil {
+			return fi, b, nil
+		}
+		if !u.isNotExist(err) {
+			return nil, b, err
+		}
+	}
+
+	fi, err := u.Stat(name)
+
+	return fi, false, err
+}
+
+func (u *CopyOnWriteFs) SymlinkIfPossible(oldname, newname string) error {
+	if slayer, ok := u.layer.(Linker); ok {
+		return slayer.SymlinkIfPossible(oldname, newname)
+	}
+
+	return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: ErrNoSymlink}
+}
+
+func (u *CopyOnWriteFs) ReadlinkIfPossible(name string) (string, error) {
+	if rlayer, ok := u.layer.(LinkReader); ok {
+		return rlayer.ReadlinkIfPossible(name)
+	}
+
+	if rbase, ok := u.base.(LinkReader); ok {
+		return rbase.ReadlinkIfPossible(name)
+	}
+
+	return "", &os.PathError{Op: "readlink", Path: name, Err: ErrNoReadlink}
+}
+
+func (u *CopyOnWriteFs) isNotExist(err error) bool {
+	if e, ok := err.(*os.PathError); ok {
+		err = e.Err
+	}
+	if err == os.ErrNotExist || err == syscall.ENOENT || err == syscall.ENOTDIR {
+		return true
+	}
+	return false
+}
+
+// Renaming files present only in the base layer is not permitted
+func (u *CopyOnWriteFs) Rename(oldname, newname string) error {
+	b, err := u.isBaseFile(oldname)
+	if err != nil {
+		return err
+	}
+	if b {
+		return syscall.EPERM
+	}
+	return u.layer.Rename(oldname, newname)
+}
+
+// Removing files present only in the base layer is not permitted. If
+// a file is present in the base layer and the overlay, only the overlay
+// will be removed.
+func (u *CopyOnWriteFs) Remove(name string) error {
+	err := u.layer.Remove(name)
+	switch err {
+	case syscall.ENOENT:
+		_, err = u.base.Stat(name)
+		if err == nil {
+			return syscall.EPERM
+		}
+		return syscall.ENOENT
+	default:
+		return err
+	}
+}
+
+func (u *CopyOnWriteFs) RemoveAll(name string) error {
+	err := u.layer.RemoveAll(name)
+	switch err {
+	case syscall.ENOENT:
+		_, err = u.base.Stat(name)
+		if err == nil {
+			return syscall.EPERM
+		}
+		return syscall.ENOENT
+	default:
+		return err
+	}
+}
+
+func (u *CopyOnWriteFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	b, err := u.isBaseFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		if b {
+			if err = u.copyToLayer(name); err != nil {
+				return nil, err
+			}
+			return u.layer.OpenFile(name, flag, perm)
+		}
+
+		dir := filepath.Dir(name)
+		isaDir, err := IsDir(u.base, dir)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		if isaDir {
+			if err = u.layer.MkdirAll(dir, 0o777); err != nil {
+				return nil, err
+			}
+			return u.layer.OpenFile(name, flag, perm)
+		}
+
+		isaDir, err = IsDir(u.layer, dir)
+		if err != nil {
+			return nil, err
+		}
+		if isaDir {
+			return u.layer.OpenFile(name, flag, perm)
+		}
+
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: name,
+			Err:  syscall.ENOTDIR,
+		} // ...or os.ErrNotExist?
+	}
+	if b {
+		return u.base.OpenFile(name, flag, perm)
+	}
+	return u.layer.OpenFile(name, flag, perm)
+}
+
+// This function handles the 9 different possibilities caused
+// by the union which are the intersection of the following...
+//
+//	layer: doesn't exist, exists as a file, and exists as a directory
+//	base:  doesn't exist, exists as a file, and exists as a directory
+func (u *CopyOnWriteFs) Open(name string) (File, error) {
+	// Since the overlay overrides the base we check that first
+	b, err := u.isBaseFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// If overlay doesn't exist, return the base (base state irrelevant)
+	if b {
+		return u.base.Open(name)
+	}
+
+	// If overlay is a file, return it (base state irrelevant)
+	dir, err := IsDir(u.layer, name)
+	if err != nil {
+		return nil, err
+	}
+	if !dir {
+		return u.layer.Open(name)
+	}
+
+	// Overlay is a directory, base state now matters.
+	// Base state has 3 states to check but 2 outcomes:
+	// A. It's a file or non-readable in the base (return just the overlay)
+	// B. It's an accessible directory in the base (return a UnionFile)
+
+	// If base is file or nonreadable, return overlay
+	dir, err = IsDir(u.base, name)
+	if !dir || err != nil {
+		return u.layer.Open(name)
+	}
+
+	// Both base & layer are directories
+	// Return union file (if opens are without error)
+	bfile, bErr := u.base.Open(name)
+	lfile, lErr := u.layer.Open(name)
+
+	// If either have errors at this point something is very wrong. Return nil and the errors
+	if bErr != nil || lErr != nil {
+		return nil, fmt.Errorf("BaseErr: %v\nOverlayErr: %v", bErr, lErr)
+	}
+
+	return &UnionFile{Base: bfile, Layer: lfile}, nil
+}
+
+func (u *CopyOnWriteFs) Mkdir(name string, perm os.FileMode) error {
+	dir, err := IsDir(u.base, name)
+	if err != nil {
+		return u.layer.MkdirAll(name, perm)
+	}
+	if dir {
+		return ErrFileExists
+	}
+	return u.layer.MkdirAll(name, perm)
+}
+
+func (u *CopyOnWriteFs) Name() string {
+	return "CopyOnWriteFs"
+}
+
+func (u *CopyOnWriteFs) MkdirAll(name string, perm os.FileMode) error {
+	dir, err := IsDir(u.base, name)
+	if err != nil {
+		return u.layer.MkdirAll(name, perm)
+	}
+	if dir {
+		// This is in line with how os.MkdirAll behaves.
+		return nil
+	}
+	return u.layer.MkdirAll(name, perm)
+}
+
+func (u *CopyOnWriteFs) Create(name string) (File, error) {
+	return u.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o666)
+}

--- a/vendor/github.com/spf13/afero/httpFs.go
+++ b/vendor/github.com/spf13/afero/httpFs.go
@@ -1,0 +1,114 @@
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type httpDir struct {
+	basePath string
+	fs       HttpFs
+}
+
+func (d httpDir) Open(name string) (http.File, error) {
+	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) ||
+		strings.Contains(name, "\x00") {
+		return nil, errors.New("http: invalid character in file path")
+	}
+	dir := string(d.basePath)
+	if dir == "" {
+		dir = "."
+	}
+
+	f, err := d.fs.Open(filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name))))
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+type HttpFs struct {
+	source Fs
+}
+
+func NewHttpFs(source Fs) *HttpFs {
+	return &HttpFs{source: source}
+}
+
+func (h HttpFs) Dir(s string) *httpDir {
+	return &httpDir{basePath: s, fs: h}
+}
+
+func (h HttpFs) Name() string { return "h HttpFs" }
+
+func (h HttpFs) Create(name string) (File, error) {
+	return h.source.Create(name)
+}
+
+func (h HttpFs) Chmod(name string, mode os.FileMode) error {
+	return h.source.Chmod(name, mode)
+}
+
+func (h HttpFs) Chown(name string, uid, gid int) error {
+	return h.source.Chown(name, uid, gid)
+}
+
+func (h HttpFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return h.source.Chtimes(name, atime, mtime)
+}
+
+func (h HttpFs) Mkdir(name string, perm os.FileMode) error {
+	return h.source.Mkdir(name, perm)
+}
+
+func (h HttpFs) MkdirAll(path string, perm os.FileMode) error {
+	return h.source.MkdirAll(path, perm)
+}
+
+func (h HttpFs) Open(name string) (http.File, error) {
+	f, err := h.source.Open(name)
+	if err == nil {
+		if httpfile, ok := f.(http.File); ok {
+			return httpfile, nil
+		}
+	}
+	return nil, err
+}
+
+func (h HttpFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	return h.source.OpenFile(name, flag, perm)
+}
+
+func (h HttpFs) Remove(name string) error {
+	return h.source.Remove(name)
+}
+
+func (h HttpFs) RemoveAll(path string) error {
+	return h.source.RemoveAll(path)
+}
+
+func (h HttpFs) Rename(oldname, newname string) error {
+	return h.source.Rename(oldname, newname)
+}
+
+func (h HttpFs) Stat(name string) (os.FileInfo, error) {
+	return h.source.Stat(name)
+}

--- a/vendor/github.com/spf13/afero/internal/common/adapters.go
+++ b/vendor/github.com/spf13/afero/internal/common/adapters.go
@@ -1,0 +1,27 @@
+// Copyright © 2022 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "io/fs"
+
+// FileInfoDirEntry provides an adapter from os.FileInfo to fs.DirEntry
+type FileInfoDirEntry struct {
+	fs.FileInfo
+}
+
+var _ fs.DirEntry = FileInfoDirEntry{}
+
+func (d FileInfoDirEntry) Type() fs.FileMode { return d.FileInfo.Mode().Type() }
+
+func (d FileInfoDirEntry) Info() (fs.FileInfo, error) { return d.FileInfo, nil }

--- a/vendor/github.com/spf13/afero/iofs.go
+++ b/vendor/github.com/spf13/afero/iofs.go
@@ -1,0 +1,302 @@
+//go:build go1.16
+// +build go1.16
+
+package afero
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"sort"
+	"time"
+
+	"github.com/spf13/afero/internal/common"
+)
+
+// IOFS adopts afero.Fs to stdlib io/fs.FS
+type IOFS struct {
+	Fs
+}
+
+func NewIOFS(fs Fs) IOFS {
+	return IOFS{Fs: fs}
+}
+
+var (
+	_ fs.FS         = IOFS{}
+	_ fs.GlobFS     = IOFS{}
+	_ fs.ReadDirFS  = IOFS{}
+	_ fs.ReadFileFS = IOFS{}
+	_ fs.StatFS     = IOFS{}
+	_ fs.SubFS      = IOFS{}
+)
+
+func (iofs IOFS) Open(name string) (fs.File, error) {
+	const op = "open"
+
+	// by convention for fs.FS implementations we should perform this check
+	if !fs.ValidPath(name) {
+		return nil, iofs.wrapError(op, name, fs.ErrInvalid)
+	}
+
+	file, err := iofs.Fs.Open(name)
+	if err != nil {
+		return nil, iofs.wrapError(op, name, err)
+	}
+
+	// file should implement fs.ReadDirFile
+	if _, ok := file.(fs.ReadDirFile); !ok {
+		file = readDirFile{file}
+	}
+
+	return file, nil
+}
+
+func (iofs IOFS) Glob(pattern string) ([]string, error) {
+	const op = "glob"
+
+	// afero.Glob does not perform this check but it's required for implementations
+	if _, err := path.Match(pattern, ""); err != nil {
+		return nil, iofs.wrapError(op, pattern, err)
+	}
+
+	items, err := Glob(iofs.Fs, pattern)
+	if err != nil {
+		return nil, iofs.wrapError(op, pattern, err)
+	}
+
+	return items, nil
+}
+
+func (iofs IOFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	f, err := iofs.Fs.Open(name)
+	if err != nil {
+		return nil, iofs.wrapError("readdir", name, err)
+	}
+
+	defer f.Close()
+
+	if rdf, ok := f.(fs.ReadDirFile); ok {
+		items, err := rdf.ReadDir(-1)
+		if err != nil {
+			return nil, iofs.wrapError("readdir", name, err)
+		}
+		sort.Slice(items, func(i, j int) bool { return items[i].Name() < items[j].Name() })
+		return items, nil
+	}
+
+	items, err := f.Readdir(-1)
+	if err != nil {
+		return nil, iofs.wrapError("readdir", name, err)
+	}
+	sort.Sort(byName(items))
+
+	ret := make([]fs.DirEntry, len(items))
+	for i := range items {
+		ret[i] = common.FileInfoDirEntry{FileInfo: items[i]}
+	}
+
+	return ret, nil
+}
+
+func (iofs IOFS) ReadFile(name string) ([]byte, error) {
+	const op = "readfile"
+
+	if !fs.ValidPath(name) {
+		return nil, iofs.wrapError(op, name, fs.ErrInvalid)
+	}
+
+	bytes, err := ReadFile(iofs.Fs, name)
+	if err != nil {
+		return nil, iofs.wrapError(op, name, err)
+	}
+
+	return bytes, nil
+}
+
+func (iofs IOFS) Sub(dir string) (fs.FS, error) { return IOFS{NewBasePathFs(iofs.Fs, dir)}, nil }
+
+func (IOFS) wrapError(op, path string, err error) error {
+	if _, ok := err.(*fs.PathError); ok {
+		return err // don't need to wrap again
+	}
+
+	return &fs.PathError{
+		Op:   op,
+		Path: path,
+		Err:  err,
+	}
+}
+
+// readDirFile provides adapter from afero.File to fs.ReadDirFile needed for correct Open
+type readDirFile struct {
+	File
+}
+
+var _ fs.ReadDirFile = readDirFile{}
+
+func (r readDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	items, err := r.Readdir(n)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]fs.DirEntry, len(items))
+	for i := range items {
+		ret[i] = common.FileInfoDirEntry{FileInfo: items[i]}
+	}
+
+	return ret, nil
+}
+
+// FromIOFS adopts io/fs.FS to use it as afero.Fs
+// Note that io/fs.FS is read-only so all mutating methods will return fs.PathError with fs.ErrPermission
+// To store modifications you may use afero.CopyOnWriteFs
+type FromIOFS struct {
+	fs.FS
+}
+
+var _ Fs = FromIOFS{}
+
+func (f FromIOFS) Create(name string) (File, error) { return nil, notImplemented("create", name) }
+
+func (f FromIOFS) Mkdir(
+	name string,
+	perm os.FileMode,
+) error {
+	return notImplemented("mkdir", name)
+}
+
+func (f FromIOFS) MkdirAll(path string, perm os.FileMode) error {
+	return notImplemented("mkdirall", path)
+}
+
+func (f FromIOFS) Open(name string) (File, error) {
+	file, err := f.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return fromIOFSFile{File: file, name: name}, nil
+}
+
+func (f FromIOFS) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	return f.Open(name)
+}
+
+func (f FromIOFS) Remove(name string) error {
+	return notImplemented("remove", name)
+}
+
+func (f FromIOFS) RemoveAll(path string) error {
+	return notImplemented("removeall", path)
+}
+
+func (f FromIOFS) Rename(oldname, newname string) error {
+	return notImplemented("rename", oldname)
+}
+
+func (f FromIOFS) Stat(name string) (os.FileInfo, error) { return fs.Stat(f.FS, name) }
+
+func (f FromIOFS) Name() string { return "fromiofs" }
+
+func (f FromIOFS) Chmod(name string, mode os.FileMode) error {
+	return notImplemented("chmod", name)
+}
+
+func (f FromIOFS) Chown(name string, uid, gid int) error {
+	return notImplemented("chown", name)
+}
+
+func (f FromIOFS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return notImplemented("chtimes", name)
+}
+
+type fromIOFSFile struct {
+	fs.File
+	name string
+}
+
+func (f fromIOFSFile) ReadAt(p []byte, off int64) (n int, err error) {
+	readerAt, ok := f.File.(io.ReaderAt)
+	if !ok {
+		return -1, notImplemented("readat", f.name)
+	}
+
+	return readerAt.ReadAt(p, off)
+}
+
+func (f fromIOFSFile) Seek(offset int64, whence int) (int64, error) {
+	seeker, ok := f.File.(io.Seeker)
+	if !ok {
+		return -1, notImplemented("seek", f.name)
+	}
+
+	return seeker.Seek(offset, whence)
+}
+
+func (f fromIOFSFile) Write(p []byte) (n int, err error) {
+	return -1, notImplemented("write", f.name)
+}
+
+func (f fromIOFSFile) WriteAt(p []byte, off int64) (n int, err error) {
+	return -1, notImplemented("writeat", f.name)
+}
+
+func (f fromIOFSFile) Name() string { return f.name }
+
+func (f fromIOFSFile) Readdir(count int) ([]os.FileInfo, error) {
+	rdfile, ok := f.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, notImplemented("readdir", f.name)
+	}
+
+	entries, err := rdfile.ReadDir(count)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]os.FileInfo, len(entries))
+	for i := range entries {
+		ret[i], err = entries[i].Info()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ret, nil
+}
+
+func (f fromIOFSFile) Readdirnames(n int) ([]string, error) {
+	rdfile, ok := f.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, notImplemented("readdir", f.name)
+	}
+
+	entries, err := rdfile.ReadDir(n)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]string, len(entries))
+	for i := range entries {
+		ret[i] = entries[i].Name()
+	}
+
+	return ret, nil
+}
+
+func (f fromIOFSFile) Sync() error { return nil }
+
+func (f fromIOFSFile) Truncate(size int64) error {
+	return notImplemented("truncate", f.name)
+}
+
+func (f fromIOFSFile) WriteString(s string) (ret int, err error) {
+	return -1, notImplemented("writestring", f.name)
+}
+
+func notImplemented(op, path string) error {
+	return &fs.PathError{Op: op, Path: path, Err: fs.ErrPermission}
+}

--- a/vendor/github.com/spf13/afero/ioutil.go
+++ b/vendor/github.com/spf13/afero/ioutil.go
@@ -1,0 +1,243 @@
+// Copyright ©2015 The Go Authors
+// Copyright ©2015 Steve Francia <spf@spf13.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// byName implements sort.Interface.
+type byName []os.FileInfo
+
+func (f byName) Len() int           { return len(f) }
+func (f byName) Less(i, j int) bool { return f[i].Name() < f[j].Name() }
+func (f byName) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
+
+// ReadDir reads the directory named by dirname and returns
+// a list of sorted directory entries.
+func (a Afero) ReadDir(dirname string) ([]os.FileInfo, error) {
+	return ReadDir(a.Fs, dirname)
+}
+
+func ReadDir(fs Fs, dirname string) ([]os.FileInfo, error) {
+	f, err := fs.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	list, err := f.Readdir(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(byName(list))
+	return list, nil
+}
+
+// ReadFile reads the file named by filename and returns the contents.
+// A successful call returns err == nil, not err == EOF. Because ReadFile
+// reads the whole file, it does not treat an EOF from Read as an error
+// to be reported.
+func (a Afero) ReadFile(filename string) ([]byte, error) {
+	return ReadFile(a.Fs, filename)
+}
+
+func ReadFile(fs Fs, filename string) ([]byte, error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	// It's a good but not certain bet that FileInfo will tell us exactly how much to
+	// read, so let's try it but be prepared for the answer to be wrong.
+	var n int64
+
+	if fi, err := f.Stat(); err == nil {
+		// Don't preallocate a huge buffer, just in case.
+		if size := fi.Size(); size < 1e9 {
+			n = size
+		}
+	}
+	// As initial capacity for readAll, use n + a little extra in case Size is zero,
+	// and to avoid another allocation after Read has filled the buffer.  The readAll
+	// call will read into its allocated internal buffer cheaply.  If the size was
+	// wrong, we'll either waste some space off the end or reallocate as needed, but
+	// in the overwhelmingly common case we'll get it just right.
+	return readAll(f, n+bytes.MinRead)
+}
+
+// readAll reads from r until an error or EOF and returns the data it read
+// from the internal buffer allocated with a specified capacity.
+func readAll(r io.Reader, capacity int64) (b []byte, err error) {
+	buf := bytes.NewBuffer(make([]byte, 0, capacity))
+	// If the buffer overflows, we will get bytes.ErrTooLarge.
+	// Return that as an error. Any other panic remains.
+	defer func() {
+		e := recover()
+		if e == nil {
+			return
+		}
+		if panicErr, ok := e.(error); ok && panicErr == bytes.ErrTooLarge {
+			err = panicErr
+		} else {
+			panic(e)
+		}
+	}()
+	_, err = buf.ReadFrom(r)
+	return buf.Bytes(), err
+}
+
+// ReadAll reads from r until an error or EOF and returns the data it read.
+// A successful call returns err == nil, not err == EOF. Because ReadAll is
+// defined to read from src until EOF, it does not treat an EOF from Read
+// as an error to be reported.
+func ReadAll(r io.Reader) ([]byte, error) {
+	return readAll(r, bytes.MinRead)
+}
+
+// WriteFile writes data to a file named by filename.
+// If the file does not exist, WriteFile creates it with permissions perm;
+// otherwise WriteFile truncates it before writing.
+func (a Afero) WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return WriteFile(a.Fs, filename, data, perm)
+}
+
+func WriteFile(fs Fs, filename string, data []byte, perm os.FileMode) error {
+	f, err := fs.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write(data)
+	if err == nil && n < len(data) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+// Random number state.
+// We generate random temporary file names so that there's a good
+// chance the file doesn't exist yet - keeps the number of tries in
+// TempFile to a minimum.
+var (
+	randNum uint32
+	randmu  sync.Mutex
+)
+
+func reseed() uint32 {
+	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+}
+
+func nextRandom() string {
+	randmu.Lock()
+	r := randNum
+	if r == 0 {
+		r = reseed()
+	}
+	r = r*1664525 + 1013904223 // constants from Numerical Recipes
+	randNum = r
+	randmu.Unlock()
+	return strconv.Itoa(int(1e9 + r%1e9))[1:]
+}
+
+// TempFile creates a new temporary file in the directory dir,
+// opens the file for reading and writing, and returns the resulting *os.File.
+// The filename is generated by taking pattern and adding a random
+// string to the end. If pattern includes a "*", the random string
+// replaces the last "*".
+// If dir is the empty string, TempFile uses the default directory
+// for temporary files (see os.TempDir).
+// Multiple programs calling TempFile simultaneously
+// will not choose the same file. The caller can use f.Name()
+// to find the pathname of the file. It is the caller's responsibility
+// to remove the file when no longer needed.
+func (a Afero) TempFile(dir, pattern string) (f File, err error) {
+	return TempFile(a.Fs, dir, pattern)
+}
+
+func TempFile(fs Fs, dir, pattern string) (f File, err error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	var prefix, suffix string
+	if pos := strings.LastIndex(pattern, "*"); pos != -1 {
+		prefix, suffix = pattern[:pos], pattern[pos+1:]
+	} else {
+		prefix = pattern
+	}
+
+	nconflict := 0
+	for i := 0; i < 10000; i++ {
+		name := filepath.Join(dir, prefix+nextRandom()+suffix)
+		f, err = fs.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if os.IsExist(err) {
+			if nconflict++; nconflict > 10 {
+				randmu.Lock()
+				randNum = reseed()
+				randmu.Unlock()
+			}
+			continue
+		}
+		break
+	}
+	return
+}
+
+// TempDir creates a new temporary directory in the directory dir
+// with a name beginning with prefix and returns the path of the
+// new directory.  If dir is the empty string, TempDir uses the
+// default directory for temporary files (see os.TempDir).
+// Multiple programs calling TempDir simultaneously
+// will not choose the same directory.  It is the caller's responsibility
+// to remove the directory when no longer needed.
+func (a Afero) TempDir(dir, prefix string) (name string, err error) {
+	return TempDir(a.Fs, dir, prefix)
+}
+
+func TempDir(fs Fs, dir, prefix string) (name string, err error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	nconflict := 0
+	for i := 0; i < 10000; i++ {
+		try := filepath.Join(dir, prefix+nextRandom())
+		err = fs.Mkdir(try, 0o700)
+		if os.IsExist(err) {
+			if nconflict++; nconflict > 10 {
+				randmu.Lock()
+				randNum = reseed()
+				randmu.Unlock()
+			}
+			continue
+		}
+		if err == nil {
+			name = try
+		}
+		break
+	}
+	return
+}

--- a/vendor/github.com/spf13/afero/lstater.go
+++ b/vendor/github.com/spf13/afero/lstater.go
@@ -1,0 +1,27 @@
+// Copyright © 2018 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"os"
+)
+
+// Lstater is an optional interface in Afero. It is only implemented by the
+// filesystems saying so.
+// It will call Lstat if the filesystem itself is, or it delegates to, the os filesystem.
+// Else it will call Stat.
+// In addition to the FileInfo, it will return a boolean telling whether Lstat was called or not.
+type Lstater interface {
+	LstatIfPossible(name string) (os.FileInfo, bool, error)
+}

--- a/vendor/github.com/spf13/afero/match.go
+++ b/vendor/github.com/spf13/afero/match.go
@@ -1,0 +1,110 @@
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+// Copyright 2009 The Go Authors. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Glob returns the names of all files matching pattern or nil
+// if there is no matching file. The syntax of patterns is the same
+// as in Match. The pattern may describe hierarchical names such as
+// /usr/*/bin/ed (assuming the Separator is '/').
+//
+// Glob ignores file system errors such as I/O errors reading directories.
+// The only possible returned error is ErrBadPattern, when pattern
+// is malformed.
+//
+// This was adapted from (http://golang.org/pkg/path/filepath) and uses several
+// built-ins from that package.
+func Glob(fs Fs, pattern string) (matches []string, err error) {
+	if !hasMeta(pattern) {
+		// Lstat not supported by a ll filesystems.
+		if _, err = lstatIfPossible(fs, pattern); err != nil {
+			return nil, nil
+		}
+		return []string{pattern}, nil
+	}
+
+	dir, file := filepath.Split(pattern)
+	switch dir {
+	case "":
+		dir = "."
+	case string(filepath.Separator):
+	// nothing
+	default:
+		dir = dir[0 : len(dir)-1] // chop off trailing separator
+	}
+
+	if !hasMeta(dir) {
+		return glob(fs, dir, file, nil)
+	}
+
+	var m []string
+	m, err = Glob(fs, dir)
+	if err != nil {
+		return
+	}
+	for _, d := range m {
+		matches, err = glob(fs, d, file, matches)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// glob searches for files matching pattern in the directory dir
+// and appends them to matches. If the directory cannot be
+// opened, it returns the existing matches. New matches are
+// added in lexicographical order.
+func glob(fs Fs, dir, pattern string, matches []string) (m []string, e error) {
+	m = matches
+	fi, err := fs.Stat(dir)
+	if err != nil {
+		return
+	}
+	if !fi.IsDir() {
+		return
+	}
+	d, err := fs.Open(dir)
+	if err != nil {
+		return
+	}
+	defer d.Close()
+
+	names, _ := d.Readdirnames(-1)
+	sort.Strings(names)
+
+	for _, n := range names {
+		matched, err := filepath.Match(pattern, n)
+		if err != nil {
+			return m, err
+		}
+		if matched {
+			m = append(m, filepath.Join(dir, n))
+		}
+	}
+	return
+}
+
+// hasMeta reports whether path contains any of the magic characters
+// recognized by Match.
+func hasMeta(path string) bool {
+	// TODO(niemeyer): Should other magic characters be added here?
+	return strings.ContainsAny(path, "*?[")
+}

--- a/vendor/github.com/spf13/afero/mem/dir.go
+++ b/vendor/github.com/spf13/afero/mem/dir.go
@@ -1,0 +1,37 @@
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mem
+
+type Dir interface {
+	Len() int
+	Names() []string
+	Files() []*FileData
+	Add(*FileData)
+	Remove(*FileData)
+}
+
+func RemoveFromMemDir(dir *FileData, f *FileData) {
+	dir.memDir.Remove(f)
+}
+
+func AddToMemDir(dir *FileData, f *FileData) {
+	dir.memDir.Add(f)
+}
+
+func InitializeDir(d *FileData) {
+	if d.memDir == nil {
+		d.dir = true
+		d.memDir = &DirMap{}
+	}
+}

--- a/vendor/github.com/spf13/afero/mem/dirmap.go
+++ b/vendor/github.com/spf13/afero/mem/dirmap.go
@@ -1,0 +1,43 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mem
+
+import "sort"
+
+type DirMap map[string]*FileData
+
+func (m DirMap) Len() int           { return len(m) }
+func (m DirMap) Add(f *FileData)    { m[f.name] = f }
+func (m DirMap) Remove(f *FileData) { delete(m, f.name) }
+func (m DirMap) Files() (files []*FileData) {
+	for _, f := range m {
+		files = append(files, f)
+	}
+	sort.Sort(filesSorter(files))
+	return files
+}
+
+// implement sort.Interface for []*FileData
+type filesSorter []*FileData
+
+func (s filesSorter) Len() int           { return len(s) }
+func (s filesSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s filesSorter) Less(i, j int) bool { return s[i].name < s[j].name }
+
+func (m DirMap) Names() (names []string) {
+	for x := range m {
+		names = append(names, x)
+	}
+	return names
+}

--- a/vendor/github.com/spf13/afero/mem/file.go
+++ b/vendor/github.com/spf13/afero/mem/file.go
@@ -1,0 +1,373 @@
+// Copyright © 2015 Steve Francia <spf@spf13.com>.
+// Copyright 2013 tsuru authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mem
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/afero/internal/common"
+)
+
+const FilePathSeparator = string(filepath.Separator)
+
+var _ fs.ReadDirFile = &File{}
+
+type File struct {
+	// atomic requires 64-bit alignment for struct field access
+	at           int64
+	readDirCount int64
+	closed       bool
+	readOnly     bool
+	fileData     *FileData
+}
+
+func NewFileHandle(data *FileData) *File {
+	return &File{fileData: data}
+}
+
+func NewReadOnlyFileHandle(data *FileData) *File {
+	return &File{fileData: data, readOnly: true}
+}
+
+func (f File) Data() *FileData {
+	return f.fileData
+}
+
+type FileData struct {
+	sync.Mutex
+	name    string
+	data    []byte
+	memDir  Dir
+	dir     bool
+	mode    os.FileMode
+	modtime time.Time
+	uid     int
+	gid     int
+}
+
+func (d *FileData) Name() string {
+	d.Lock()
+	defer d.Unlock()
+	return d.name
+}
+
+func CreateFile(name string) *FileData {
+	return &FileData{name: name, mode: os.ModeTemporary, modtime: time.Now()}
+}
+
+func CreateDir(name string) *FileData {
+	return &FileData{name: name, memDir: &DirMap{}, dir: true, modtime: time.Now()}
+}
+
+func ChangeFileName(f *FileData, newname string) {
+	f.Lock()
+	f.name = newname
+	f.Unlock()
+}
+
+func SetMode(f *FileData, mode os.FileMode) {
+	f.Lock()
+	f.mode = mode
+	f.Unlock()
+}
+
+func SetModTime(f *FileData, mtime time.Time) {
+	f.Lock()
+	setModTime(f, mtime)
+	f.Unlock()
+}
+
+func setModTime(f *FileData, mtime time.Time) {
+	f.modtime = mtime
+}
+
+func SetUID(f *FileData, uid int) {
+	f.Lock()
+	f.uid = uid
+	f.Unlock()
+}
+
+func SetGID(f *FileData, gid int) {
+	f.Lock()
+	f.gid = gid
+	f.Unlock()
+}
+
+func GetFileInfo(f *FileData) *FileInfo {
+	return &FileInfo{f}
+}
+
+func (f *File) Open() error {
+	atomic.StoreInt64(&f.at, 0)
+	atomic.StoreInt64(&f.readDirCount, 0)
+	f.fileData.Lock()
+	f.closed = false
+	f.fileData.Unlock()
+	return nil
+}
+
+func (f *File) Close() error {
+	f.fileData.Lock()
+	f.closed = true
+	if !f.readOnly {
+		setModTime(f.fileData, time.Now())
+	}
+	f.fileData.Unlock()
+	return nil
+}
+
+func (f *File) Name() string {
+	return f.fileData.Name()
+}
+
+func (f *File) Stat() (os.FileInfo, error) {
+	return &FileInfo{f.fileData}, nil
+}
+
+func (f *File) Sync() error {
+	return nil
+}
+
+func (f *File) Readdir(count int) (res []os.FileInfo, err error) {
+	if !f.fileData.dir {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: f.fileData.name,
+			Err:  errors.New("not a dir"),
+		}
+	}
+	var outLength int64
+
+	f.fileData.Lock()
+	files := f.fileData.memDir.Files()[f.readDirCount:]
+	if count > 0 {
+		if len(files) < count {
+			outLength = int64(len(files))
+		} else {
+			outLength = int64(count)
+		}
+		if len(files) == 0 {
+			err = io.EOF
+		}
+	} else {
+		outLength = int64(len(files))
+	}
+	f.readDirCount += outLength
+	f.fileData.Unlock()
+
+	res = make([]os.FileInfo, outLength)
+	for i := range res {
+		res[i] = &FileInfo{files[i]}
+	}
+
+	return res, err
+}
+
+func (f *File) Readdirnames(n int) (names []string, err error) {
+	fi, err := f.Readdir(n)
+	names = make([]string, len(fi))
+	for i, f := range fi {
+		_, names[i] = filepath.Split(f.Name())
+	}
+	return names, err
+}
+
+// Implements fs.ReadDirFile
+func (f *File) ReadDir(n int) ([]fs.DirEntry, error) {
+	fi, err := f.Readdir(n)
+	if err != nil {
+		return nil, err
+	}
+	di := make([]fs.DirEntry, len(fi))
+	for i, f := range fi {
+		di[i] = common.FileInfoDirEntry{FileInfo: f}
+	}
+	return di, nil
+}
+
+func (f *File) Read(b []byte) (n int, err error) {
+	f.fileData.Lock()
+	defer f.fileData.Unlock()
+	if f.closed {
+		return 0, ErrFileClosed
+	}
+	if len(b) > 0 && int(f.at) == len(f.fileData.data) {
+		return 0, io.EOF
+	}
+	if int(f.at) > len(f.fileData.data) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	if len(f.fileData.data)-int(f.at) >= len(b) {
+		n = len(b)
+	} else {
+		n = len(f.fileData.data) - int(f.at)
+	}
+	copy(b, f.fileData.data[f.at:f.at+int64(n)])
+	atomic.AddInt64(&f.at, int64(n))
+	return
+}
+
+func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
+	prev := atomic.LoadInt64(&f.at)
+	atomic.StoreInt64(&f.at, off)
+	n, err = f.Read(b)
+	atomic.StoreInt64(&f.at, prev)
+	return
+}
+
+func (f *File) Truncate(size int64) error {
+	if f.closed {
+		return ErrFileClosed
+	}
+	if f.readOnly {
+		return &os.PathError{
+			Op:   "truncate",
+			Path: f.fileData.name,
+			Err:  errors.New("file handle is read only"),
+		}
+	}
+	if size < 0 {
+		return ErrOutOfRange
+	}
+	f.fileData.Lock()
+	defer f.fileData.Unlock()
+	if size > int64(len(f.fileData.data)) {
+		diff := size - int64(len(f.fileData.data))
+		f.fileData.data = append(f.fileData.data, bytes.Repeat([]byte{0o0}, int(diff))...)
+	} else {
+		f.fileData.data = f.fileData.data[0:size]
+	}
+	setModTime(f.fileData, time.Now())
+	return nil
+}
+
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	if f.closed {
+		return 0, ErrFileClosed
+	}
+	switch whence {
+	case io.SeekStart:
+		atomic.StoreInt64(&f.at, offset)
+	case io.SeekCurrent:
+		atomic.AddInt64(&f.at, offset)
+	case io.SeekEnd:
+		atomic.StoreInt64(&f.at, int64(len(f.fileData.data))+offset)
+	}
+	return f.at, nil
+}
+
+func (f *File) Write(b []byte) (n int, err error) {
+	if f.closed {
+		return 0, ErrFileClosed
+	}
+	if f.readOnly {
+		return 0, &os.PathError{
+			Op:   "write",
+			Path: f.fileData.name,
+			Err:  errors.New("file handle is read only"),
+		}
+	}
+	n = len(b)
+	cur := atomic.LoadInt64(&f.at)
+	f.fileData.Lock()
+	defer f.fileData.Unlock()
+	diff := cur - int64(len(f.fileData.data))
+	var tail []byte
+	if n+int(cur) < len(f.fileData.data) {
+		tail = f.fileData.data[n+int(cur):]
+	}
+	if diff > 0 {
+		f.fileData.data = append(
+			f.fileData.data,
+			append(bytes.Repeat([]byte{0o0}, int(diff)), b...)...)
+		f.fileData.data = append(f.fileData.data, tail...)
+	} else {
+		f.fileData.data = append(f.fileData.data[:cur], b...)
+		f.fileData.data = append(f.fileData.data, tail...)
+	}
+	setModTime(f.fileData, time.Now())
+
+	atomic.AddInt64(&f.at, int64(n))
+	return
+}
+
+func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
+	atomic.StoreInt64(&f.at, off)
+	return f.Write(b)
+}
+
+func (f *File) WriteString(s string) (ret int, err error) {
+	return f.Write([]byte(s))
+}
+
+func (f *File) Info() *FileInfo {
+	return &FileInfo{f.fileData}
+}
+
+type FileInfo struct {
+	*FileData
+}
+
+// Implements os.FileInfo
+func (s *FileInfo) Name() string {
+	s.Lock()
+	_, name := filepath.Split(s.name)
+	s.Unlock()
+	return name
+}
+
+func (s *FileInfo) Mode() os.FileMode {
+	s.Lock()
+	defer s.Unlock()
+	return s.mode
+}
+
+func (s *FileInfo) ModTime() time.Time {
+	s.Lock()
+	defer s.Unlock()
+	return s.modtime
+}
+
+func (s *FileInfo) IsDir() bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.dir
+}
+func (s *FileInfo) Sys() interface{} { return nil }
+func (s *FileInfo) Size() int64 {
+	if s.IsDir() {
+		return int64(42)
+	}
+	s.Lock()
+	defer s.Unlock()
+	return int64(len(s.data))
+}
+
+var (
+	ErrFileClosed        = errors.New("File is closed")
+	ErrOutOfRange        = errors.New("out of range")
+	ErrTooLarge          = errors.New("too large")
+	ErrFileNotFound      = os.ErrNotExist
+	ErrFileExists        = os.ErrExist
+	ErrDestinationExists = os.ErrExist
+)

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -1,0 +1,463 @@
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/afero/mem"
+)
+
+const chmodBits = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky // Only a subset of bits are allowed to be changed. Documented under os.Chmod()
+
+type MemMapFs struct {
+	mu   sync.RWMutex
+	data map[string]*mem.FileData
+	init sync.Once
+}
+
+func NewMemMapFs() Fs {
+	return &MemMapFs{}
+}
+
+func (m *MemMapFs) getData() map[string]*mem.FileData {
+	m.init.Do(func() {
+		m.data = make(map[string]*mem.FileData)
+		// Root should always exist, right?
+		// TODO: what about windows?
+		root := mem.CreateDir(FilePathSeparator)
+		mem.SetMode(root, os.ModeDir|0o755)
+		m.data[FilePathSeparator] = root
+	})
+	return m.data
+}
+
+func (*MemMapFs) Name() string { return "MemMapFS" }
+
+func (m *MemMapFs) Create(name string) (File, error) {
+	name = normalizePath(name)
+	m.mu.Lock()
+	file := mem.CreateFile(name)
+	m.getData()[name] = file
+	m.registerWithParent(file, 0)
+	m.mu.Unlock()
+	return mem.NewFileHandle(file), nil
+}
+
+func (m *MemMapFs) unRegisterWithParent(fileName string) error {
+	f, err := m.lockfreeOpen(fileName)
+	if err != nil {
+		return err
+	}
+	parent := m.findParent(f)
+	if parent == nil {
+		log.Panic("parent of ", f.Name(), " is nil")
+	}
+
+	parent.Lock()
+	mem.RemoveFromMemDir(parent, f)
+	parent.Unlock()
+	return nil
+}
+
+func (m *MemMapFs) findParent(f *mem.FileData) *mem.FileData {
+	pdir, _ := filepath.Split(f.Name())
+	pdir = filepath.Clean(pdir)
+	pfile, err := m.lockfreeOpen(pdir)
+	if err != nil {
+		return nil
+	}
+	return pfile
+}
+
+func (m *MemMapFs) findDescendants(name string) []*mem.FileData {
+	fData := m.getData()
+	descendants := make([]*mem.FileData, 0, len(fData))
+	for p, dFile := range fData {
+		if strings.HasPrefix(p, name+FilePathSeparator) {
+			descendants = append(descendants, dFile)
+		}
+	}
+
+	sort.Slice(descendants, func(i, j int) bool {
+		cur := len(strings.Split(descendants[i].Name(), FilePathSeparator))
+		next := len(strings.Split(descendants[j].Name(), FilePathSeparator))
+		return cur < next
+	})
+
+	return descendants
+}
+
+func (m *MemMapFs) registerWithParent(f *mem.FileData, perm os.FileMode) {
+	if f == nil {
+		return
+	}
+	parent := m.findParent(f)
+	if parent == nil {
+		pdir := filepath.Dir(filepath.Clean(f.Name()))
+		err := m.lockfreeMkdir(pdir, perm)
+		if err != nil {
+			// log.Println("Mkdir error:", err)
+			return
+		}
+		parent, err = m.lockfreeOpen(pdir)
+		if err != nil {
+			// log.Println("Open after Mkdir error:", err)
+			return
+		}
+	}
+
+	parent.Lock()
+	mem.InitializeDir(parent)
+	mem.AddToMemDir(parent, f)
+	parent.Unlock()
+}
+
+func (m *MemMapFs) lockfreeMkdir(name string, perm os.FileMode) error {
+	name = normalizePath(name)
+	x, ok := m.getData()[name]
+	if ok {
+		// Only return ErrFileExists if it's a file, not a directory.
+		i := mem.FileInfo{FileData: x}
+		if !i.IsDir() {
+			return ErrFileExists
+		}
+	} else {
+		item := mem.CreateDir(name)
+		mem.SetMode(item, os.ModeDir|perm)
+		m.getData()[name] = item
+		m.registerWithParent(item, perm)
+	}
+	return nil
+}
+
+func (m *MemMapFs) Mkdir(name string, perm os.FileMode) error {
+	perm &= chmodBits
+	name = normalizePath(name)
+
+	m.mu.RLock()
+	_, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if ok {
+		return &os.PathError{Op: "mkdir", Path: name, Err: ErrFileExists}
+	}
+
+	m.mu.Lock()
+	// Dobule check that it doesn't exist.
+	if _, ok := m.getData()[name]; ok {
+		m.mu.Unlock()
+		return &os.PathError{Op: "mkdir", Path: name, Err: ErrFileExists}
+	}
+	item := mem.CreateDir(name)
+	mem.SetMode(item, os.ModeDir|perm)
+	m.getData()[name] = item
+	m.registerWithParent(item, perm)
+	m.mu.Unlock()
+
+	return m.setFileMode(name, perm|os.ModeDir)
+}
+
+func (m *MemMapFs) MkdirAll(path string, perm os.FileMode) error {
+	err := m.Mkdir(path, perm)
+	if err != nil {
+		if err.(*os.PathError).Err == ErrFileExists {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// Handle some relative paths
+func normalizePath(path string) string {
+	path = filepath.Clean(path)
+
+	switch path {
+	case ".":
+		return FilePathSeparator
+	case "..":
+		return FilePathSeparator
+	default:
+		return path
+	}
+}
+
+func (m *MemMapFs) Open(name string) (File, error) {
+	f, err := m.open(name)
+	if f != nil {
+		return mem.NewReadOnlyFileHandle(f), err
+	}
+	return nil, err
+}
+
+func (m *MemMapFs) openWrite(name string) (File, error) {
+	f, err := m.open(name)
+	if f != nil {
+		return mem.NewFileHandle(f), err
+	}
+	return nil, err
+}
+
+func (m *MemMapFs) open(name string) (*mem.FileData, error) {
+	name = normalizePath(name)
+
+	m.mu.RLock()
+	f, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, &os.PathError{Op: "open", Path: name, Err: ErrFileNotFound}
+	}
+	return f, nil
+}
+
+func (m *MemMapFs) lockfreeOpen(name string) (*mem.FileData, error) {
+	name = normalizePath(name)
+	f, ok := m.getData()[name]
+	if ok {
+		return f, nil
+	} else {
+		return nil, ErrFileNotFound
+	}
+}
+
+func (m *MemMapFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	perm &= chmodBits
+	chmod := false
+	file, err := m.openWrite(name)
+	if err == nil && (flag&os.O_EXCL > 0) {
+		return nil, &os.PathError{Op: "open", Path: name, Err: ErrFileExists}
+	}
+	if os.IsNotExist(err) && (flag&os.O_CREATE > 0) {
+		file, err = m.Create(name)
+		chmod = true
+	}
+	if err != nil {
+		return nil, err
+	}
+	if flag == os.O_RDONLY {
+		file = mem.NewReadOnlyFileHandle(file.(*mem.File).Data())
+	}
+	if flag&os.O_APPEND > 0 {
+		_, err = file.Seek(0, io.SeekEnd)
+		if err != nil {
+			file.Close()
+			return nil, err
+		}
+	}
+	if flag&os.O_TRUNC > 0 && flag&(os.O_RDWR|os.O_WRONLY) > 0 {
+		err = file.Truncate(0)
+		if err != nil {
+			file.Close()
+			return nil, err
+		}
+	}
+	if chmod {
+		return file, m.setFileMode(name, perm)
+	}
+	return file, nil
+}
+
+func (m *MemMapFs) Remove(name string) error {
+	name = normalizePath(name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.getData()[name]; ok {
+		err := m.unRegisterWithParent(name)
+		if err != nil {
+			return &os.PathError{Op: "remove", Path: name, Err: err}
+		}
+		delete(m.getData(), name)
+	} else {
+		return &os.PathError{Op: "remove", Path: name, Err: os.ErrNotExist}
+	}
+	return nil
+}
+
+func (m *MemMapFs) RemoveAll(path string) error {
+	path = normalizePath(path)
+	m.mu.Lock()
+	m.unRegisterWithParent(path)
+	m.mu.Unlock()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for p := range m.getData() {
+		if p == path || strings.HasPrefix(p, path+FilePathSeparator) {
+			m.mu.RUnlock()
+			m.mu.Lock()
+			delete(m.getData(), p)
+			m.mu.Unlock()
+			m.mu.RLock()
+		}
+	}
+	return nil
+}
+
+func (m *MemMapFs) Rename(oldname, newname string) error {
+	oldname = normalizePath(oldname)
+	newname = normalizePath(newname)
+
+	if oldname == newname {
+		return nil
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if _, ok := m.getData()[oldname]; ok {
+		m.mu.RUnlock()
+		m.mu.Lock()
+		err := m.unRegisterWithParent(oldname)
+		if err != nil {
+			return err
+		}
+
+		fileData := m.getData()[oldname]
+		mem.ChangeFileName(fileData, newname)
+		m.getData()[newname] = fileData
+
+		err = m.renameDescendants(oldname, newname)
+		if err != nil {
+			return err
+		}
+
+		delete(m.getData(), oldname)
+
+		m.registerWithParent(fileData, 0)
+		m.mu.Unlock()
+		m.mu.RLock()
+	} else {
+		return &os.PathError{Op: "rename", Path: oldname, Err: ErrFileNotFound}
+	}
+	return nil
+}
+
+func (m *MemMapFs) renameDescendants(oldname, newname string) error {
+	descendants := m.findDescendants(oldname)
+	removes := make([]string, 0, len(descendants))
+	for _, desc := range descendants {
+		descNewName := strings.Replace(desc.Name(), oldname, newname, 1)
+		err := m.unRegisterWithParent(desc.Name())
+		if err != nil {
+			return err
+		}
+
+		removes = append(removes, desc.Name())
+		mem.ChangeFileName(desc, descNewName)
+		m.getData()[descNewName] = desc
+
+		m.registerWithParent(desc, 0)
+	}
+	for _, r := range removes {
+		delete(m.getData(), r)
+	}
+
+	return nil
+}
+
+func (m *MemMapFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	fileInfo, err := m.Stat(name)
+	return fileInfo, false, err
+}
+
+func (m *MemMapFs) Stat(name string) (os.FileInfo, error) {
+	f, err := m.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	fi := mem.GetFileInfo(f.(*mem.File).Data())
+	return fi, nil
+}
+
+func (m *MemMapFs) Chmod(name string, mode os.FileMode) error {
+	mode &= chmodBits
+
+	m.mu.RLock()
+	f, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if !ok {
+		return &os.PathError{Op: "chmod", Path: name, Err: ErrFileNotFound}
+	}
+	prevOtherBits := mem.GetFileInfo(f).Mode() & ^chmodBits
+
+	mode = prevOtherBits | mode
+	return m.setFileMode(name, mode)
+}
+
+func (m *MemMapFs) setFileMode(name string, mode os.FileMode) error {
+	name = normalizePath(name)
+
+	m.mu.RLock()
+	f, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if !ok {
+		return &os.PathError{Op: "chmod", Path: name, Err: ErrFileNotFound}
+	}
+
+	m.mu.Lock()
+	mem.SetMode(f, mode)
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *MemMapFs) Chown(name string, uid, gid int) error {
+	name = normalizePath(name)
+
+	m.mu.RLock()
+	f, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if !ok {
+		return &os.PathError{Op: "chown", Path: name, Err: ErrFileNotFound}
+	}
+
+	mem.SetUID(f, uid)
+	mem.SetGID(f, gid)
+
+	return nil
+}
+
+func (m *MemMapFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	name = normalizePath(name)
+
+	m.mu.RLock()
+	f, ok := m.getData()[name]
+	m.mu.RUnlock()
+	if !ok {
+		return &os.PathError{Op: "chtimes", Path: name, Err: ErrFileNotFound}
+	}
+
+	m.mu.Lock()
+	mem.SetModTime(f, mtime)
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *MemMapFs) List() {
+	for _, x := range m.data {
+		y := mem.FileInfo{FileData: x}
+		fmt.Println(x.Name(), y.Size())
+	}
+}

--- a/vendor/github.com/spf13/afero/os.go
+++ b/vendor/github.com/spf13/afero/os.go
@@ -1,0 +1,113 @@
+// Copyright © 2014 Steve Francia <spf@spf13.com>.
+// Copyright 2013 tsuru authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"os"
+	"time"
+)
+
+var _ Lstater = (*OsFs)(nil)
+
+// OsFs is a Fs implementation that uses functions provided by the os package.
+//
+// For details in any method, check the documentation of the os package
+// (http://golang.org/pkg/os/).
+type OsFs struct{}
+
+func NewOsFs() Fs {
+	return &OsFs{}
+}
+
+func (OsFs) Name() string { return "OsFs" }
+
+func (OsFs) Create(name string) (File, error) {
+	f, e := os.Create(name)
+	if f == nil {
+		// while this looks strange, we need to return a bare nil (of type nil) not
+		// a nil value of type *os.File or nil won't be nil
+		return nil, e
+	}
+	return f, e
+}
+
+func (OsFs) Mkdir(name string, perm os.FileMode) error {
+	return os.Mkdir(name, perm)
+}
+
+func (OsFs) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (OsFs) Open(name string) (File, error) {
+	f, e := os.Open(name)
+	if f == nil {
+		// while this looks strange, we need to return a bare nil (of type nil) not
+		// a nil value of type *os.File or nil won't be nil
+		return nil, e
+	}
+	return f, e
+}
+
+func (OsFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	f, e := os.OpenFile(name, flag, perm)
+	if f == nil {
+		// while this looks strange, we need to return a bare nil (of type nil) not
+		// a nil value of type *os.File or nil won't be nil
+		return nil, e
+	}
+	return f, e
+}
+
+func (OsFs) Remove(name string) error {
+	return os.Remove(name)
+}
+
+func (OsFs) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (OsFs) Rename(oldname, newname string) error {
+	return os.Rename(oldname, newname)
+}
+
+func (OsFs) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (OsFs) Chmod(name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
+func (OsFs) Chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
+}
+
+func (OsFs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return os.Chtimes(name, atime, mtime)
+}
+
+func (OsFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	fi, err := os.Lstat(name)
+	return fi, true, err
+}
+
+func (OsFs) SymlinkIfPossible(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
+func (OsFs) ReadlinkIfPossible(name string) (string, error) {
+	return os.Readlink(name)
+}

--- a/vendor/github.com/spf13/afero/path.go
+++ b/vendor/github.com/spf13/afero/path.go
@@ -1,0 +1,106 @@
+// Copyright ©2015 The Go Authors
+// Copyright ©2015 Steve Francia <spf@spf13.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// readDirNames reads the directory named by dirname and returns
+// a sorted list of directory entries.
+// adapted from https://golang.org/src/path/filepath/path.go
+func readDirNames(fs Fs, dirname string) ([]string, error) {
+	f, err := fs.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// walk recursively descends path, calling walkFn
+// adapted from https://golang.org/src/path/filepath/path.go
+func walk(fs Fs, path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	err := walkFn(path, info, nil)
+	if err != nil {
+		if info.IsDir() && err == filepath.SkipDir {
+			return nil
+		}
+		return err
+	}
+
+	if !info.IsDir() {
+		return nil
+	}
+
+	names, err := readDirNames(fs, path)
+	if err != nil {
+		return walkFn(path, info, err)
+	}
+
+	for _, name := range names {
+		filename := filepath.Join(path, name)
+		fileInfo, err := lstatIfPossible(fs, filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil && err != filepath.SkipDir {
+				return err
+			}
+		} else {
+			err = walk(fs, filename, fileInfo, walkFn)
+			if err != nil {
+				if !fileInfo.IsDir() || err != filepath.SkipDir {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// if the filesystem supports it, use Lstat, else use fs.Stat
+func lstatIfPossible(fs Fs, path string) (os.FileInfo, error) {
+	if lfs, ok := fs.(Lstater); ok {
+		fi, _, err := lfs.LstatIfPossible(path)
+		return fi, err
+	}
+	return fs.Stat(path)
+}
+
+// Walk walks the file tree rooted at root, calling walkFn for each file or
+// directory in the tree, including root. All errors that arise visiting files
+// and directories are filtered by walkFn. The files are walked in lexical
+// order, which makes the output deterministic but means that for very
+// large directories Walk can be inefficient.
+// Walk does not follow symbolic links.
+
+func (a Afero) Walk(root string, walkFn filepath.WalkFunc) error {
+	return Walk(a.Fs, root, walkFn)
+}
+
+func Walk(fs Fs, root string, walkFn filepath.WalkFunc) error {
+	info, err := lstatIfPossible(fs, root)
+	if err != nil {
+		return walkFn(root, nil, err)
+	}
+	return walk(fs, root, info, walkFn)
+}

--- a/vendor/github.com/spf13/afero/readonlyfs.go
+++ b/vendor/github.com/spf13/afero/readonlyfs.go
@@ -1,0 +1,96 @@
+package afero
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+var _ Lstater = (*ReadOnlyFs)(nil)
+
+type ReadOnlyFs struct {
+	source Fs
+}
+
+func NewReadOnlyFs(source Fs) Fs {
+	return &ReadOnlyFs{source: source}
+}
+
+func (r *ReadOnlyFs) ReadDir(name string) ([]os.FileInfo, error) {
+	return ReadDir(r.source, name)
+}
+
+func (r *ReadOnlyFs) Chtimes(n string, a, m time.Time) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) Chmod(n string, m os.FileMode) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) Chown(n string, uid, gid int) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) Name() string {
+	return "ReadOnlyFilter"
+}
+
+func (r *ReadOnlyFs) Stat(name string) (os.FileInfo, error) {
+	return r.source.Stat(name)
+}
+
+func (r *ReadOnlyFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if lsf, ok := r.source.(Lstater); ok {
+		return lsf.LstatIfPossible(name)
+	}
+	fi, err := r.Stat(name)
+	return fi, false, err
+}
+
+func (r *ReadOnlyFs) SymlinkIfPossible(oldname, newname string) error {
+	return &os.LinkError{Op: "symlink", Old: oldname, New: newname, Err: ErrNoSymlink}
+}
+
+func (r *ReadOnlyFs) ReadlinkIfPossible(name string) (string, error) {
+	if srdr, ok := r.source.(LinkReader); ok {
+		return srdr.ReadlinkIfPossible(name)
+	}
+
+	return "", &os.PathError{Op: "readlink", Path: name, Err: ErrNoReadlink}
+}
+
+func (r *ReadOnlyFs) Rename(o, n string) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) RemoveAll(p string) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) Remove(n string) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	if flag&(os.O_WRONLY|syscall.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		return nil, syscall.EPERM
+	}
+	return r.source.OpenFile(name, flag, perm)
+}
+
+func (r *ReadOnlyFs) Open(n string) (File, error) {
+	return r.source.Open(n)
+}
+
+func (r *ReadOnlyFs) Mkdir(n string, p os.FileMode) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) MkdirAll(n string, p os.FileMode) error {
+	return syscall.EPERM
+}
+
+func (r *ReadOnlyFs) Create(n string) (File, error) {
+	return nil, syscall.EPERM
+}

--- a/vendor/github.com/spf13/afero/regexpfs.go
+++ b/vendor/github.com/spf13/afero/regexpfs.go
@@ -1,0 +1,223 @@
+package afero
+
+import (
+	"os"
+	"regexp"
+	"syscall"
+	"time"
+)
+
+// The RegexpFs filters files (not directories) by regular expression. Only
+// files matching the given regexp will be allowed, all others get a ENOENT error (
+// "No such file or directory").
+type RegexpFs struct {
+	re     *regexp.Regexp
+	source Fs
+}
+
+func NewRegexpFs(source Fs, re *regexp.Regexp) Fs {
+	return &RegexpFs{source: source, re: re}
+}
+
+type RegexpFile struct {
+	f  File
+	re *regexp.Regexp
+}
+
+func (r *RegexpFs) matchesName(name string) error {
+	if r.re == nil {
+		return nil
+	}
+	if r.re.MatchString(name) {
+		return nil
+	}
+	return syscall.ENOENT
+}
+
+func (r *RegexpFs) dirOrMatches(name string) error {
+	dir, err := IsDir(r.source, name)
+	if err != nil {
+		return err
+	}
+	if dir {
+		return nil
+	}
+	return r.matchesName(name)
+}
+
+func (r *RegexpFs) Chtimes(name string, a, m time.Time) error {
+	if err := r.dirOrMatches(name); err != nil {
+		return err
+	}
+	return r.source.Chtimes(name, a, m)
+}
+
+func (r *RegexpFs) Chmod(name string, mode os.FileMode) error {
+	if err := r.dirOrMatches(name); err != nil {
+		return err
+	}
+	return r.source.Chmod(name, mode)
+}
+
+func (r *RegexpFs) Chown(name string, uid, gid int) error {
+	if err := r.dirOrMatches(name); err != nil {
+		return err
+	}
+	return r.source.Chown(name, uid, gid)
+}
+
+func (r *RegexpFs) Name() string {
+	return "RegexpFs"
+}
+
+func (r *RegexpFs) Stat(name string) (os.FileInfo, error) {
+	if err := r.dirOrMatches(name); err != nil {
+		return nil, err
+	}
+	return r.source.Stat(name)
+}
+
+func (r *RegexpFs) Rename(oldname, newname string) error {
+	dir, err := IsDir(r.source, oldname)
+	if err != nil {
+		return err
+	}
+	if dir {
+		return nil
+	}
+	if err := r.matchesName(oldname); err != nil {
+		return err
+	}
+	if err := r.matchesName(newname); err != nil {
+		return err
+	}
+	return r.source.Rename(oldname, newname)
+}
+
+func (r *RegexpFs) RemoveAll(p string) error {
+	dir, err := IsDir(r.source, p)
+	if err != nil {
+		return err
+	}
+	if !dir {
+		if err := r.matchesName(p); err != nil {
+			return err
+		}
+	}
+	return r.source.RemoveAll(p)
+}
+
+func (r *RegexpFs) Remove(name string) error {
+	if err := r.dirOrMatches(name); err != nil {
+		return err
+	}
+	return r.source.Remove(name)
+}
+
+func (r *RegexpFs) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	if err := r.dirOrMatches(name); err != nil {
+		return nil, err
+	}
+	return r.source.OpenFile(name, flag, perm)
+}
+
+func (r *RegexpFs) Open(name string) (File, error) {
+	dir, err := IsDir(r.source, name)
+	if err != nil {
+		return nil, err
+	}
+	if !dir {
+		if err := r.matchesName(name); err != nil {
+			return nil, err
+		}
+	}
+	f, err := r.source.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &RegexpFile{f: f, re: r.re}, nil
+}
+
+func (r *RegexpFs) Mkdir(n string, p os.FileMode) error {
+	return r.source.Mkdir(n, p)
+}
+
+func (r *RegexpFs) MkdirAll(n string, p os.FileMode) error {
+	return r.source.MkdirAll(n, p)
+}
+
+func (r *RegexpFs) Create(name string) (File, error) {
+	if err := r.matchesName(name); err != nil {
+		return nil, err
+	}
+	return r.source.Create(name)
+}
+
+func (f *RegexpFile) Close() error {
+	return f.f.Close()
+}
+
+func (f *RegexpFile) Read(s []byte) (int, error) {
+	return f.f.Read(s)
+}
+
+func (f *RegexpFile) ReadAt(s []byte, o int64) (int, error) {
+	return f.f.ReadAt(s, o)
+}
+
+func (f *RegexpFile) Seek(o int64, w int) (int64, error) {
+	return f.f.Seek(o, w)
+}
+
+func (f *RegexpFile) Write(s []byte) (int, error) {
+	return f.f.Write(s)
+}
+
+func (f *RegexpFile) WriteAt(s []byte, o int64) (int, error) {
+	return f.f.WriteAt(s, o)
+}
+
+func (f *RegexpFile) Name() string {
+	return f.f.Name()
+}
+
+func (f *RegexpFile) Readdir(c int) (fi []os.FileInfo, err error) {
+	var rfi []os.FileInfo
+	rfi, err = f.f.Readdir(c)
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range rfi {
+		if i.IsDir() || f.re.MatchString(i.Name()) {
+			fi = append(fi, i)
+		}
+	}
+	return fi, nil
+}
+
+func (f *RegexpFile) Readdirnames(c int) (n []string, err error) {
+	fi, err := f.Readdir(c)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range fi {
+		n = append(n, s.Name())
+	}
+	return n, nil
+}
+
+func (f *RegexpFile) Stat() (os.FileInfo, error) {
+	return f.f.Stat()
+}
+
+func (f *RegexpFile) Sync() error {
+	return f.f.Sync()
+}
+
+func (f *RegexpFile) Truncate(s int64) error {
+	return f.f.Truncate(s)
+}
+
+func (f *RegexpFile) WriteString(s string) (int, error) {
+	return f.f.WriteString(s)
+}

--- a/vendor/github.com/spf13/afero/symlink.go
+++ b/vendor/github.com/spf13/afero/symlink.go
@@ -1,0 +1,55 @@
+// Copyright © 2018 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"errors"
+)
+
+// Symlinker is an optional interface in Afero. It is only implemented by the
+// filesystems saying so.
+// It indicates support for 3 symlink related interfaces that implement the
+// behaviors of the os methods:
+//   - Lstat
+//   - Symlink, and
+//   - Readlink
+type Symlinker interface {
+	Lstater
+	Linker
+	LinkReader
+}
+
+// Linker is an optional interface in Afero. It is only implemented by the
+// filesystems saying so.
+// It will call Symlink if the filesystem itself is, or it delegates to, the os filesystem,
+// or the filesystem otherwise supports Symlink's.
+type Linker interface {
+	SymlinkIfPossible(oldname, newname string) error
+}
+
+// ErrNoSymlink is the error that will be wrapped in an os.LinkError if a file system
+// does not support Symlink's either directly or through its delegated filesystem.
+// As expressed by support for the Linker interface.
+var ErrNoSymlink = errors.New("symlink not supported")
+
+// LinkReader is an optional interface in Afero. It is only implemented by the
+// filesystems saying so.
+type LinkReader interface {
+	ReadlinkIfPossible(name string) (string, error)
+}
+
+// ErrNoReadlink is the error that will be wrapped in an os.Path if a file system
+// does not support the readlink operation either directly or through its delegated filesystem.
+// As expressed by support for the LinkReader interface.
+var ErrNoReadlink = errors.New("readlink not supported")

--- a/vendor/github.com/spf13/afero/unionFile.go
+++ b/vendor/github.com/spf13/afero/unionFile.go
@@ -1,0 +1,331 @@
+package afero
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// The UnionFile implements the afero.File interface and will be returned
+// when reading a directory present at least in the overlay or opening a file
+// for writing.
+//
+// The calls to
+// Readdir() and Readdirnames() merge the file os.FileInfo / names from the
+// base and the overlay - for files present in both layers, only those
+// from the overlay will be used.
+//
+// When opening files for writing (Create() / OpenFile() with the right flags)
+// the operations will be done in both layers, starting with the overlay. A
+// successful read in the overlay will move the cursor position in the base layer
+// by the number of bytes read.
+type UnionFile struct {
+	Base   File
+	Layer  File
+	Merger DirsMerger
+	off    int
+	files  []os.FileInfo
+}
+
+func (f *UnionFile) Close() error {
+	// first close base, so we have a newer timestamp in the overlay. If we'd close
+	// the overlay first, we'd get a cacheStale the next time we access this file
+	// -> cache would be useless ;-)
+	if f.Base != nil {
+		f.Base.Close()
+	}
+	if f.Layer != nil {
+		return f.Layer.Close()
+	}
+	return BADFD
+}
+
+func (f *UnionFile) Read(s []byte) (int, error) {
+	if f.Layer != nil {
+		n, err := f.Layer.Read(s)
+		if (err == nil || err == io.EOF) && f.Base != nil {
+			// advance the file position also in the base file, the next
+			// call may be a write at this position (or a seek with SEEK_CUR)
+			if _, seekErr := f.Base.Seek(int64(n), io.SeekCurrent); seekErr != nil {
+				// only overwrite err in case the seek fails: we need to
+				// report an eventual io.EOF to the caller
+				err = seekErr
+			}
+		}
+		return n, err
+	}
+	if f.Base != nil {
+		return f.Base.Read(s)
+	}
+	return 0, BADFD
+}
+
+func (f *UnionFile) ReadAt(s []byte, o int64) (int, error) {
+	if f.Layer != nil {
+		n, err := f.Layer.ReadAt(s, o)
+		if (err == nil || err == io.EOF) && f.Base != nil {
+			_, err = f.Base.Seek(o+int64(n), io.SeekStart)
+		}
+		return n, err
+	}
+	if f.Base != nil {
+		return f.Base.ReadAt(s, o)
+	}
+	return 0, BADFD
+}
+
+func (f *UnionFile) Seek(o int64, w int) (pos int64, err error) {
+	if f.Layer != nil {
+		pos, err = f.Layer.Seek(o, w)
+		if (err == nil || err == io.EOF) && f.Base != nil {
+			_, err = f.Base.Seek(o, w)
+		}
+		return pos, err
+	}
+	if f.Base != nil {
+		return f.Base.Seek(o, w)
+	}
+	return 0, BADFD
+}
+
+func (f *UnionFile) Write(s []byte) (n int, err error) {
+	if f.Layer != nil {
+		n, err = f.Layer.Write(s)
+		if err == nil &&
+			f.Base != nil { // hmm, do we have fixed size files where a write may hit the EOF mark?
+			_, err = f.Base.Write(s)
+		}
+		return n, err
+	}
+	if f.Base != nil {
+		return f.Base.Write(s)
+	}
+	return 0, BADFD
+}
+
+func (f *UnionFile) WriteAt(s []byte, o int64) (n int, err error) {
+	if f.Layer != nil {
+		n, err = f.Layer.WriteAt(s, o)
+		if err == nil && f.Base != nil {
+			_, err = f.Base.WriteAt(s, o)
+		}
+		return n, err
+	}
+	if f.Base != nil {
+		return f.Base.WriteAt(s, o)
+	}
+	return 0, BADFD
+}
+
+func (f *UnionFile) Name() string {
+	if f.Layer != nil {
+		return f.Layer.Name()
+	}
+	return f.Base.Name()
+}
+
+// DirsMerger is how UnionFile weaves two directories together.
+// It takes the FileInfo slices from the layer and the base and returns a
+// single view.
+type DirsMerger func(lofi, bofi []os.FileInfo) ([]os.FileInfo, error)
+
+var defaultUnionMergeDirsFn = func(lofi, bofi []os.FileInfo) ([]os.FileInfo, error) {
+	files := make(map[string]os.FileInfo)
+
+	for _, fi := range lofi {
+		files[fi.Name()] = fi
+	}
+
+	for _, fi := range bofi {
+		if _, exists := files[fi.Name()]; !exists {
+			files[fi.Name()] = fi
+		}
+	}
+
+	rfi := make([]os.FileInfo, len(files))
+
+	i := 0
+	for _, fi := range files {
+		rfi[i] = fi
+		i++
+	}
+
+	return rfi, nil
+}
+
+// Readdir will weave the two directories together and
+// return a single view of the overlayed directories.
+// At the end of the directory view, the error is io.EOF if c > 0.
+func (f *UnionFile) Readdir(c int) (ofi []os.FileInfo, err error) {
+	merge := f.Merger
+	if merge == nil {
+		merge = defaultUnionMergeDirsFn
+	}
+
+	if f.off == 0 {
+		var lfi []os.FileInfo
+		if f.Layer != nil {
+			lfi, err = f.Layer.Readdir(-1)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var bfi []os.FileInfo
+		if f.Base != nil {
+			bfi, err = f.Base.Readdir(-1)
+			if err != nil {
+				return nil, err
+			}
+
+		}
+		merged, err := merge(lfi, bfi)
+		if err != nil {
+			return nil, err
+		}
+		f.files = append(f.files, merged...)
+	}
+	files := f.files[f.off:]
+
+	if c <= 0 {
+		return files, nil
+	}
+
+	if len(files) == 0 {
+		return nil, io.EOF
+	}
+
+	if c > len(files) {
+		c = len(files)
+	}
+
+	defer func() { f.off += c }()
+	return files[:c], nil
+}
+
+func (f *UnionFile) Readdirnames(c int) ([]string, error) {
+	rfi, err := f.Readdir(c)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, fi := range rfi {
+		names = append(names, fi.Name())
+	}
+	return names, nil
+}
+
+func (f *UnionFile) Stat() (os.FileInfo, error) {
+	if f.Layer != nil {
+		return f.Layer.Stat()
+	}
+	if f.Base != nil {
+		return f.Base.Stat()
+	}
+	return nil, BADFD
+}
+
+func (f *UnionFile) Sync() (err error) {
+	if f.Layer != nil {
+		err = f.Layer.Sync()
+		if err == nil && f.Base != nil {
+			err = f.Base.Sync()
+		}
+		return err
+	}
+	if f.Base != nil {
+		return f.Base.Sync()
+	}
+	return BADFD
+}
+
+func (f *UnionFile) Truncate(s int64) (err error) {
+	if f.Layer != nil {
+		err = f.Layer.Truncate(s)
+		if err == nil && f.Base != nil {
+			err = f.Base.Truncate(s)
+		}
+		return err
+	}
+	if f.Base != nil {
+		return f.Base.Truncate(s)
+	}
+	return BADFD
+}
+
+func (f *UnionFile) WriteString(s string) (n int, err error) {
+	if f.Layer != nil {
+		n, err = f.Layer.WriteString(s)
+		if err == nil && f.Base != nil {
+			_, err = f.Base.WriteString(s)
+		}
+		return n, err
+	}
+	if f.Base != nil {
+		return f.Base.WriteString(s)
+	}
+	return 0, BADFD
+}
+
+func copyFile(base Fs, layer Fs, name string, bfh File) error {
+	// First make sure the directory exists
+	exists, err := Exists(layer, filepath.Dir(name))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		err = layer.MkdirAll(filepath.Dir(name), 0o777) // FIXME?
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create the file on the overlay
+	lfh, err := layer.Create(name)
+	if err != nil {
+		return err
+	}
+	n, err := io.Copy(lfh, bfh)
+	if err != nil {
+		// If anything fails, clean up the file
+		layer.Remove(name)
+		lfh.Close()
+		return err
+	}
+
+	bfi, err := bfh.Stat()
+	if err != nil || bfi.Size() != n {
+		layer.Remove(name)
+		lfh.Close()
+		return syscall.EIO
+	}
+
+	err = lfh.Close()
+	if err != nil {
+		layer.Remove(name)
+		lfh.Close()
+		return err
+	}
+	return layer.Chtimes(name, bfi.ModTime(), bfi.ModTime())
+}
+
+func copyToLayer(base Fs, layer Fs, name string) error {
+	bfh, err := base.Open(name)
+	if err != nil {
+		return err
+	}
+	defer bfh.Close()
+
+	return copyFile(base, layer, name, bfh)
+}
+
+func copyFileToLayer(base Fs, layer Fs, name string, flag int, perm os.FileMode) error {
+	bfh, err := base.OpenFile(name, flag, perm)
+	if err != nil {
+		return err
+	}
+	defer bfh.Close()
+
+	return copyFile(base, layer, name, bfh)
+}

--- a/vendor/github.com/spf13/afero/util.go
+++ b/vendor/github.com/spf13/afero/util.go
@@ -1,0 +1,329 @@
+// Copyright ©2015 Steve Francia <spf@spf13.com>
+// Portions Copyright ©2015 The Hugo Authors
+// Portions Copyright 2016-present Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package afero
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// Filepath separator defined by os.Separator.
+const FilePathSeparator = string(filepath.Separator)
+
+// Takes a reader and a path and writes the content
+func (a Afero) WriteReader(path string, r io.Reader) (err error) {
+	return WriteReader(a.Fs, path, r)
+}
+
+func WriteReader(fs Fs, path string, r io.Reader) (err error) {
+	dir, _ := filepath.Split(path)
+	ospath := filepath.FromSlash(dir)
+
+	if ospath != "" {
+		err = fs.MkdirAll(ospath, 0o777) // rwx, rw, r
+		if err != nil {
+			if err != os.ErrExist {
+				return err
+			}
+		}
+	}
+
+	file, err := fs.Create(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, r)
+	return
+}
+
+// Same as WriteReader but checks to see if file/directory already exists.
+func (a Afero) SafeWriteReader(path string, r io.Reader) (err error) {
+	return SafeWriteReader(a.Fs, path, r)
+}
+
+func SafeWriteReader(fs Fs, path string, r io.Reader) (err error) {
+	dir, _ := filepath.Split(path)
+	ospath := filepath.FromSlash(dir)
+
+	if ospath != "" {
+		err = fs.MkdirAll(ospath, 0o777) // rwx, rw, r
+		if err != nil {
+			return
+		}
+	}
+
+	exists, err := Exists(fs, path)
+	if err != nil {
+		return
+	}
+	if exists {
+		return fmt.Errorf("%v already exists", path)
+	}
+
+	file, err := fs.Create(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, r)
+	return
+}
+
+func (a Afero) GetTempDir(subPath string) string {
+	return GetTempDir(a.Fs, subPath)
+}
+
+// GetTempDir returns the default temp directory with trailing slash
+// if subPath is not empty then it will be created recursively with mode 777 rwx rwx rwx
+func GetTempDir(fs Fs, subPath string) string {
+	addSlash := func(p string) string {
+		if FilePathSeparator != p[len(p)-1:] {
+			p = p + FilePathSeparator
+		}
+		return p
+	}
+	dir := addSlash(os.TempDir())
+
+	if subPath != "" {
+		// preserve windows backslash :-(
+		if FilePathSeparator == "\\" {
+			subPath = strings.ReplaceAll(subPath, "\\", "____")
+		}
+		dir = dir + UnicodeSanitize((subPath))
+		if FilePathSeparator == "\\" {
+			dir = strings.ReplaceAll(dir, "____", "\\")
+		}
+
+		if exists, _ := Exists(fs, dir); exists {
+			return addSlash(dir)
+		}
+
+		err := fs.MkdirAll(dir, 0o777)
+		if err != nil {
+			panic(err)
+		}
+		dir = addSlash(dir)
+	}
+	return dir
+}
+
+// Rewrite string to remove non-standard path characters
+func UnicodeSanitize(s string) string {
+	source := []rune(s)
+	target := make([]rune, 0, len(source))
+
+	for _, r := range source {
+		if unicode.IsLetter(r) ||
+			unicode.IsDigit(r) ||
+			unicode.IsMark(r) ||
+			r == '.' ||
+			r == '/' ||
+			r == '\\' ||
+			r == '_' ||
+			r == '-' ||
+			r == '%' ||
+			r == ' ' ||
+			r == '#' {
+			target = append(target, r)
+		}
+	}
+
+	return string(target)
+}
+
+// Transform characters with accents into plain forms.
+func NeuterAccents(s string) string {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	result, _, _ := transform.String(t, string(s))
+
+	return result
+}
+
+func (a Afero) FileContainsBytes(filename string, subslice []byte) (bool, error) {
+	return FileContainsBytes(a.Fs, filename, subslice)
+}
+
+// Check if a file contains a specified byte slice.
+func FileContainsBytes(fs Fs, filename string, subslice []byte) (bool, error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	return readerContainsAny(f, subslice), nil
+}
+
+func (a Afero) FileContainsAnyBytes(filename string, subslices [][]byte) (bool, error) {
+	return FileContainsAnyBytes(a.Fs, filename, subslices)
+}
+
+// Check if a file contains any of the specified byte slices.
+func FileContainsAnyBytes(fs Fs, filename string, subslices [][]byte) (bool, error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	return readerContainsAny(f, subslices...), nil
+}
+
+// readerContains reports whether any of the subslices is within r.
+func readerContainsAny(r io.Reader, subslices ...[]byte) bool {
+	if r == nil || len(subslices) == 0 {
+		return false
+	}
+
+	largestSlice := 0
+
+	for _, sl := range subslices {
+		if len(sl) > largestSlice {
+			largestSlice = len(sl)
+		}
+	}
+
+	if largestSlice == 0 {
+		return false
+	}
+
+	bufflen := largestSlice * 4
+	halflen := bufflen / 2
+	buff := make([]byte, bufflen)
+	var err error
+	var n, i int
+
+	for {
+		i++
+		if i == 1 {
+			n, err = io.ReadAtLeast(r, buff[:halflen], halflen)
+		} else {
+			if i != 2 {
+				// shift left to catch overlapping matches
+				copy(buff[:], buff[halflen:])
+			}
+			n, err = io.ReadAtLeast(r, buff[halflen:], halflen)
+		}
+
+		if n > 0 {
+			for _, sl := range subslices {
+				if bytes.Contains(buff, sl) {
+					return true
+				}
+			}
+		}
+
+		if err != nil {
+			break
+		}
+	}
+	return false
+}
+
+func (a Afero) DirExists(path string) (bool, error) {
+	return DirExists(a.Fs, path)
+}
+
+// DirExists checks if a path exists and is a directory.
+func DirExists(fs Fs, path string) (bool, error) {
+	fi, err := fs.Stat(path)
+	if err == nil && fi.IsDir() {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (a Afero) IsDir(path string) (bool, error) {
+	return IsDir(a.Fs, path)
+}
+
+// IsDir checks if a given path is a directory.
+func IsDir(fs Fs, path string) (bool, error) {
+	fi, err := fs.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
+}
+
+func (a Afero) IsEmpty(path string) (bool, error) {
+	return IsEmpty(a.Fs, path)
+}
+
+// IsEmpty checks if a given file or directory is empty.
+func IsEmpty(fs Fs, path string) (bool, error) {
+	if b, _ := Exists(fs, path); !b {
+		return false, fmt.Errorf("%q path does not exist", path)
+	}
+	fi, err := fs.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if fi.IsDir() {
+		f, err := fs.Open(path)
+		if err != nil {
+			return false, err
+		}
+		defer f.Close()
+		list, err := f.Readdir(-1)
+		if err != nil {
+			return false, err
+		}
+		return len(list) == 0, nil
+	}
+	return fi.Size() == 0, nil
+}
+
+func (a Afero) Exists(path string) (bool, error) {
+	return Exists(a.Fs, path)
+}
+
+// Check if a file or directory exists.
+func Exists(fs Fs, path string) (bool, error) {
+	_, err := fs.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func FullBaseFsPath(basePathFs *BasePathFs, relativePath string) string {
+	combinedPath := filepath.Join(basePathFs.path, relativePath)
+	if parent, ok := basePathFs.source.(*BasePathFs); ok {
+		return FullBaseFsPath(parent, combinedPath)
+	}
+
+	return combinedPath
+}

--- a/vendor/golang.org/x/text/runes/cond.go
+++ b/vendor/golang.org/x/text/runes/cond.go
@@ -1,0 +1,187 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runes
+
+import (
+	"unicode/utf8"
+
+	"golang.org/x/text/transform"
+)
+
+// Note: below we pass invalid UTF-8 to the tIn and tNotIn transformers as is.
+// This is done for various reasons:
+// - To retain the semantics of the Nop transformer: if input is passed to a Nop
+//   one would expect it to be unchanged.
+// - It would be very expensive to pass a converted RuneError to a transformer:
+//   a transformer might need more source bytes after RuneError, meaning that
+//   the only way to pass it safely is to create a new buffer and manage the
+//   intermingling of RuneErrors and normal input.
+// - Many transformers leave ill-formed UTF-8 as is, so this is not
+//   inconsistent. Generally ill-formed UTF-8 is only replaced if it is a
+//   logical consequence of the operation (as for Map) or if it otherwise would
+//   pose security concerns (as for Remove).
+// - An alternative would be to return an error on ill-formed UTF-8, but this
+//   would be inconsistent with other operations.
+
+// If returns a transformer that applies tIn to consecutive runes for which
+// s.Contains(r) and tNotIn to consecutive runes for which !s.Contains(r). Reset
+// is called on tIn and tNotIn at the start of each run. A Nop transformer will
+// substitute a nil value passed to tIn or tNotIn. Invalid UTF-8 is translated
+// to RuneError to determine which transformer to apply, but is passed as is to
+// the respective transformer.
+func If(s Set, tIn, tNotIn transform.Transformer) Transformer {
+	if tIn == nil && tNotIn == nil {
+		return Transformer{transform.Nop}
+	}
+	if tIn == nil {
+		tIn = transform.Nop
+	}
+	if tNotIn == nil {
+		tNotIn = transform.Nop
+	}
+	sIn, ok := tIn.(transform.SpanningTransformer)
+	if !ok {
+		sIn = dummySpan{tIn}
+	}
+	sNotIn, ok := tNotIn.(transform.SpanningTransformer)
+	if !ok {
+		sNotIn = dummySpan{tNotIn}
+	}
+
+	a := &cond{
+		tIn:    sIn,
+		tNotIn: sNotIn,
+		f:      s.Contains,
+	}
+	a.Reset()
+	return Transformer{a}
+}
+
+type dummySpan struct{ transform.Transformer }
+
+func (d dummySpan) Span(src []byte, atEOF bool) (n int, err error) {
+	return 0, transform.ErrEndOfSpan
+}
+
+type cond struct {
+	tIn, tNotIn transform.SpanningTransformer
+	f           func(rune) bool
+	check       func(rune) bool               // current check to perform
+	t           transform.SpanningTransformer // current transformer to use
+}
+
+// Reset implements transform.Transformer.
+func (t *cond) Reset() {
+	t.check = t.is
+	t.t = t.tIn
+	t.t.Reset() // notIn will be reset on first usage.
+}
+
+func (t *cond) is(r rune) bool {
+	if t.f(r) {
+		return true
+	}
+	t.check = t.isNot
+	t.t = t.tNotIn
+	t.tNotIn.Reset()
+	return false
+}
+
+func (t *cond) isNot(r rune) bool {
+	if !t.f(r) {
+		return true
+	}
+	t.check = t.is
+	t.t = t.tIn
+	t.tIn.Reset()
+	return false
+}
+
+// This implementation of Span doesn't help all too much, but it needs to be
+// there to satisfy this package's Transformer interface.
+// TODO: there are certainly room for improvements, though. For example, if
+// t.t == transform.Nop (which will a common occurrence) it will save a bundle
+// to special-case that loop.
+func (t *cond) Span(src []byte, atEOF bool) (n int, err error) {
+	p := 0
+	for n < len(src) && err == nil {
+		// Don't process too much at a time as the Spanner that will be
+		// called on this block may terminate early.
+		const maxChunk = 4096
+		max := len(src)
+		if v := n + maxChunk; v < max {
+			max = v
+		}
+		atEnd := false
+		size := 0
+		current := t.t
+		for ; p < max; p += size {
+			r := rune(src[p])
+			if r < utf8.RuneSelf {
+				size = 1
+			} else if r, size = utf8.DecodeRune(src[p:]); size == 1 {
+				if !atEOF && !utf8.FullRune(src[p:]) {
+					err = transform.ErrShortSrc
+					break
+				}
+			}
+			if !t.check(r) {
+				// The next rune will be the start of a new run.
+				atEnd = true
+				break
+			}
+		}
+		n2, err2 := current.Span(src[n:p], atEnd || (atEOF && p == len(src)))
+		n += n2
+		if err2 != nil {
+			return n, err2
+		}
+		// At this point either err != nil or t.check will pass for the rune at p.
+		p = n + size
+	}
+	return n, err
+}
+
+func (t *cond) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	p := 0
+	for nSrc < len(src) && err == nil {
+		// Don't process too much at a time, as the work might be wasted if the
+		// destination buffer isn't large enough to hold the result or a
+		// transform returns an error early.
+		const maxChunk = 4096
+		max := len(src)
+		if n := nSrc + maxChunk; n < len(src) {
+			max = n
+		}
+		atEnd := false
+		size := 0
+		current := t.t
+		for ; p < max; p += size {
+			r := rune(src[p])
+			if r < utf8.RuneSelf {
+				size = 1
+			} else if r, size = utf8.DecodeRune(src[p:]); size == 1 {
+				if !atEOF && !utf8.FullRune(src[p:]) {
+					err = transform.ErrShortSrc
+					break
+				}
+			}
+			if !t.check(r) {
+				// The next rune will be the start of a new run.
+				atEnd = true
+				break
+			}
+		}
+		nDst2, nSrc2, err2 := current.Transform(dst[nDst:], src[nSrc:p], atEnd || (atEOF && p == len(src)))
+		nDst += nDst2
+		nSrc += nSrc2
+		if err2 != nil {
+			return nDst, nSrc, err2
+		}
+		// At this point either err != nil or t.check will pass for the rune at p.
+		p = nSrc + size
+	}
+	return nDst, nSrc, err
+}

--- a/vendor/golang.org/x/text/runes/runes.go
+++ b/vendor/golang.org/x/text/runes/runes.go
@@ -1,0 +1,355 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package runes provide transforms for UTF-8 encoded text.
+package runes // import "golang.org/x/text/runes"
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/transform"
+)
+
+// A Set is a collection of runes.
+type Set interface {
+	// Contains returns true if r is contained in the set.
+	Contains(r rune) bool
+}
+
+type setFunc func(rune) bool
+
+func (s setFunc) Contains(r rune) bool {
+	return s(r)
+}
+
+// Note: using funcs here instead of wrapping types result in cleaner
+// documentation and a smaller API.
+
+// In creates a Set with a Contains method that returns true for all runes in
+// the given RangeTable.
+func In(rt *unicode.RangeTable) Set {
+	return setFunc(func(r rune) bool { return unicode.Is(rt, r) })
+}
+
+// NotIn creates a Set with a Contains method that returns true for all runes not
+// in the given RangeTable.
+func NotIn(rt *unicode.RangeTable) Set {
+	return setFunc(func(r rune) bool { return !unicode.Is(rt, r) })
+}
+
+// Predicate creates a Set with a Contains method that returns f(r).
+func Predicate(f func(rune) bool) Set {
+	return setFunc(f)
+}
+
+// Transformer implements the transform.Transformer interface.
+type Transformer struct {
+	t transform.SpanningTransformer
+}
+
+func (t Transformer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	return t.t.Transform(dst, src, atEOF)
+}
+
+func (t Transformer) Span(b []byte, atEOF bool) (n int, err error) {
+	return t.t.Span(b, atEOF)
+}
+
+func (t Transformer) Reset() { t.t.Reset() }
+
+// Bytes returns a new byte slice with the result of converting b using t.  It
+// calls Reset on t. It returns nil if any error was found. This can only happen
+// if an error-producing Transformer is passed to If.
+func (t Transformer) Bytes(b []byte) []byte {
+	b, _, err := transform.Bytes(t, b)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// String returns a string with the result of converting s using t. It calls
+// Reset on t. It returns the empty string if any error was found. This can only
+// happen if an error-producing Transformer is passed to If.
+func (t Transformer) String(s string) string {
+	s, _, err := transform.String(t, s)
+	if err != nil {
+		return ""
+	}
+	return s
+}
+
+// TODO:
+// - Copy: copying strings and bytes in whole-rune units.
+// - Validation (maybe)
+// - Well-formed-ness (maybe)
+
+const runeErrorString = string(utf8.RuneError)
+
+// Remove returns a Transformer that removes runes r for which s.Contains(r).
+// Illegal input bytes are replaced by RuneError before being passed to f.
+func Remove(s Set) Transformer {
+	if f, ok := s.(setFunc); ok {
+		// This little trick cuts the running time of BenchmarkRemove for sets
+		// created by Predicate roughly in half.
+		// TODO: special-case RangeTables as well.
+		return Transformer{remove(f)}
+	}
+	return Transformer{remove(s.Contains)}
+}
+
+// TODO: remove transform.RemoveFunc.
+
+type remove func(r rune) bool
+
+func (remove) Reset() {}
+
+// Span implements transform.Spanner.
+func (t remove) Span(src []byte, atEOF bool) (n int, err error) {
+	for r, size := rune(0), 0; n < len(src); {
+		if r = rune(src[n]); r < utf8.RuneSelf {
+			size = 1
+		} else if r, size = utf8.DecodeRune(src[n:]); size == 1 {
+			// Invalid rune.
+			if !atEOF && !utf8.FullRune(src[n:]) {
+				err = transform.ErrShortSrc
+			} else {
+				err = transform.ErrEndOfSpan
+			}
+			break
+		}
+		if t(r) {
+			err = transform.ErrEndOfSpan
+			break
+		}
+		n += size
+	}
+	return
+}
+
+// Transform implements transform.Transformer.
+func (t remove) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	for r, size := rune(0), 0; nSrc < len(src); {
+		if r = rune(src[nSrc]); r < utf8.RuneSelf {
+			size = 1
+		} else if r, size = utf8.DecodeRune(src[nSrc:]); size == 1 {
+			// Invalid rune.
+			if !atEOF && !utf8.FullRune(src[nSrc:]) {
+				err = transform.ErrShortSrc
+				break
+			}
+			// We replace illegal bytes with RuneError. Not doing so might
+			// otherwise turn a sequence of invalid UTF-8 into valid UTF-8.
+			// The resulting byte sequence may subsequently contain runes
+			// for which t(r) is true that were passed unnoticed.
+			if !t(utf8.RuneError) {
+				if nDst+3 > len(dst) {
+					err = transform.ErrShortDst
+					break
+				}
+				dst[nDst+0] = runeErrorString[0]
+				dst[nDst+1] = runeErrorString[1]
+				dst[nDst+2] = runeErrorString[2]
+				nDst += 3
+			}
+			nSrc++
+			continue
+		}
+		if t(r) {
+			nSrc += size
+			continue
+		}
+		if nDst+size > len(dst) {
+			err = transform.ErrShortDst
+			break
+		}
+		for i := 0; i < size; i++ {
+			dst[nDst] = src[nSrc]
+			nDst++
+			nSrc++
+		}
+	}
+	return
+}
+
+// Map returns a Transformer that maps the runes in the input using the given
+// mapping. Illegal bytes in the input are converted to utf8.RuneError before
+// being passed to the mapping func.
+func Map(mapping func(rune) rune) Transformer {
+	return Transformer{mapper(mapping)}
+}
+
+type mapper func(rune) rune
+
+func (mapper) Reset() {}
+
+// Span implements transform.Spanner.
+func (t mapper) Span(src []byte, atEOF bool) (n int, err error) {
+	for r, size := rune(0), 0; n < len(src); n += size {
+		if r = rune(src[n]); r < utf8.RuneSelf {
+			size = 1
+		} else if r, size = utf8.DecodeRune(src[n:]); size == 1 {
+			// Invalid rune.
+			if !atEOF && !utf8.FullRune(src[n:]) {
+				err = transform.ErrShortSrc
+			} else {
+				err = transform.ErrEndOfSpan
+			}
+			break
+		}
+		if t(r) != r {
+			err = transform.ErrEndOfSpan
+			break
+		}
+	}
+	return n, err
+}
+
+// Transform implements transform.Transformer.
+func (t mapper) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	var replacement rune
+	var b [utf8.UTFMax]byte
+
+	for r, size := rune(0), 0; nSrc < len(src); {
+		if r = rune(src[nSrc]); r < utf8.RuneSelf {
+			if replacement = t(r); replacement < utf8.RuneSelf {
+				if nDst == len(dst) {
+					err = transform.ErrShortDst
+					break
+				}
+				dst[nDst] = byte(replacement)
+				nDst++
+				nSrc++
+				continue
+			}
+			size = 1
+		} else if r, size = utf8.DecodeRune(src[nSrc:]); size == 1 {
+			// Invalid rune.
+			if !atEOF && !utf8.FullRune(src[nSrc:]) {
+				err = transform.ErrShortSrc
+				break
+			}
+
+			if replacement = t(utf8.RuneError); replacement == utf8.RuneError {
+				if nDst+3 > len(dst) {
+					err = transform.ErrShortDst
+					break
+				}
+				dst[nDst+0] = runeErrorString[0]
+				dst[nDst+1] = runeErrorString[1]
+				dst[nDst+2] = runeErrorString[2]
+				nDst += 3
+				nSrc++
+				continue
+			}
+		} else if replacement = t(r); replacement == r {
+			if nDst+size > len(dst) {
+				err = transform.ErrShortDst
+				break
+			}
+			for i := 0; i < size; i++ {
+				dst[nDst] = src[nSrc]
+				nDst++
+				nSrc++
+			}
+			continue
+		}
+
+		n := utf8.EncodeRune(b[:], replacement)
+
+		if nDst+n > len(dst) {
+			err = transform.ErrShortDst
+			break
+		}
+		for i := 0; i < n; i++ {
+			dst[nDst] = b[i]
+			nDst++
+		}
+		nSrc += size
+	}
+	return
+}
+
+// ReplaceIllFormed returns a transformer that replaces all input bytes that are
+// not part of a well-formed UTF-8 code sequence with utf8.RuneError.
+func ReplaceIllFormed() Transformer {
+	return Transformer{&replaceIllFormed{}}
+}
+
+type replaceIllFormed struct{ transform.NopResetter }
+
+func (t replaceIllFormed) Span(src []byte, atEOF bool) (n int, err error) {
+	for n < len(src) {
+		// ASCII fast path.
+		if src[n] < utf8.RuneSelf {
+			n++
+			continue
+		}
+
+		r, size := utf8.DecodeRune(src[n:])
+
+		// Look for a valid non-ASCII rune.
+		if r != utf8.RuneError || size != 1 {
+			n += size
+			continue
+		}
+
+		// Look for short source data.
+		if !atEOF && !utf8.FullRune(src[n:]) {
+			err = transform.ErrShortSrc
+			break
+		}
+
+		// We have an invalid rune.
+		err = transform.ErrEndOfSpan
+		break
+	}
+	return n, err
+}
+
+func (t replaceIllFormed) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	for nSrc < len(src) {
+		// ASCII fast path.
+		if r := src[nSrc]; r < utf8.RuneSelf {
+			if nDst == len(dst) {
+				err = transform.ErrShortDst
+				break
+			}
+			dst[nDst] = r
+			nDst++
+			nSrc++
+			continue
+		}
+
+		// Look for a valid non-ASCII rune.
+		if _, size := utf8.DecodeRune(src[nSrc:]); size != 1 {
+			if size != copy(dst[nDst:], src[nSrc:nSrc+size]) {
+				err = transform.ErrShortDst
+				break
+			}
+			nDst += size
+			nSrc += size
+			continue
+		}
+
+		// Look for short source data.
+		if !atEOF && !utf8.FullRune(src[nSrc:]) {
+			err = transform.ErrShortSrc
+			break
+		}
+
+		// We have an invalid rune.
+		if nDst+3 > len(dst) {
+			err = transform.ErrShortDst
+			break
+		}
+		dst[nDst+0] = runeErrorString[0]
+		dst[nDst+1] = runeErrorString[1]
+		dst[nDst+2] = runeErrorString[2]
+		nDst += 3
+		nSrc++
+	}
+	return nDst, nSrc, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -315,6 +315,11 @@ github.com/safchain/ethtool
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus
+# github.com/spf13/afero v1.15.0
+## explicit; go 1.23.0
+github.com/spf13/afero
+github.com/spf13/afero/internal/common
+github.com/spf13/afero/mem
 # github.com/spf13/cobra v1.10.2
 ## explicit; go 1.15
 github.com/spf13/cobra
@@ -484,6 +489,7 @@ golang.org/x/text/internal/tag
 golang.org/x/text/language
 golang.org/x/text/message
 golang.org/x/text/message/catalog
+golang.org/x/text/runes
 golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
@@ -1347,6 +1353,15 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
+# sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260125163108-a19ec76a3c5d
+## explicit; go 1.24.0
+sigs.k8s.io/controller-runtime/tools/setup-envtest
+sigs.k8s.io/controller-runtime/tools/setup-envtest/env
+sigs.k8s.io/controller-runtime/tools/setup-envtest/remote
+sigs.k8s.io/controller-runtime/tools/setup-envtest/store
+sigs.k8s.io/controller-runtime/tools/setup-envtest/version
+sigs.k8s.io/controller-runtime/tools/setup-envtest/versions
+sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows
 # sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 ## explicit; go 1.23
 sigs.k8s.io/json

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/LICENSE
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/README.md
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/README.md
@@ -1,0 +1,119 @@
+# Envtest Binaries Manager
+
+This is a small tool that manages binaries for envtest. It can be used to
+download new binaries, list currently installed and available ones, and
+clean up versions.
+
+To use it, just go-install it with Golang 1.24+ (it's a separate, self-contained
+module):
+
+```shell
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+```
+
+If you are using Golang 1.23, use the `release-0.20` branch instead:
+
+```shell
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
+```
+
+For full documentation, run it with the `--help` flag, but here are some
+examples:
+
+```shell
+# download the latest envtest, and print out info about it
+setup-envtest use
+
+# download the latest 1.19 envtest, and print out the path
+setup-envtest use -p path 1.19.x!
+
+# switch to the most recent 1.21 envtest on disk
+source <(setup-envtest use -i -p env 1.21.x)
+
+# list all available local versions for darwin/amd64
+setup-envtest list -i --os darwin --arch amd64
+
+# remove all versions older than 1.16 from disk
+setup-envtest cleanup <1.16
+
+# use the value from $KUBEBUILDER_ASSETS if set, otherwise follow the normal
+# logic for 'use'
+setup-envtest --use-env
+
+# use the value from $KUBEBUILDER_ASSETS if set, otherwise use the latest
+# installed version
+setup-envtest use -i --use-env
+
+# sideload a pre-downloaded tarball as Kubernetes 1.16.2 into our store
+setup-envtest sideload 1.16.2 < downloaded-envtest.tar.gz
+
+# Per default envtest binaries are downloaded from:
+# https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/envtest-releases.yaml
+# To download from a custom index use the following:
+setup-envtest use --index https://custom.com/envtest-releases.yaml
+
+```
+
+## Where does it put all those binaries?
+
+By default, binaries are stored in a subdirectory of an OS-specific data
+directory, as per the OS's conventions.
+
+On Linux, this is `$XDG_DATA_HOME`; on Windows, `%LocalAppData`; and on
+OSX, `~/Library/Application Support`.
+
+There's an overall folder that holds all files, and inside that is
+a folder for each version/platform pair. The exact directory structure is
+not guaranteed, except that the leaf directory will contain the names
+expected by envtest. You should always use `setup-envtest fetch` or
+`setup-envtest switch` (generally with the `-p path` or `-p env` flags) to
+get the directory that you should use.
+
+## Why do I have to do that `source <(blah blah blah)` thing
+
+This is a normal binary, not a shell script, so we can't set the parent
+process's environment variables. If you use this by hand a lot and want
+to save the typing, you could put something like the following in your
+`~/.zshrc` (or similar for bash/fish/whatever, modified to those):
+
+```shell
+setup-envtest() {
+    if (($@[(Ie)use])); then
+        source <($GOPATH/bin/setup-envtest "$@" -p env)
+    else
+        $GOPATH/bin/setup-envtest "$@"
+    fi
+}
+```
+
+## What if I don't want to talk to the internet?
+
+There are a few options.
+
+First, you'll probably want to set the `-i/--installed` flag. If you want
+to avoid forgetting to set this flag, set the `ENVTEST_INSTALLED_ONLY`
+env variable, which will switch that flag on by default.
+
+Then, you have a few options for managing your binaries:
+
+- If you don't *really* want to manage with this tool, or you want to
+  respect the $KUBEBUILDER_ASSETS variable if it's set to something
+  outside the store, use the `use --use-env -i` command.
+
+  `--use-env` makes the command unconditionally use the value of
+  KUBEBUILDER_ASSETS as long as it contains the required binaries, and
+  `-i` indicates that we only ever want to work with installed binaries.
+
+  As noted about, you can use `ENVTEST_INSTALLED_ONLY=true` to switch `-i`
+  on by default, and you can use `ENVTEST_USE_ENV=true` to switch
+  `--use-env` on by default.
+
+- If you want to use this tool, but download your gziped tarballs
+  separately, you can use the `sideload` command. You'll need to use the
+  `-k/--version` flag to indicate which version you're sideloading.
+
+  After that, it'll be as if you'd installed the binaries with `use`.
+
+- If you want to talk to some internal source via HTTP, you can simply set `--index`
+  The index must contain references to envtest binary archives in the same format as:
+  https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/envtest-releases.yaml

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/env/env.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/env/env.go
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package env
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/afero" // too bad fs.FS isn't writable :-/
+
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/remote"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/store"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+)
+
+// Env represents an environment for downloading and otherwise manipulating
+// envtest binaries.
+//
+// In general, the methods will use the Exit{,Cause} functions from this package
+// to indicate errors. Catch them with a `defer HandleExitWithCode()`.
+type Env struct {
+	// the following *must* be set on input
+
+	// Platform is our current platform
+	Platform versions.PlatformItem
+
+	// VerifySum indicates whether we should run checksums.
+	VerifySum bool
+	// NoDownload forces us to not contact remote services,
+	// looking only at local files instead.
+	NoDownload bool
+	// ForceDownload forces us to ignore local files and always
+	// contact remote services & re-download.
+	ForceDownload bool
+
+	// Client is our remote client for contacting remote services.
+	Client remote.Client
+
+	// Log allows us to log.
+	Log logr.Logger
+
+	// the following *may* be set on input, or may be discovered
+
+	// Version is the version(s) that we want to download
+	// (may be automatically retrieved later on).
+	Version versions.Spec
+
+	// Store is used to load/store entries to/from disk.
+	Store *store.Store
+
+	// FS is the file system to read from/write to for provisioning temp files
+	// for storing the archives temporarily.
+	FS afero.Afero
+
+	// Out is the place to write output text to
+	Out io.Writer
+
+	// manualPath is the manually discovered path from PathMatches, if
+	// a non-store path was used.  It'll be printed by PrintInfo if present.
+	manualPath string
+}
+
+// CheckCoherence checks that this environment has filled-out, coherent settings
+// (e.g. NoDownload & ForceDownload aren't both set).
+func (e *Env) CheckCoherence() {
+	if e.NoDownload && e.ForceDownload {
+		Exit(2, "cannot both skip downloading *and* force re-downloading")
+	}
+
+	if e.Platform.OS == "" || e.Platform.Arch == "" {
+		Exit(2, "must specify non-empty OS and arch (did you specify bad --os or --arch values?)")
+	}
+}
+
+func (e *Env) filter() store.Filter {
+	return store.Filter{Version: e.Version, Platform: e.Platform.Platform}
+}
+
+func (e *Env) item() store.Item {
+	concreteVer := e.Version.AsConcrete()
+	if concreteVer == nil || e.Platform.IsWildcard() {
+		panic("no platform/version set") // unexpected, print stack trace
+	}
+	return store.Item{Version: *concreteVer, Platform: e.Platform.Platform}
+}
+
+// ListVersions prints out all available versions matching this Env's
+// platform & version selector (respecting NoDownload to figure
+// out whether or not to match remote versions).
+func (e *Env) ListVersions(ctx context.Context) {
+	out := tabwriter.NewWriter(e.Out, 4, 4, 2, ' ', 0)
+	defer out.Flush()
+	localVersions, err := e.Store.List(ctx, e.filter())
+	if err != nil {
+		ExitCause(2, err, "unable to list installed versions")
+	}
+	for _, item := range localVersions {
+		// already filtered by onDiskVersions
+		fmt.Fprintf(out, "(installed)\tv%s\t%s\n", item.Version, item.Platform)
+	}
+
+	if e.NoDownload {
+		return
+	}
+
+	remoteVersions, err := e.Client.ListVersions(ctx)
+	if err != nil {
+		ExitCause(2, err, "unable list to available versions")
+	}
+
+	for _, set := range remoteVersions {
+		if !e.Version.Matches(set.Version) {
+			continue
+		}
+		sort.Slice(set.Platforms, func(i, j int) bool {
+			return orderPlatforms(set.Platforms[i].Platform, set.Platforms[j].Platform)
+		})
+		for _, plat := range set.Platforms {
+			if e.Platform.Matches(plat.Platform) {
+				fmt.Fprintf(out, "(available)\tv%s\t%s\n", set.Version, plat)
+			}
+		}
+	}
+}
+
+// LatestVersion returns the latest version matching our version selector and
+// platform from the remote server, with the corresponding checksum for later
+// use as well.
+func (e *Env) LatestVersion(ctx context.Context) (versions.Concrete, versions.PlatformItem) {
+	vers, err := e.Client.ListVersions(ctx)
+	if err != nil {
+		ExitCause(2, err, "unable to list versions to find latest one")
+	}
+	for _, set := range vers {
+		if !e.Version.Matches(set.Version) {
+			e.Log.V(1).Info("skipping non-matching version", "version", set.Version)
+			continue
+		}
+		// double-check that our platform is supported
+		for _, plat := range set.Platforms {
+			// NB(directxman12): we're already iterating in order, so no
+			// need to check if the wildcard is latest vs any
+			if e.Platform.Matches(plat.Platform) && e.Version.Matches(set.Version) {
+				return set.Version, plat
+			}
+		}
+		e.Log.Info("latest version not supported for your platform, checking older ones", "version", set.Version, "platform", e.Platform)
+	}
+
+	Exit(2, "unable to find a version that was supported for platform %s", e.Platform)
+	return versions.Concrete{}, versions.PlatformItem{} // unreachable, but Go's type system can't express the "never" type
+}
+
+// ExistsAndValid checks if our current (concrete) version & platform
+// exist on disk (unless ForceDownload is set, in which cause it always
+// returns false).
+//
+// Must be called after EnsureVersionIsSet so that we have a concrete
+// Version selected.  Must have a concrete platform, or ForceDownload
+// must be set.
+func (e *Env) ExistsAndValid() bool {
+	if e.ForceDownload {
+		// we always want to download, so don't check here
+		return false
+	}
+
+	if e.Platform.IsWildcard() {
+		Exit(2, "you must have a concrete platform with this command -- you cannot use wildcard platforms with fetch or switch")
+	}
+
+	exists, err := e.Store.Has(e.item())
+	if err != nil {
+		ExitCause(2, err, "unable to check if existing version exists")
+	}
+
+	if exists {
+		e.Log.Info("applicable version found on disk", "version", e.Version)
+	}
+	return exists
+}
+
+// EnsureVersionIsSet ensures that we have a non-wildcard version
+// configured.
+//
+// If necessary, it will enumerate on-disk and remote versions to accomplish
+// this, finding a version that matches our version selector and platform.
+// It will always yield a concrete version, it *may* yield a concrete platform
+// as well.
+func (e *Env) EnsureVersionIsSet(ctx context.Context) {
+	if e.Version.AsConcrete() != nil {
+		return
+	}
+	var localVer *versions.Concrete
+	var localPlat versions.Platform
+
+	items, err := e.Store.List(ctx, e.filter())
+	if err != nil {
+		ExitCause(2, err, "unable to determine installed versions")
+	}
+
+	for _, item := range items {
+		if !e.Version.Matches(item.Version) || !e.Platform.Matches(item.Platform) {
+			e.Log.V(1).Info("skipping version, doesn't match", "version", item.Version, "platform", item.Platform)
+			continue
+		}
+		// NB(directxman12): we're already iterating in order, so no
+		// need to check if the wildcard is latest vs any
+		ver := item.Version // copy to avoid referencing iteration variable
+		localVer = &ver
+		localPlat = item.Platform
+		break
+	}
+
+	if e.NoDownload || !e.Version.CheckLatest {
+		// no version specified, but we either
+		//
+		// a) shouldn't contact remote
+		// b) don't care to find the absolute latest
+		//
+		// so just find the latest local version
+		if localVer != nil {
+			e.Version.MakeConcrete(*localVer)
+			e.Platform.Platform = localPlat
+			return
+		}
+		if e.NoDownload {
+			Exit(2, "no applicable on-disk versions for %s found, you'll have to download one, or run list -i to see what you do have", e.Platform)
+		}
+		// if we didn't ask for the latest version, but don't have anything
+		// available, try the internet ;-)
+	}
+
+	// no version specified and we need the latest in some capacity, so find latest from remote
+	// so find the latest local first, then compare it to the latest remote, and use whichever
+	// of the two is more recent.
+	e.Log.Info("no version specified, finding latest")
+	serverVer, platform := e.LatestVersion(ctx)
+
+	// if we're not forcing a download, and we have a newer local version, just use that
+	if !e.ForceDownload && localVer != nil && localVer.NewerThan(serverVer) {
+		e.Platform.Platform = localPlat // update our data with hash
+		e.Version.MakeConcrete(*localVer)
+		return
+	}
+
+	// otherwise, use the new version from the server
+	e.Platform = platform // update our data with hash
+	e.Version.MakeConcrete(serverVer)
+}
+
+// Fetch ensures that the requested platform and version are on disk.
+// You must call EnsureVersionIsSet before calling this method.
+//
+// If ForceDownload is set, we always download, otherwise we only download
+// if we're missing the version on disk.
+func (e *Env) Fetch(ctx context.Context) {
+	log := e.Log.WithName("fetch")
+
+	// if we didn't just fetch it, grab the sum to verify
+	if e.VerifySum && e.Platform.Hash == nil {
+		if err := e.Client.FetchSum(ctx, *e.Version.AsConcrete(), &e.Platform); err != nil {
+			ExitCause(2, err, "unable to fetch hash for requested version")
+		}
+	}
+	if !e.VerifySum {
+		e.Platform.Hash = nil // skip verification
+	}
+
+	var packedPath string
+
+	// cleanup on error (needs to be here so it will happen after the other defers)
+	defer e.cleanupOnError(func() {
+		if packedPath != "" {
+			e.Log.V(1).Info("cleaning up downloaded archive", "path", packedPath)
+			if err := e.FS.Remove(packedPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				e.Log.Error(err, "unable to clean up archive path", "path", packedPath)
+			}
+		}
+	})
+
+	archiveOut, err := e.FS.TempFile("", "*-"+e.Platform.ArchiveName(*e.Version.AsConcrete()))
+	if err != nil {
+		ExitCause(2, err, "unable to open file to write downloaded archive to")
+	}
+	defer archiveOut.Close()
+	packedPath = archiveOut.Name()
+	log.V(1).Info("writing downloaded archive", "path", packedPath)
+
+	if err := e.Client.GetVersion(ctx, *e.Version.AsConcrete(), e.Platform, archiveOut); err != nil {
+		ExitCause(2, err, "unable to download requested version")
+	}
+	log.V(1).Info("downloaded archive", "path", packedPath)
+
+	if err := archiveOut.Sync(); err != nil { // sync before reading back
+		ExitCause(2, err, "unable to flush downloaded archive file")
+	}
+	if _, err := archiveOut.Seek(0, 0); err != nil {
+		ExitCause(2, err, "unable to jump back to beginning of archive file to unzip")
+	}
+
+	if err := e.Store.Add(ctx, e.item(), archiveOut); err != nil {
+		ExitCause(2, err, "unable to store version to disk")
+	}
+
+	log.V(1).Info("removing archive from disk", "path", packedPath)
+	if err := e.FS.Remove(packedPath); err != nil {
+		// don't bail, this isn't fatal
+		log.Error(err, "unable to remove downloaded archive", "path", packedPath)
+	}
+}
+
+// cleanup on error cleans up if we hit an exitCode error.
+//
+// Use it in a defer.
+func (e *Env) cleanupOnError(extraCleanup func()) {
+	cause := recover()
+	if cause == nil {
+		return
+	}
+	// don't panic in a panic handler
+	var exit *exitCode
+	if asExit(cause, &exit) && exit.code != 0 {
+		e.Log.Info("cleaning up due to error")
+		// we already log in the function, and don't want to panic, so
+		// ignore the error
+		extraCleanup()
+	}
+	panic(cause) // re-start the panic now that we're done
+}
+
+// Remove removes the data for our version selector & platform from disk.
+func (e *Env) Remove(ctx context.Context) {
+	items, err := e.Store.Remove(ctx, e.filter())
+	for _, item := range items {
+		fmt.Fprintf(e.Out, "removed %s\n", item)
+	}
+	if err != nil {
+		ExitCause(2, err, "unable to remove all requested version(s)")
+	}
+}
+
+// PrintInfo prints out information about a single, current version
+// and platform, according to the given formatting info.
+func (e *Env) PrintInfo(printFmt PrintFormat) {
+	// use the manual path if it's set, otherwise use the standard path
+	path := e.manualPath
+	if e.manualPath == "" {
+		item := e.item()
+		var err error
+		path, err = e.Store.Path(item)
+		if err != nil {
+			ExitCause(2, err, "unable to get path for version %s", item)
+		}
+	}
+	switch printFmt {
+	case PrintOverview:
+		fmt.Fprintf(e.Out, "Version: %s\n", e.Version)
+		fmt.Fprintf(e.Out, "OS/Arch: %s\n", e.Platform)
+		if e.Platform.Hash != nil {
+			fmt.Fprintf(e.Out, "%s: %s\n", e.Platform.Hash.Type, e.Platform.Hash.Value)
+		}
+		fmt.Fprintf(e.Out, "Path: %s\n", path)
+	case PrintPath:
+		fmt.Fprint(e.Out, path) // NB(directxman12): no newline -- want the bare path here
+	case PrintEnv:
+		// quote in case there are spaces, etc in the path
+		// the weird string below works like this:
+		// - you can't escape quotes in shell
+		// - shell strings that are next to each other are concatenated (so "a""b""c" == "abc")
+		// - you can intermix quote styles using the above
+		// - so `'"'"'` --> CLOSE_QUOTE + "'" + OPEN_QUOTE
+		shellQuoted := strings.ReplaceAll(path, "'", `'"'"'`)
+		fmt.Fprintf(e.Out, "export KUBEBUILDER_ASSETS='%s'\n", shellQuoted)
+	default:
+		panic(fmt.Sprintf("unexpected print format %v", printFmt))
+	}
+}
+
+// EnsureBaseDirs ensures that the base packed and unpacked directories
+// exist.
+//
+// This should be the first thing called after CheckCoherence.
+func (e *Env) EnsureBaseDirs(ctx context.Context) {
+	if err := e.Store.Initialize(ctx); err != nil {
+		ExitCause(2, err, "unable to make sure store is initialized")
+	}
+}
+
+// Sideload takes an input stream, and loads it as if it had been a downloaded .tar.gz file
+// for the current *concrete* version and platform.
+func (e *Env) Sideload(ctx context.Context, input io.Reader) {
+	log := e.Log.WithName("sideload")
+	if e.Version.AsConcrete() == nil || e.Platform.IsWildcard() {
+		Exit(2, "must specify a concrete version and platform to sideload.  Make sure you've passed a version, like 'sideload 1.21.0'")
+	}
+	log.V(1).Info("sideloading from input stream to version", "version", e.Version, "platform", e.Platform)
+	if err := e.Store.Add(ctx, e.item(), input); err != nil {
+		ExitCause(2, err, "unable to sideload item to disk")
+	}
+}
+
+var (
+	// expectedExecutables are the executables that are checked in PathMatches
+	// for non-store paths.
+	expectedExecutables = []string{
+		"kube-apiserver",
+		"etcd",
+		"kubectl",
+	}
+)
+
+// PathMatches checks if the path (e.g. from the environment variable)
+// matches this version & platform selector, and if so, returns true.
+func (e *Env) PathMatches(value string) bool {
+	e.Log.V(1).Info("checking if (env var) path represents our desired version", "path", value)
+	if value == "" {
+		// if we're unset,
+		return false
+	}
+
+	if e.versionFromPathName(value) {
+		e.Log.V(1).Info("path appears to be in our store, using that info", "path", value)
+		return true
+	}
+
+	e.Log.V(1).Info("path is not in our store, checking for binaries", "path", value)
+	for _, expected := range expectedExecutables {
+		_, err := e.FS.Stat(filepath.Join(value, expected))
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// one of our required binaries is missing, return false
+				e.Log.V(1).Info("missing required binary in (env var) path", "binary", expected, "path", value)
+				return false
+			}
+			ExitCause(2, err, "unable to check for existence of binary %s from existing (env var) path %s", value, expected)
+		}
+	}
+
+	// success, all binaries present
+	e.Log.V(1).Info("all required binaries present in (env var) path, using that", "path", value)
+
+	// don't bother checking the version, the user explicitly asked us to use this
+	// we don't know the version, so set it to wildcard
+	e.Version = versions.AnyVersion
+	e.Platform.OS = "*"
+	e.Platform.Arch = "*"
+	e.manualPath = value
+	return true
+}
+
+// versionFromPathName checks if the given path's last component looks like one
+// of our versions, and, if so, what version it represents.  If successful,
+// it'll set version and platform, and return true.  Otherwise it returns
+// false.
+func (e *Env) versionFromPathName(value string) bool {
+	baseName := filepath.Base(value)
+	ver, pl := versions.ExtractWithPlatform(versions.VersionPlatformRE, baseName)
+	if ver == nil {
+		// not a version that we can tell
+		return false
+	}
+
+	// yay we got a version!
+	e.Version.MakeConcrete(*ver)
+	e.Platform.Platform = pl
+	e.manualPath = value // might be outside our store, set this just in case
+
+	return true
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/env/exit.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/env/exit.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package env
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Exit exits with the given code and error message.
+//
+// Defer HandleExitWithCode in main to catch this and get the right behavior.
+func Exit(code int, msg string, args ...interface{}) {
+	panic(&exitCode{
+		code: code,
+		err:  fmt.Errorf(msg, args...),
+	})
+}
+
+// ExitCause exits with the given code and error message, automatically
+// wrapping the underlying error passed as well.
+//
+// Defer HandleExitWithCode in main to catch this and get the right behavior.
+func ExitCause(code int, err error, msg string, args ...interface{}) {
+	args = append(args, err)
+	panic(&exitCode{
+		code: code,
+		err:  fmt.Errorf(msg+": %w", args...),
+	})
+}
+
+// exitCode is an error that indicates, on a panic, to exit with the given code
+// and message.
+type exitCode struct {
+	code int
+	err  error
+}
+
+func (c *exitCode) Error() string {
+	return fmt.Sprintf("%v (exit code %d)", c.err, c.code)
+}
+func (c *exitCode) Unwrap() error {
+	return c.err
+}
+
+// asExit checks if the given (panic) value is an exitCode error,
+// and if so stores it in the given pointer.  It's roughly analogous
+// to errors.As, except it works on recover() values.
+func asExit(val interface{}, exit **exitCode) bool {
+	if val == nil {
+		return false
+	}
+	err, isErr := val.(error)
+	if !isErr {
+		return false
+	}
+	if !errors.As(err, exit) {
+		return false
+	}
+	return true
+}
+
+// HandleExitWithCode handles panics of type exitCode,
+// printing the status message and existing with the given
+// exit code, or re-raising if not an exitCode error.
+//
+// This should be the first defer in your main function.
+func HandleExitWithCode() {
+	if cause := recover(); CheckRecover(cause, func(code int, err error) {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(code)
+	}) {
+		panic(cause)
+	}
+}
+
+// CheckRecover checks the value of cause, calling the given callback
+// if it's an exitCode error.  It returns true if we should re-panic
+// the cause.
+//
+// It's mainly useful for testing, normally you'd use HandleExitWithCode.
+func CheckRecover(cause interface{}, cb func(int, error)) bool {
+	if cause == nil {
+		return false
+	}
+	var exitErr *exitCode
+	if !asExit(cause, &exitErr) {
+		// re-raise if it's not an exit error
+		return true
+	}
+
+	cb(exitErr.code, exitErr.err)
+	return false
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/env/helpers.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/env/helpers.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package env
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+)
+
+// orderPlatforms orders platforms by OS then arch.
+func orderPlatforms(first, second versions.Platform) bool {
+	// sort by OS, then arch
+	if first.OS != second.OS {
+		return first.OS < second.OS
+	}
+	return first.Arch < second.Arch
+}
+
+// PrintFormat indicates how to print out fetch and switch results.
+// It's a valid pflag.Value so it can be used as a flag directly.
+type PrintFormat int
+
+const (
+	// PrintOverview prints human-readable data,
+	// including path, version, arch, and checksum (when available).
+	PrintOverview PrintFormat = iota
+	// PrintPath prints *only* the path, with no decoration.
+	PrintPath
+	// PrintEnv prints the path with the corresponding env variable, so that
+	// you can source the output like
+	// `source $(fetch-envtest switch -p env 1.20.x)`.
+	PrintEnv
+)
+
+func (f PrintFormat) String() string {
+	switch f {
+	case PrintOverview:
+		return "overview"
+	case PrintPath:
+		return "path"
+	case PrintEnv:
+		return "env"
+	default:
+		panic(fmt.Sprintf("unexpected print format %d", int(f)))
+	}
+}
+
+// Set sets the value of this as a flag.
+func (f *PrintFormat) Set(val string) error {
+	switch val {
+	case "overview":
+		*f = PrintOverview
+	case "path":
+		*f = PrintPath
+	case "env":
+		*f = PrintEnv
+	default:
+		return fmt.Errorf("unknown print format %q, use one of overview|path|env", val)
+	}
+	return nil
+}
+
+// Type is the type of this value as a flag.
+func (PrintFormat) Type() string {
+	return "{overview|path|env}"
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/main.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/main.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package main
+
+import (
+	goflag "flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/spf13/afero"
+	flag "github.com/spf13/pflag"
+	"go.uber.org/zap"
+
+	envp "sigs.k8s.io/controller-runtime/tools/setup-envtest/env"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/remote"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/store"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows"
+)
+
+const (
+	// envNoDownload is an env variable that can be set to always force
+	// the --installed-only, -i flag to be set.
+	envNoDownload = "ENVTEST_INSTALLED_ONLY"
+	// envUseEnv is an env variable that can be set to control the --use-env
+	// flag globally.
+	envUseEnv = "ENVTEST_USE_ENV"
+)
+
+var (
+	force         = flag.Bool("force", false, "force re-downloading dependencies, even if they're already present and correct")
+	installedOnly = flag.BoolP("installed-only", "i", os.Getenv(envNoDownload) != "",
+		"only look at installed versions -- do not query the remote API server, "+
+			"and error out if it would be necessary to")
+	verify = flag.Bool("verify", true, "verify dependencies while downloading")
+	useEnv = flag.Bool("use-env", os.Getenv(envUseEnv) != "", "whether to return the value of KUBEBUILDER_ASSETS if it's already set")
+
+	targetOS   = flag.String("os", runtime.GOOS, "os to download for (e.g. linux, darwin, for listing operations, use '*' to list all platforms)")
+	targetArch = flag.String("arch", runtime.GOARCH, "architecture to download for (e.g. amd64, for listing operations, use '*' to list all platforms)")
+
+	// printFormat is the flag value for -p, --print.
+	printFormat = envp.PrintOverview
+	// zapLvl is the flag value for logging verbosity.
+	zapLvl = zap.WarnLevel
+
+	binDir = flag.String("bin-dir", "",
+		"directory to store binary assets (default: $OS_SPECIFIC_DATA_DIR/envtest-binaries)")
+
+	index = flag.String("index", remote.DefaultIndexURL, "index to discover envtest binaries")
+)
+
+// TODO(directxman12): handle interrupts?
+
+// setupLogging configures a Zap logger.
+func setupLogging() logr.Logger {
+	logCfg := zap.NewDevelopmentConfig()
+	logCfg.Level = zap.NewAtomicLevelAt(zapLvl)
+	zapLog, err := logCfg.Build()
+	if err != nil {
+		envp.ExitCause(1, err, "who logs the logger errors?")
+	}
+	return zapr.NewLogger(zapLog)
+}
+
+// setupEnv initializes the environment from flags.
+func setupEnv(globalLog logr.Logger, version string) *envp.Env {
+	log := globalLog.WithName("setup")
+	if *binDir == "" {
+		dataDir, err := store.DefaultStoreDir()
+		if err != nil {
+			envp.ExitCause(1, err, "unable to deterimine default binaries directory (use --bin-dir to manually override)")
+		}
+
+		*binDir = dataDir
+	}
+	log.V(1).Info("using binaries directory", "dir", *binDir)
+
+	client := &remote.HTTPClient{
+		Log:      globalLog.WithName("storage-client"),
+		IndexURL: *index,
+	}
+	log.V(1).Info("using HTTP client", "index", *index)
+
+	env := &envp.Env{
+		Log:           globalLog,
+		Client:        client,
+		VerifySum:     *verify,
+		ForceDownload: *force,
+		NoDownload:    *installedOnly,
+		Platform: versions.PlatformItem{
+			Platform: versions.Platform{
+				OS:   *targetOS,
+				Arch: *targetArch,
+			},
+		},
+		FS:    afero.Afero{Fs: afero.NewOsFs()},
+		Store: store.NewAt(*binDir),
+		Out:   os.Stdout,
+	}
+
+	switch version {
+	case "", "latest":
+		env.Version = versions.LatestVersion
+	case "latest-on-disk":
+		// we sort by version, latest first, so this'll give us the latest on
+		// disk (as per the contract from env.List & store.List)
+		env.Version = versions.AnyVersion
+		env.NoDownload = true
+	default:
+		var err error
+		env.Version, err = versions.FromExpr(version)
+		if err != nil {
+			envp.ExitCause(1, err, "version be a valid version, or simply 'latest' or 'latest-on-disk'")
+		}
+	}
+
+	env.CheckCoherence()
+
+	return env
+}
+
+func main() {
+	// exit with appropriate error codes -- this should be the first defer so
+	// that it's the last one executed.
+	defer envp.HandleExitWithCode()
+
+	// set up flags
+	flag.Usage = func() {
+		name := os.Args[0]
+		fmt.Fprintf(os.Stderr, "Usage: %s [FLAGS] use|list|cleanup|sideload [VERSION]\n", name)
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr,
+			`
+Note: this command is currently alpha, and the usage/behavior may change from release to release.
+
+Examples:
+
+	# download the latest envtest, and print out info about it
+	%[1]s use
+
+	# download the latest 1.19 envtest, and print out the path
+	%[1]s use -p path 1.19.x!
+
+	# switch to the most recent 1.21 envtest on disk
+	source <(%[1]s use -i -p env 1.21.x)
+
+	# list all available local versions for darwin/amd64
+	%[1]s list -i --os darwin --arch amd64
+
+	# remove all versions older than 1.16 from disk
+	%[1]s cleanup <1.16
+
+	# use the value from $KUBEBUILDER_ASSETS if set, otherwise follow the normal
+	# logic for 'use'
+	%[1]s --use-env
+
+	# use the value from $KUBEBUILDER_ASSETS if set, otherwise use the latest
+	# installed version
+	%[1]s use -i --use-env
+
+	# sideload a pre-downloaded tarball as Kubernetes 1.16.2 into our store
+	%[1]s sideload 1.16.2 < downloaded-envtest.tar.gz
+
+Commands:
+
+	use:
+		get information for the requested version, downloading it if necessary and allowed.
+		Needs a concrete platform (no wildcards), but wildcard versions are supported.
+
+	list:
+		list installed *and* available versions matching the given version & platform.
+		May have wildcard versions *and* platforms.
+		If the -i flag is passed, only installed versions are listed.
+
+	cleanup:
+		remove all versions matching the given version & platform selector.
+		May have wildcard versions *and* platforms.
+
+	sideload:
+		reads a .tar.gz file from stdin and expand it into the store.
+		must have a concrete version and platform.
+
+	version:
+		list the installed version of setup-envtest.
+
+Versions:
+
+	Versions take the form of a small subset of semver selectors.
+
+	Basic semver whole versions are accepted: X.Y.Z.
+	Z may also be '*' or 'x' to match a wildcard.
+	You may also just write X.Y, which means X.Y.*.
+
+	A version may be prefixed with '~' to match the most recent Z release
+	in the given Y release ( [X.Y.Z, X.Y+1.0) ).
+
+	Finally, you may suffix the version with '!' to force checking the
+	remote API server for the latest version.
+
+	For example:
+
+		1.16.x / 1.16.* / 1.16 # any 1.16 version
+		~1.19.3                # any 1.19 version that's at least 1.19.3
+		<1.17                  # any release 1.17.x or below
+		1.22.x!                # the latest one 1.22 release available remotely
+
+Output:
+
+	The fetch & switch commands respect the --print, -p flag.
+
+	overview: human readable information
+	path: print out the path, by itself
+	env: print out the path in a form that can be sourced to use that version with envtest
+
+	Other command have human-readable output formats only.
+
+Environment Variables:
+
+	KUBEBUILDER_ASSETS:
+		--use-env will check this, and '-p/--print env' will return this.
+		If --use-env is true and this is set, we won't check our store
+		for versions -- we'll just immediately return whatever's in
+		this env var.
+
+	%[2]s:
+		will switch the default of -i/--installed to true if set to any value
+
+	%[3]s:
+		will switch the default of --use-env to true if set to any value
+
+`, name, envNoDownload, envUseEnv)
+	}
+	flag.CommandLine.AddGoFlag(&goflag.Flag{Name: "v", Usage: "logging level", Value: &zapLvl})
+	flag.VarP(&printFormat, "print", "p", "what info to print after fetch-style commands (overview, path, env)")
+	needHelp := flag.Bool("help", false, "print out this help text") // register help so that we don't get an error at the end
+	flag.Parse()
+
+	if *needHelp {
+		flag.Usage()
+		envp.Exit(2, "")
+	}
+
+	// check our argument count
+	if numArgs := flag.NArg(); numArgs < 1 || numArgs > 2 {
+		flag.Usage()
+		envp.Exit(2, "please specify a command to use, and optionally a version selector")
+	}
+
+	// set up logging
+	globalLog := setupLogging()
+
+	// set up the environment
+	var version string
+	if flag.NArg() > 1 {
+		version = flag.Arg(1)
+	}
+	env := setupEnv(globalLog, version)
+	// perform our main set of actions
+	switch action := flag.Arg(0); action {
+	case "use":
+		workflows.Use{
+			UseEnv:      *useEnv,
+			PrintFormat: printFormat,
+			AssetsPath:  os.Getenv("KUBEBUILDER_ASSETS"),
+		}.Do(env)
+	case "list":
+		workflows.List{}.Do(env)
+	case "cleanup":
+		workflows.Cleanup{}.Do(env)
+	case "sideload":
+		workflows.Sideload{
+			Input:       os.Stdin,
+			PrintFormat: printFormat,
+		}.Do(env)
+	case "version":
+		workflows.Version{}.Do(env)
+	default:
+		flag.Usage()
+		envp.Exit(2, "unknown action %q", action)
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/remote/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/remote/client.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Kubernetes Authors
+
+package remote
+
+import (
+	"context"
+	"io"
+
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+)
+
+// Client is an interface to get and list envtest binary archives.
+type Client interface {
+	ListVersions(ctx context.Context) ([]versions.Set, error)
+
+	GetVersion(ctx context.Context, version versions.Concrete, platform versions.PlatformItem, out io.Writer) error
+
+	FetchSum(ctx context.Context, ver versions.Concrete, pl *versions.PlatformItem) error
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/remote/http_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/remote/http_client.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+	"sigs.k8s.io/yaml"
+)
+
+// DefaultIndexURL is the default index used in HTTPClient.
+var DefaultIndexURL = "https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml"
+
+var _ Client = &HTTPClient{}
+
+// HTTPClient is a client for fetching versions of the envtest binary archives
+// from an index via HTTP.
+type HTTPClient struct {
+	// Log allows us to log.
+	Log logr.Logger
+
+	// IndexURL is the URL of the index, defaults to DefaultIndexURL.
+	IndexURL string
+}
+
+// Index represents an index of envtest binary archives. Example:
+//
+//	releases:
+//		v1.28.0:
+//			envtest-v1.28.0-darwin-amd64.tar.gz:
+//	    		hash: <sha512-hash>
+//				selfLink: <url-to-archive-with-envtest-binaries>
+type Index struct {
+	// Releases maps Kubernetes versions to Releases (envtest archives).
+	Releases map[string]Release `json:"releases"`
+}
+
+// Release maps an archive name to an archive.
+type Release map[string]Archive
+
+// Archive contains the self link to an archive and its hash.
+type Archive struct {
+	Hash     string `json:"hash"`
+	SelfLink string `json:"selfLink"`
+}
+
+// ListVersions lists all available tools versions in the index, along
+// with supported os/arch combos and the corresponding hash.
+//
+// The results are sorted with newer versions first.
+func (c *HTTPClient) ListVersions(ctx context.Context) ([]versions.Set, error) {
+	index, err := c.getIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	knownVersions := map[versions.Concrete][]versions.PlatformItem{}
+	for _, releases := range index.Releases {
+		for archiveName, archive := range releases {
+			ver, details := versions.ExtractWithPlatform(versions.ArchiveRE, archiveName)
+			if ver == nil {
+				c.Log.V(1).Info("skipping archive -- does not appear to be a versioned tools archive", "name", archiveName)
+				continue
+			}
+			c.Log.V(1).Info("found version", "version", ver, "platform", details)
+			knownVersions[*ver] = append(knownVersions[*ver], versions.PlatformItem{
+				Platform: details,
+				Hash: &versions.Hash{
+					Type:     versions.SHA512HashType,
+					Encoding: versions.HexHashEncoding,
+					Value:    archive.Hash,
+				},
+			})
+		}
+	}
+
+	res := make([]versions.Set, 0, len(knownVersions))
+	for ver, details := range knownVersions {
+		res = append(res, versions.Set{Version: ver, Platforms: details})
+	}
+	// sort in inverse order so that the newest one is first
+	sort.Slice(res, func(i, j int) bool {
+		first, second := res[i].Version, res[j].Version
+		return first.NewerThan(second)
+	})
+
+	return res, nil
+}
+
+// GetVersion downloads the given concrete version for the given concrete platform, writing it to the out.
+func (c *HTTPClient) GetVersion(ctx context.Context, version versions.Concrete, platform versions.PlatformItem, out io.Writer) error {
+	index, err := c.getIndex(ctx)
+	if err != nil {
+		return err
+	}
+
+	var loc *url.URL
+	var name string
+	for _, releases := range index.Releases {
+		for archiveName, archive := range releases {
+			ver, details := versions.ExtractWithPlatform(versions.ArchiveRE, archiveName)
+			if ver == nil {
+				c.Log.V(1).Info("skipping archive -- does not appear to be a versioned tools archive", "name", archiveName)
+				continue
+			}
+
+			if *ver == version && details.OS == platform.OS && details.Arch == platform.Arch {
+				loc, err = url.Parse(archive.SelfLink)
+				if err != nil {
+					return fmt.Errorf("error parsing selfLink %q, %w", loc, err)
+				}
+				name = archiveName
+				break
+			}
+		}
+	}
+	if name == "" {
+		return fmt.Errorf("unable to find archive for %s (%s,%s)", version, platform.OS, platform.Arch)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", loc.String(), nil)
+	if err != nil {
+		return fmt.Errorf("unable to construct request to fetch %s: %w", name, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to fetch %s (%s): %w", name, req.URL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unable fetch %s (%s) -- got status %q", name, req.URL, resp.Status)
+	}
+
+	return readBody(resp, out, name, platform)
+}
+
+// FetchSum fetches the checksum for the given concrete version & platform into
+// the given platform item.
+func (c *HTTPClient) FetchSum(ctx context.Context, version versions.Concrete, platform *versions.PlatformItem) error {
+	index, err := c.getIndex(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, releases := range index.Releases {
+		for archiveName, archive := range releases {
+			ver, details := versions.ExtractWithPlatform(versions.ArchiveRE, archiveName)
+			if ver == nil {
+				c.Log.V(1).Info("skipping archive -- does not appear to be a versioned tools archive", "name", archiveName)
+				continue
+			}
+
+			if *ver == version && details.OS == platform.OS && details.Arch == platform.Arch {
+				platform.Hash = &versions.Hash{
+					Type:     versions.SHA512HashType,
+					Encoding: versions.HexHashEncoding,
+					Value:    archive.Hash,
+				}
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("unable to find archive for %s (%s,%s)", version, platform.OS, platform.Arch)
+}
+
+func (c *HTTPClient) getIndex(ctx context.Context) (*Index, error) {
+	indexURL := c.IndexURL
+	if indexURL == "" {
+		indexURL = DefaultIndexURL
+	}
+
+	loc, err := url.Parse(indexURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse index URL: %w", err)
+	}
+
+	c.Log.V(1).Info("listing versions", "index", indexURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", loc.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct request to get index: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to perform request to get index: %w", err)
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unable to get index -- got status %q", resp.Status)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get index -- unable to read body %w", err)
+	}
+
+	var index Index
+	if err := yaml.Unmarshal(responseBody, &index); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal index: %w", err)
+	}
+	return &index, nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/remote/read_body.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/remote/read_body.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Kubernetes Authors
+
+package remote
+
+import (
+	"crypto/md5"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+)
+
+func readBody(resp *http.Response, out io.Writer, archiveName string, platform versions.PlatformItem) error {
+	if platform.Hash != nil {
+		// stream in chunks to do the checksum, don't load the whole thing into
+		// memory to avoid causing issues with big files.
+		buf := make([]byte, 32*1024) // 32KiB, same as io.Copy
+		var hasher hash.Hash
+		switch platform.Hash.Type {
+		case versions.SHA512HashType:
+			hasher = sha512.New()
+		case versions.MD5HashType:
+			hasher = md5.New()
+		default:
+			return fmt.Errorf("hash type %s not implemented", platform.Hash.Type)
+		}
+		for cont := true; cont; {
+			amt, err := resp.Body.Read(buf)
+			if err != nil && !errors.Is(err, io.EOF) {
+				return fmt.Errorf("unable read next chunk of %s: %w", archiveName, err)
+			}
+			if amt > 0 {
+				// checksum never returns errors according to docs
+				hasher.Write(buf[:amt])
+				if _, err := out.Write(buf[:amt]); err != nil {
+					return fmt.Errorf("unable write next chunk of %s: %w", archiveName, err)
+				}
+			}
+			cont = amt > 0 && !errors.Is(err, io.EOF)
+		}
+
+		var sum string
+		switch platform.Hash.Encoding {
+		case versions.Base64HashEncoding:
+			sum = base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+		case versions.HexHashEncoding:
+			sum = hex.EncodeToString(hasher.Sum(nil))
+		default:
+			return fmt.Errorf("hash encoding %s not implemented", platform.Hash.Encoding)
+		}
+		if sum != platform.Hash.Value {
+			return fmt.Errorf("checksum mismatch for %s: %s (computed) != %s (reported)", archiveName, sum, platform.Hash.Value)
+		}
+	} else if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("unable to download %s: %w", archiveName, err)
+	}
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/store/helpers.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/store/helpers.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package store
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// DefaultStoreDir returns the default location for the store.
+// It's dependent on operating system:
+//
+// - Windows: %LocalAppData%\kubebuilder-envtest
+// - OSX: ~/Library/Application Support/io.kubebuilder.envtest
+// - Others: ${XDG_DATA_HOME:-~/.local/share}/kubebuilder-envtest
+//
+// Otherwise, it errors out.  Note that these paths must not be relied upon
+// manually.
+func DefaultStoreDir() (string, error) {
+	var baseDir string
+
+	// find the base data directory
+	switch runtime.GOOS {
+	case "windows":
+		baseDir = os.Getenv("LocalAppData")
+		if baseDir == "" {
+			return "", errors.New("%LocalAppData% is not defined")
+		}
+	case "darwin", "ios":
+		homeDir := os.Getenv("HOME")
+		if homeDir == "" {
+			return "", errors.New("$HOME is not defined")
+		}
+		baseDir = filepath.Join(homeDir, "Library/Application Support")
+	default:
+		baseDir = os.Getenv("XDG_DATA_HOME")
+		if baseDir == "" {
+			homeDir := os.Getenv("HOME")
+			if homeDir == "" {
+				return "", errors.New("neither $XDG_DATA_HOME nor $HOME are defined")
+			}
+			baseDir = filepath.Join(homeDir, ".local/share")
+		}
+	}
+
+	// append our program-specific dir to it (OSX has a slightly different
+	// convention so try to follow that).
+	switch runtime.GOOS {
+	case "darwin", "ios":
+		return filepath.Join(baseDir, "io.kubebuilder.envtest"), nil
+	default:
+		return filepath.Join(baseDir, "kubebuilder-envtest"), nil
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/store/store.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/store/store.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package store
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/afero"
+
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/versions"
+)
+
+// TODO(directxman12): error messages don't show full path, which is gonna make
+// things hard to debug
+
+// Item is a version-platform pair.
+type Item struct {
+	Version  versions.Concrete
+	Platform versions.Platform
+}
+
+// dirName returns the directory name in the store for this item.
+func (i Item) dirName() string {
+	return i.Platform.BaseName(i.Version)
+}
+func (i Item) String() string {
+	return fmt.Sprintf("%s (%s)", i.Version, i.Platform)
+}
+
+// Filter is a version spec & platform selector (i.e. platform
+// potentially with wildcards) to filter store items.
+type Filter struct {
+	Version  versions.Spec
+	Platform versions.Platform
+}
+
+// Matches checks if this filter matches the given item.
+func (f Filter) Matches(item Item) bool {
+	return f.Version.Matches(item.Version) && f.Platform.Matches(item.Platform)
+}
+
+// Store knows how to list, load, store, and delete envtest tools.
+type Store struct {
+	// Root is the root FS that the store stores in.  You'll probably
+	// want to use a BasePathFS to scope it down to a particular directory.
+	//
+	// Note that if for some reason there are nested BasePathFSes, and they're
+	// interrupted by a non-BasePathFS, Path won't work properly.
+	Root afero.Fs
+}
+
+// NewAt creates a new store on disk at the given path.
+func NewAt(path string) *Store {
+	return &Store{
+		Root: afero.NewBasePathFs(afero.NewOsFs(), path),
+	}
+}
+
+// Initialize ensures that the store is all set up on disk, etc.
+func (s *Store) Initialize(ctx context.Context) error {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.V(1).Info("ensuring base binaries dir exists")
+	if err := s.unpackedBase().MkdirAll("", 0755); err != nil {
+		return fmt.Errorf("unable to make sure base binaries dir exists: %w", err)
+	}
+	return nil
+}
+
+// Has checks if an item exists in the store.
+func (s *Store) Has(item Item) (bool, error) {
+	path := s.unpackedPath(item.dirName())
+	_, err := path.Stat("")
+	if err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return false, fmt.Errorf("unable to check if version-platform dir exists: %w", err)
+	}
+	return err == nil, nil
+}
+
+// List lists all items matching the given filter.
+//
+// Results are stored by version (newest first), and OS/arch (consistently,
+// but no guaranteed ordering).
+func (s *Store) List(ctx context.Context, matching Filter) ([]Item, error) {
+	var res []Item
+	if err := s.eachItem(ctx, matching, func(_ string, item Item) {
+		res = append(res, item)
+	}); err != nil {
+		return nil, fmt.Errorf("unable to list version-platform pairs in store: %w", err)
+	}
+
+	sort.Slice(res, func(i, j int) bool {
+		if !res[i].Version.Matches(res[j].Version) {
+			return res[i].Version.NewerThan(res[j].Version)
+		}
+		return orderPlatforms(res[i].Platform, res[j].Platform)
+	})
+
+	return res, nil
+}
+
+// Add adds this item to the store, with the given contents (a .tar.gz file).
+func (s *Store) Add(ctx context.Context, item Item, contents io.Reader) (resErr error) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	itemName := item.dirName()
+	log = log.WithValues("version-platform", itemName)
+	itemPath := s.unpackedPath(itemName)
+
+	// make sure to clean up if we hit an error
+	defer func() {
+		if resErr != nil {
+			// intentially ignore this because we can't really do anything
+			err := s.removeItem(itemPath)
+			if err != nil {
+				log.Error(err, "unable to clean up partially added version-platform pair after error")
+			}
+		}
+	}()
+
+	log.V(1).Info("ensuring version-platform binaries dir exists and is empty & writable")
+	_, err = itemPath.Stat("")
+	if err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return fmt.Errorf("unable to ensure version-platform binaries dir %s exists", itemName)
+	}
+	if err == nil { // exists
+		log.V(1).Info("cleaning up old version-platform binaries dir")
+		if err := s.removeItem(itemPath); err != nil {
+			return fmt.Errorf("unable to clean up existing version-platform binaries dir %s", itemName)
+		}
+	}
+	if err := itemPath.MkdirAll("", 0755); err != nil {
+		return fmt.Errorf("unable to make sure entry dir %s exists", itemName)
+	}
+
+	log.V(1).Info("extracting archive")
+	gzStream, err := gzip.NewReader(contents)
+	if err != nil {
+		return fmt.Errorf("unable to start un-gz-ing entry archive")
+	}
+	tarReader := tar.NewReader(gzStream)
+
+	var header *tar.Header
+	for header, err = tarReader.Next(); err == nil; header, err = tarReader.Next() {
+		if header.Typeflag != tar.TypeReg { // TODO(directxman12): support symlinks, etc?
+			log.V(1).Info("skipping non-regular-file entry in archive", "entry", header.Name)
+			continue
+		}
+		// just dump all files to the main path, ignoring the prefixed directory
+		// paths -- they're redundant.  We also ignore bits for the most part (except for X),
+		// preferfing our own scheme.
+		targetPath := filepath.Base(header.Name)
+		log.V(1).Info("writing archive file to disk", "archive file", header.Name, "on-disk file", targetPath)
+		perms := 0555 & header.Mode // make sure we're at most r+x
+		binOut, err := itemPath.OpenFile(targetPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(perms))
+		if err != nil {
+			return fmt.Errorf("unable to create file %s from archive to disk for version-platform pair %s", targetPath, itemName)
+		}
+		if err := func() error { // IIFE to get the defer properly in a loop
+			defer binOut.Close()
+			if _, err := io.Copy(binOut, tarReader); err != nil {
+				return fmt.Errorf("unable to write file %s from archive to disk for version-platform pair %s", targetPath, itemName)
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
+	}
+	if err != nil && !errors.Is(err, io.EOF) { //nolint:govet
+		return fmt.Errorf("unable to finish un-tar-ing the downloaded archive: %w", err)
+	}
+	log.V(1).Info("unpacked archive")
+
+	log.V(1).Info("switching version-platform directory to read-only")
+	if err := itemPath.Chmod("", 0555); err != nil {
+		// don't bail, this isn't fatal
+		log.Error(err, "unable to make version-platform directory read-only")
+	}
+	return nil
+}
+
+// Remove removes all items matching the given filter.
+//
+// It returns a list of the successfully removed items (even in the case
+// of an error).
+func (s *Store) Remove(ctx context.Context, matching Filter) ([]Item, error) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var removed []Item
+	var savedErr error
+	if err := s.eachItem(ctx, matching, func(name string, item Item) {
+		log.V(1).Info("Removing version-platform pair at path", "version-platform", item, "path", name)
+
+		if err := s.removeItem(s.unpackedPath(name)); err != nil {
+			log.Error(err, "unable to make existing version-platform dir writable to clean it up", "path", name)
+			savedErr = fmt.Errorf("unable to remove version-platform pair %s (dir %s): %w", item, name, err)
+			return // don't mark this as removed in the report
+		}
+		removed = append(removed, item)
+	}); err != nil {
+		return removed, fmt.Errorf("unable to list version-platform pairs to figure out what to delete: %w", err)
+	}
+	if savedErr != nil {
+		return removed, savedErr
+	}
+	return removed, nil
+}
+
+// Path returns an actual path that case be used to access this item.
+func (s *Store) Path(item Item) (string, error) {
+	path := s.unpackedPath(item.dirName())
+	// NB(directxman12): we need root's realpath because RealPath only
+	// looks at its own path, and so thus doesn't prepend the underlying
+	// root's base path.
+	//
+	// Technically, if we're fed something that's double wrapped as root,
+	// this'll be wrong, but this is basically as much as we can do
+	return afero.FullBaseFsPath(path.(*afero.BasePathFs), ""), nil
+}
+
+// unpackedBase returns the directory in which item dirs lives.
+func (s *Store) unpackedBase() afero.Fs {
+	return afero.NewBasePathFs(s.Root, "k8s")
+}
+
+// unpackedPath returns the item dir with this name.
+func (s *Store) unpackedPath(name string) afero.Fs {
+	return afero.NewBasePathFs(s.unpackedBase(), name)
+}
+
+// eachItem iterates through the on-disk versions that match our version & platform selector,
+// calling the callback for each.
+func (s *Store) eachItem(ctx context.Context, filter Filter, cb func(name string, item Item)) error {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	entries, err := afero.ReadDir(s.unpackedBase(), "")
+	if err != nil {
+		return fmt.Errorf("unable to list folders in store's unpacked directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			log.V(1).Info("skipping dir entry, not a folder", "entry", entry.Name())
+			continue
+		}
+		ver, pl := versions.ExtractWithPlatform(versions.VersionPlatformRE, entry.Name())
+		if ver == nil {
+			log.V(1).Info("skipping dir entry, not a version", "entry", entry.Name())
+			continue
+		}
+		item := Item{Version: *ver, Platform: pl}
+
+		if !filter.Matches(item) {
+			log.V(1).Info("skipping on disk version, does not match version and platform selectors", "platform", pl, "version", ver, "entry", entry.Name())
+			continue
+		}
+
+		cb(entry.Name(), item)
+	}
+
+	return nil
+}
+
+// removeItem removes the given item directory from disk.
+func (s *Store) removeItem(itemDir afero.Fs) error {
+	if err := itemDir.Chmod("", 0755); err != nil {
+		// no point in trying to remove if we can't fix the permissions, bail here
+		return fmt.Errorf("unable to make version-platform dir writable: %w", err)
+	}
+	if err := itemDir.RemoveAll(""); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return fmt.Errorf("unable to remove version-platform dir: %w", err)
+	}
+	return nil
+}
+
+// orderPlatforms orders platforms by OS then arch.
+func orderPlatforms(first, second versions.Platform) bool {
+	// sort by OS, then arch
+	if first.OS != second.OS {
+		return first.OS < second.OS
+	}
+	return first.Arch < second.Arch
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/version/version.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+import "runtime/debug"
+
+// Version to be set using ldflags:
+// -ldflags "-X sigs.k8s.io/controller-runtime/tools/setup-envtest/version.version=v1.0.0"
+// falls back to module information is unse
+var version = ""
+
+// Version returns the version of the main module
+func Version() string {
+	if version != "" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info == nil || info.Main.Version == "" {
+		// binary has not been built with module support or doesn't contain a version.
+		return "(unknown)"
+	}
+	return info.Main.Version
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/versions/parse.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/versions/parse.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package versions
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var (
+	// baseVersionRE is a semver-ish version -- either X.Y.Z, X.Y, or X.Y.{*|x}.
+	baseVersionRE = `(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(?:\.(?P<patch>0|[1-9]\d*|x|\*))?`
+	// versionExprRe matches valid version input for FromExpr.
+	versionExprRE = regexp.MustCompile(`^(?P<sel><|~|<=)?` + baseVersionRE + `(?P<latest>!)?$`)
+
+	// ConcreteVersionRE matches a concrete version anywhere in the string.
+	ConcreteVersionRE = regexp.MustCompile(`(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)`)
+)
+
+// FromExpr extracts a version from a string in the form of a semver version,
+// where X, Y, and Z may also be wildcards ('*', 'x'),
+// and pre-release names & numbers may also be wildcards.  The prerelease section is slightly
+// restricted to match what k8s does.
+// The whole string is a version selector as follows:
+//   - X.Y.Z matches version X.Y.Z where x, y, and z are
+//     are ints >= 0, and Z may be '*' or 'x'
+//   - X.Y is equivalent to X.Y.*
+//   - ~X.Y.Z means >= X.Y.Z && < X.Y+1.0
+//   - <X.Y.Z means older than the X.Y.Z (mainly useful for cleanup (similarly for <=)
+//   - an '!' at the end means force checking API server for the latest versions
+//     instead of settling for local matches.
+//
+// ^[^~]?SEMVER(!)??$ .
+func FromExpr(expr string) (Spec, error) {
+	match := versionExprRE.FindStringSubmatch(expr)
+	if match == nil {
+		return Spec{}, fmt.Errorf("unable to parse %q as a version string"+
+			"should be X.Y.Z, where Z may be '*','x', or left off entirely "+
+			"to denote a wildcard, optionally prefixed by ~|<|<=, and optionally"+
+			"followed by ! (latest remote version)", expr)
+	}
+	verInfo := PatchSelectorFromMatch(match, versionExprRE)
+	latest := match[versionExprRE.SubexpIndex("latest")] == "!"
+	sel := match[versionExprRE.SubexpIndex("sel")]
+	spec := Spec{
+		CheckLatest: latest,
+	}
+	if sel == "" {
+		spec.Selector = verInfo
+		return spec, nil
+	}
+
+	switch sel {
+	case "<", "<=":
+		spec.Selector = LessThanSelector{PatchSelector: verInfo, OrEquals: sel == "<="}
+	case "~":
+		// since patch & preNum are >= comparisons, if we use
+		// wildcards with a selector we can just set them to zero.
+		if verInfo.Patch == AnyPoint {
+			verInfo.Patch = PointVersion(0)
+		}
+		baseVer := *verInfo.AsConcrete()
+		spec.Selector = TildeSelector{Concrete: baseVer}
+	default:
+		panic("unreachable: mismatch between FromExpr and its RE in selector")
+	}
+
+	return spec, nil
+}
+
+// PointVersionFromValidString extracts a point version
+// from the corresponding string representation, which may
+// be a number >= 0, or x|* (AnyPoint).
+//
+// Anything else will cause a panic (use this on strings
+// extracted from regexes).
+func PointVersionFromValidString(str string) PointVersion {
+	switch str {
+	case "*", "x":
+		return AnyPoint
+	default:
+		ver, err := strconv.Atoi(str)
+		if err != nil {
+			panic(err)
+		}
+		return PointVersion(ver)
+	}
+}
+
+// PatchSelectorFromMatch constructs a simple selector according to the
+// ParseExpr rules out of pre-validated sections.
+//
+// re must include name captures for major, minor, patch, prenum, and prelabel
+//
+// Any bad input may cause a panic.  Use with when you got the parts from an RE match.
+func PatchSelectorFromMatch(match []string, re *regexp.Regexp) PatchSelector {
+	// already parsed via RE, should be fine to ignore errors unless it's a
+	// *huge* number
+	major, err := strconv.Atoi(match[re.SubexpIndex("major")])
+	if err != nil {
+		panic("invalid input passed as patch selector (invalid state)")
+	}
+	minor, err := strconv.Atoi(match[re.SubexpIndex("minor")])
+	if err != nil {
+		panic("invalid input passed as patch selector (invalid state)")
+	}
+
+	// patch is optional, means wildcard if left off
+	patch := AnyPoint
+	if patchRaw := match[re.SubexpIndex("patch")]; patchRaw != "" {
+		patch = PointVersionFromValidString(patchRaw)
+	}
+	return PatchSelector{
+		Major: major,
+		Minor: minor,
+		Patch: patch,
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/versions/platform.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/versions/platform.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package versions
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Platform contains OS & architecture information
+// Either may be '*' to indicate a wildcard match.
+type Platform struct {
+	OS   string
+	Arch string
+}
+
+// Matches indicates if this platform matches the other platform,
+// potentially with wildcard values.
+func (p Platform) Matches(other Platform) bool {
+	return (p.OS == other.OS || p.OS == "*" || other.OS == "*") &&
+		(p.Arch == other.Arch || p.Arch == "*" || other.Arch == "*")
+}
+
+// IsWildcard checks if either OS or Arch are set to wildcard values.
+func (p Platform) IsWildcard() bool {
+	return p.OS == "*" || p.Arch == "*"
+}
+func (p Platform) String() string {
+	return fmt.Sprintf("%s/%s", p.OS, p.Arch)
+}
+
+// BaseName returns the base directory name that fully identifies a given
+// version and platform.
+func (p Platform) BaseName(ver Concrete) string {
+	return fmt.Sprintf("%d.%d.%d-%s-%s", ver.Major, ver.Minor, ver.Patch, p.OS, p.Arch)
+}
+
+// ArchiveName returns the full archive name for this version and platform.
+func (p Platform) ArchiveName(ver Concrete) string {
+	return "envtest-v" + p.BaseName(ver) + ".tar.gz"
+}
+
+// PlatformItem represents a platform with corresponding
+// known metadata for its download.
+type PlatformItem struct {
+	Platform
+
+	*Hash
+}
+
+// Hash of an archive with envtest binaries.
+type Hash struct {
+	// Type of the hash.
+	// controller-tools uses SHA512HashType.
+	Type HashType
+
+	// Encoding of the hash value.
+	// controller-tools uses HexHashEncoding.
+	Encoding HashEncoding
+
+	// Value of the hash.
+	Value string
+}
+
+// HashType is the type of a hash.
+type HashType string
+
+const (
+	// SHA512HashType represents a sha512 hash
+	SHA512HashType HashType = "sha512"
+
+	// MD5HashType represents a md5 hash
+	MD5HashType HashType = "md5"
+)
+
+// HashEncoding is the encoding of a hash
+type HashEncoding string
+
+const (
+	// Base64HashEncoding represents base64 encoding
+	Base64HashEncoding HashEncoding = "base64"
+
+	// HexHashEncoding represents hex encoding
+	HexHashEncoding HashEncoding = "hex"
+)
+
+// Set is a concrete version and all the corresponding platforms that it's available for.
+type Set struct {
+	Version   Concrete
+	Platforms []PlatformItem
+}
+
+// ExtractWithPlatform produces a version & platform from the given regular expression
+// and string that should match it.  If no match is found, Version will be nil.
+//
+// The regular expression must have the following capture groups:
+// major, minor, patch, prelabel, prenum, os, arch, and must not support wildcard
+// versions.
+func ExtractWithPlatform(re *regexp.Regexp, name string) (*Concrete, Platform) {
+	match := re.FindStringSubmatch(name)
+	if match == nil {
+		return nil, Platform{}
+	}
+	verInfo := PatchSelectorFromMatch(match, re)
+	if verInfo.AsConcrete() == nil {
+		panic(fmt.Sprintf("%v", verInfo))
+	}
+	// safe to convert, we've ruled out wildcards in our RE
+	return verInfo.AsConcrete(), Platform{
+		OS:   match[re.SubexpIndex("os")],
+		Arch: match[re.SubexpIndex("arch")],
+	}
+}
+
+var (
+	versionPlatformREBase = ConcreteVersionRE.String() + `-(?P<os>\w+)-(?P<arch>\w+)`
+	// VersionPlatformRE matches concrete version-platform strings.
+	VersionPlatformRE = regexp.MustCompile(`^` + versionPlatformREBase + `$`)
+	// ArchiveRE matches concrete version-platform.tar.gz strings.
+	// The archives published to GitHub releases by controller-tools use the "envtest-v" prefix (e.g. "envtest-v1.30.0-darwin-amd64.tar.gz").
+	ArchiveRE = regexp.MustCompile(`^envtest-v` + versionPlatformREBase + `\.tar\.gz$`)
+)

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/versions/version.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/versions/version.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package versions
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// NB(directxman12): much of this is custom instead of using a library because
+// a) none of the standard libraries have hashable version types (for valid reasons,
+//    but we can use a restricted subset for our usecase)
+// b) everybody has their own definition of how selectors work anyway
+
+// NB(directxman12): pre-release support is... complicated with selectors
+// if we end up needing it, think carefully about what a wildcard prerelease
+// type means (does it include "not a prerelease"?), and what <=1.17.3-x.x means.
+
+// Concrete is a concrete Kubernetes-style semver version.
+type Concrete struct {
+	Major, Minor, Patch int
+}
+
+// AsConcrete returns this version.
+func (c Concrete) AsConcrete() *Concrete {
+	return &c
+}
+
+// NewerThan checks if the given other version is newer than this one.
+func (c Concrete) NewerThan(other Concrete) bool {
+	if c.Major != other.Major {
+		return c.Major > other.Major
+	}
+	if c.Minor != other.Minor {
+		return c.Minor > other.Minor
+	}
+	return c.Patch > other.Patch
+}
+
+// Matches checks if this version is equal to the other one.
+func (c Concrete) Matches(other Concrete) bool {
+	return c == other
+}
+
+func (c Concrete) String() string {
+	return fmt.Sprintf("%d.%d.%d", c.Major, c.Minor, c.Patch)
+}
+
+// PatchSelector selects a set of versions where the patch is a wildcard.
+type PatchSelector struct {
+	Major, Minor int
+	Patch        PointVersion
+}
+
+func (s PatchSelector) String() string {
+	return fmt.Sprintf("%d.%d.%s", s.Major, s.Minor, s.Patch)
+}
+
+// Matches checks if the given version matches this selector.
+func (s PatchSelector) Matches(ver Concrete) bool {
+	return s.Major == ver.Major && s.Minor == ver.Minor && s.Patch.Matches(ver.Patch)
+}
+
+// AsConcrete returns nil if there are wildcards in this selector,
+// and the concrete version that this selects otherwise.
+func (s PatchSelector) AsConcrete() *Concrete {
+	if s.Patch == AnyPoint {
+		return nil
+	}
+
+	return &Concrete{
+		Major: s.Major,
+		Minor: s.Minor,
+		Patch: int(s.Patch), // safe to cast, we've just checked wildcards above
+	}
+}
+
+// TildeSelector selects [X.Y.Z, X.Y+1.0).
+type TildeSelector struct {
+	Concrete
+}
+
+// Matches checks if the given version matches this selector.
+func (s TildeSelector) Matches(ver Concrete) bool {
+	if s.Concrete.Matches(ver) {
+		// easy, "exact" match
+		return true
+	}
+	return ver.Major == s.Major && ver.Minor == s.Minor && ver.Patch >= s.Patch
+}
+func (s TildeSelector) String() string {
+	return "~" + s.Concrete.String()
+}
+
+// AsConcrete returns nil (this is never a concrete version).
+func (s TildeSelector) AsConcrete() *Concrete {
+	return nil
+}
+
+// LessThanSelector selects versions older than the given one
+// (mainly useful for cleaning up).
+type LessThanSelector struct {
+	PatchSelector
+	OrEquals bool
+}
+
+// Matches checks if the given version matches this selector.
+func (s LessThanSelector) Matches(ver Concrete) bool {
+	if s.Major != ver.Major {
+		return s.Major > ver.Major
+	}
+	if s.Minor != ver.Minor {
+		return s.Minor > ver.Minor
+	}
+	if !s.Patch.Matches(ver.Patch) {
+		// matches rules out a wildcard, so it's fine to compare as normal numbers
+		return int(s.Patch) > ver.Patch
+	}
+	return s.OrEquals
+}
+func (s LessThanSelector) String() string {
+	if s.OrEquals {
+		return "<=" + s.PatchSelector.String()
+	}
+	return "<" + s.PatchSelector.String()
+}
+
+// AsConcrete returns nil (this is never a concrete version).
+func (s LessThanSelector) AsConcrete() *Concrete {
+	return nil
+}
+
+// AnySelector matches any version at all.
+type AnySelector struct{}
+
+// Matches checks if the given version matches this selector.
+func (AnySelector) Matches(_ Concrete) bool { return true }
+
+// AsConcrete returns nil (this is never a concrete version).
+func (AnySelector) AsConcrete() *Concrete { return nil }
+func (AnySelector) String() string        { return "*" }
+
+// Selector selects some concrete version or range of versions.
+type Selector interface {
+	// AsConcrete tries to return this selector as a concrete version.
+	// If the selector would only match a single version, it'll return
+	// that, otherwise it'll return nil.
+	AsConcrete() *Concrete
+	// Matches checks if this selector matches the given concrete version.
+	Matches(ver Concrete) bool
+	String() string
+}
+
+// Spec matches some version or range of versions, and tells us how to deal with local and
+// remote when selecting a version.
+type Spec struct {
+	Selector
+
+	// CheckLatest tells us to check the remote server for the latest
+	// version that matches our selector, instead of just relying on
+	// matching local versions.
+	CheckLatest bool
+}
+
+// MakeConcrete replaces the contents of this spec with one that
+// matches the given concrete version (without checking latest
+// from the server).
+func (s *Spec) MakeConcrete(ver Concrete) {
+	s.Selector = ver
+	s.CheckLatest = false
+}
+
+// AsConcrete returns the underlying selector as a concrete version, if
+// possible.
+func (s Spec) AsConcrete() *Concrete {
+	return s.Selector.AsConcrete()
+}
+
+// Matches checks if the underlying selector matches the given version.
+func (s Spec) Matches(ver Concrete) bool {
+	return s.Selector.Matches(ver)
+}
+
+func (s Spec) String() string {
+	res := s.Selector.String()
+	if s.CheckLatest {
+		res += "!"
+	}
+	return res
+}
+
+// PointVersion represents a wildcard (patch) version
+// or concrete number.
+type PointVersion int
+
+const (
+	// AnyPoint matches any point version.
+	AnyPoint PointVersion = -1
+)
+
+// Matches checks if a point version is compatible
+// with a concrete point version.
+// Two point versions are compatible if they are
+// a) both concrete
+// b) one is a wildcard.
+func (p PointVersion) Matches(other int) bool {
+	switch p {
+	case AnyPoint:
+		return true
+	default:
+		return int(p) == other
+	}
+}
+func (p PointVersion) String() string {
+	switch p {
+	case AnyPoint:
+		return "*"
+	default:
+		return strconv.Itoa(int(p))
+	}
+}
+
+var (
+	// LatestVersion matches the most recent version on the remote server.
+	LatestVersion = Spec{
+		Selector:    AnySelector{},
+		CheckLatest: true,
+	}
+	// AnyVersion matches any local or remote version.
+	AnyVersion = Spec{
+		Selector: AnySelector{},
+	}
+)

--- a/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows/workflows.go
+++ b/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows/workflows.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 The Kubernetes Authors
+
+package workflows
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/go-logr/logr"
+
+	envp "sigs.k8s.io/controller-runtime/tools/setup-envtest/env"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/version"
+)
+
+// Use is a workflow that prints out information about stored
+// version-platform pairs, downloading them if necessary & requested.
+type Use struct {
+	UseEnv      bool
+	AssetsPath  string
+	PrintFormat envp.PrintFormat
+}
+
+// Do executes this workflow.
+func (f Use) Do(env *envp.Env) {
+	ctx := logr.NewContext(context.TODO(), env.Log.WithName("use"))
+	env.EnsureBaseDirs(ctx)
+	if f.UseEnv {
+		// the env var unconditionally
+		if env.PathMatches(f.AssetsPath) {
+			env.PrintInfo(f.PrintFormat)
+			return
+		}
+	}
+	env.EnsureVersionIsSet(ctx)
+	if env.ExistsAndValid() {
+		env.PrintInfo(f.PrintFormat)
+		return
+	}
+	if env.NoDownload {
+		envp.Exit(2, "no such version (%s) exists on disk for this architecture (%s) -- try running `list -i` to see what's on disk", env.Version, env.Platform)
+	}
+	env.Fetch(ctx)
+	env.PrintInfo(f.PrintFormat)
+}
+
+// List is a workflow that lists version-platform pairs in the store
+// and on the remote server that match the given filter.
+type List struct{}
+
+// Do executes this workflow.
+func (List) Do(env *envp.Env) {
+	ctx := logr.NewContext(context.TODO(), env.Log.WithName("list"))
+	env.EnsureBaseDirs(ctx)
+	env.ListVersions(ctx)
+}
+
+// Cleanup is a workflow that removes version-platform pairs from the store
+// that match the given filter.
+type Cleanup struct{}
+
+// Do executes this workflow.
+func (Cleanup) Do(env *envp.Env) {
+	ctx := logr.NewContext(context.TODO(), env.Log.WithName("cleanup"))
+
+	env.NoDownload = true
+	env.ForceDownload = false
+
+	env.EnsureBaseDirs(ctx)
+	env.Remove(ctx)
+}
+
+// Sideload is a workflow that adds or replaces a version-platform pair in the
+// store, using the given archive as the files.
+type Sideload struct {
+	Input       io.Reader
+	PrintFormat envp.PrintFormat
+}
+
+// Do executes this workflow.
+func (f Sideload) Do(env *envp.Env) {
+	ctx := logr.NewContext(context.TODO(), env.Log.WithName("sideload"))
+
+	env.EnsureBaseDirs(ctx)
+	env.NoDownload = true
+	env.Sideload(ctx, f.Input)
+	env.PrintInfo(f.PrintFormat)
+}
+
+// Version is the workflow that shows the current binary version
+// of setup-envtest.
+type Version struct{}
+
+// Do executes the workflow.
+func (v Version) Do(env *envp.Env) {
+	fmt.Fprintf(env.Out, "setup-envtest version: %s\n", version.Version())
+}


### PR DESCRIPTION
Add `tools/tools.go` with a blank import of `setup-envtest` so the tool is included in the vendor directory. Uses the `release-0.22` branch pseudo-version (`v0.0.0-20260125163108-a19ec76a3c5d`) which requires Go 1.24 (compatible with the project's Go 1.25). The only tagged semver release (`v0.24.0`) requires Go 1.26 and is not usable yet.

Replace the `go install`/binary invocation of `setup-envtest` in the Makefile with `go run`, removing the `envtest` target and `ENVTEST` variable. Since the tool is now vendored, `go run` picks it up directly without needing a separate install step.

Also includes the vendor drift CI check from #517: run `go mod tidy && go mod vendor` and assert with `git status --porcelain` that no tracked modifications or untracked entries remain under `vendor/`, `go.mod` or `go.sum`.