### PR TITLE
ci: fail vendor check when vendor/, go.mod or go.sum drift

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -181,7 +181,7 @@ jobs:
           go mod tidy
           go mod vendor
           if [ -n "$(git status --porcelain vendor go.mod go.sum)" ]; then
-            echo "vendor/, go.mod or go.sum is out of sync with 'go mod vendor':"
+            echo "vendor/, go.mod or go.sum is out of sync with 'go mod tidy && go mod vendor':"
             git status --porcelain vendor go.mod go.sum
             git diff -- vendor go.mod go.sum
             exit 1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -178,6 +178,7 @@ jobs:
 
       - name: Check clean vendors
         run: |
+          go mod tidy
           go mod vendor
           if [ -n "$(git status --porcelain vendor go.mod go.sum)" ]; then
             echo "vendor/, go.mod or go.sum is out of sync with 'go mod vendor':"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -177,7 +177,14 @@ jobs:
         run: make verify
 
       - name: Check clean vendors
-        run: go mod vendor
+        run: |
+          go mod vendor
+          if [ -n "$(git status --porcelain vendor go.mod go.sum)" ]; then
+            echo "vendor/, go.mod or go.sum is out of sync with 'go mod vendor':"
+            git status --porcelain vendor go.mod go.sum
+            git diff -- vendor go.mod go.sum
+            exit 1
+          fi
 
       - name: Verify generated bundle manifest
         run: |


### PR DESCRIPTION
The `Check clean vendors` step in `.github/workflows/pull_request.yml` ran `go mod vendor` and discarded the result. A pull request that left `vendor/`, `go.mod` or `go.sum` out of sync with the module graph would still pass this check.

This was not theoretical. PR #516 illustrates the exact failure mode: the contributor ran `go mod vendor` locally, updated `go.mod`/`go.sum`/`vendor/modules.txt`, but did not `git add` three newly created top-level directories under `vendor/`:

- `vendor/github.com/spf13/afero/`
- `vendor/golang.org/x/text/runes/`
- `vendor/sigs.k8s.io/controller-runtime/tools/`

The resulting tree builds against the module proxy but fails when consumed with `-mod=vendor`, which is what `make test` ends up doing via `go run sigs.k8s.io/controller-runtime/tools/setup-envtest`. CI on #516 has not yet executed (workflow is in `action_required` pending maintainer approval, so the breakage is latent rather than red.

## Change

Run `go mod vendor` and then assert with `git status --porcelain` that no tracked modifications and no untracked entries remain under `vendor/`, `go.mod` or `go.sum`. On failure, print the offending paths and the diff so the workflow log makes the cause obvious.

`git diff --exit-code` alone is insufficient: it ignores untracked files, which is precisely the failure mode we need to catch. The bundle verification step a few lines below uses `git diff --exit-code` because regenerating the bundle modifies tracked files only; vendor regeneration can also create new directories, so it needs the stricter check.

## Verification

Reproducer against PR #516's tree on a clean checkout:

```
$ gh pr checkout 516
$ go mod vendor
$ git status --porcelain vendor go.mod go.sum
?? vendor/github.com/spf13/afero/
?? vendor/golang.org/x/text/runes/
?? vendor/sigs.k8s.io/controller-runtime/tools/
```

With this PR's check inlined, the workflow would have exited 1 with the three offending paths printed.

## Test plan

- [ ] CI passes on this branch (no vendor drift on `main`).
- [ ] When PR #516 rebases on top of this change without `git add vendor/`, the verify job fails on the new check rather than silently passing.