### PR TITLE
Bake imagePullPolicy=IfNotPresent into bundle CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,13 +484,28 @@ patch-image-references: kustomize ## Update all image references with environmen
 # This means consecutive runs with different image values work
 # without needing to restore deployment.yaml from git first.
 #
-# Also reset any imagePullPolicy injection from a previous "make deploy"
-# so that deploy-openshift and bundle always start from clean defaults.
+# Also reset any imagePullPolicy injection from a previous "make
+# deploy" so we always start from a clean baseline before deciding
+# whether BPFMAN_IMAGE_PULL_POLICY needs to be honoured below.
 	$(SED) -i -e '/name: BPFMAN_IMG/{n;s|^\([[:space:]]*value:[[:space:]]*\).*|\1$(BPFMAN_IMG)|;}' \
 	       -e '/name: BPFMAN_AGENT_IMG/{n;s|^\([[:space:]]*value:[[:space:]]*\).*|\1$(BPFMAN_AGENT_IMG)|;}' \
-	       -e '/name: BPFMAN_IMAGE_PULL_POLICY/{n;s|^\([[:space:]]*value:[[:space:]]*\).*|\1""|;}' \
 	       -e '/imagePullPolicy/d' \
 	       config/bpfman-operator-deployment/deployment.yaml
+# When BPFMAN_IMAGE_PULL_POLICY is set, propagate it as the env var
+# value the operator reads when stamping out the daemon and agent,
+# and inject imagePullPolicy on the operator container so kubelet
+# honours it when pulling the operator image itself. When unset,
+# leave the env value empty and the imagePullPolicy off the manifest
+# entirely. This is what lets bundle-deploy bake IfNotPresent into
+# the bundle CSV without affecting non-kind paths.
+	@if [ -n "$(BPFMAN_IMAGE_PULL_POLICY)" ]; then \
+	    $(SED) -i -e '/name: BPFMAN_IMAGE_PULL_POLICY/{n;s|^\([[:space:]]*value:[[:space:]]*\).*|\1$(BPFMAN_IMAGE_PULL_POLICY)|;}' \
+	           -e '/^[[:space:]]*image:[[:space:]].*$$/a\          imagePullPolicy: $(BPFMAN_IMAGE_PULL_POLICY)' \
+	           config/bpfman-operator-deployment/deployment.yaml; \
+	else \
+	    $(SED) -i -e '/name: BPFMAN_IMAGE_PULL_POLICY/{n;s|^\([[:space:]]*value:[[:space:]]*\).*|\1""|;}' \
+	           config/bpfman-operator-deployment/deployment.yaml; \
+	fi
 
 ##@ Vanilla K8s Deployment
 
@@ -546,6 +561,7 @@ run-on-kind: kustomize setup-kind build-images load-images-kind install deploy #
 ##@ OLM Bundle Deployment
 
 .PHONY: bundle-deploy
+bundle-deploy: BPFMAN_IMAGE_PULL_POLICY := IfNotPresent
 bundle-deploy: operator-sdk build-images bundle bundle-build load-images-kind setup-kind-registry ## Deploy bpfman-operator via OLM bundle on the current cluster.
 	$(OPERATOR_SDK) olm install 2>/dev/null || true
 	kubectl delete catalogsource operatorhubio-catalog -n olm 2>/dev/null || true


### PR DESCRIPTION
`bundle-deploy` (the kind-specific OLM bundle deploy target) leaves operator pods in `ImagePullBackOff` when `IMAGE_TAG=latest` -- the local development default. The bundle CSV ships with no `imagePullPolicy`, kubelet's tag-based default for `:latest` is `Always`, and the kind-side-loaded image is bypassed in favour of a registry pull that fails.

This was introduced in #503 (commit c91c30fda969), which removed the hard-coded `imagePullPolicy: IfNotPresent` from the source manifests and re-injected it for `make deploy` only -- the equivalent injection for `bundle-deploy` was missed.

## Fix

Make `patch-image-references` honour `BPFMAN_IMAGE_PULL_POLICY` when set: inject `imagePullPolicy: <value>` on the operator container and write the same value into the `BPFMAN_IMAGE_PULL_POLICY` env entry the operator reads when stamping out the daemon and agent. When unset, behaviour is unchanged from `main`.

Drive the override from a target-specific variable on `bundle-deploy`:

```make
bundle-deploy: BPFMAN_IMAGE_PULL_POLICY := IfNotPresent
bundle-deploy: ... bundle ... <recipe>
```

The variable propagates through the prerequisite chain to `patch-image-references` and lands in `deployment.yaml` before `kustomize` and `operator-sdk generate bundle` consume it. The bundle CSV is built with the policy already embedded, so kubelet honours it the moment OLM creates the operator pod.

## Test plan

### Kind (`bundle-deploy`)

```sh
make destroy-kind        # if a previous cluster exists
make setup-kind
make setup-kind-registry

BPFMAN_IMG=quay.io/bpfman/bpfman:latest \
BPFMAN_AGENT_IMG=docker.io/library/bpfman-agent:latest \
BPFMAN_OPERATOR_IMG=docker.io/library/bpfman-operator:latest \
IMAGE_TAG_BASE=docker.io/library/bpfman-operator \
make bundle-deploy
```

The bpfman daemon image isn't built by this repo, so `BPFMAN_IMG` points at upstream public quay; kind nodes pull it on first scheduling. Operator and agent images are built locally with `docker.io/library/...:latest` tags and side-loaded into kind.

Result on `main` (pre-fix): operator pod sticks in `ImagePullBackOff`, CSV never reaches `Succeeded`.

Result with this PR: operator pod goes to `Running` in ~1 second, CSV reaches `Succeeded`, `bpfman-daemon` 3/3 Running. The Deployment carries `imagePullPolicy: IfNotPresent` baked into the bundle CSV by `patch-image-references`, and `BPFMAN_IMAGE_PULL_POLICY=IfNotPresent` on the operator container env so the daemon and agent inherit the same policy.

### OpenShift (`bundle-deploy-openshift`, OCP 4.21)

Override the image references to a registry your cluster can pull from:

```sh
KUBECONFIG=/path/to/auth/kubeconfig \
BPFMAN_IMG=quay.io/bpfman/bpfman:latest \
BPFMAN_AGENT_IMG=quay.io/amcdermo/bpfman-agent:latest \
BPFMAN_OPERATOR_IMG=quay.io/amcdermo/bpfman-operator:latest \
IMAGE_TAG_BASE=quay.io/amcdermo/bpfman-operator \
make bundle-deploy-openshift
```

Mixed registry deliberately: the bpfman daemon image is pulled from public quay (not built by this repo), while operator and agent images are built locally and pushed to a registry namespace the OCP cluster can reach.

Result: CSV reaches `Succeeded` in ~45 seconds. The bundle CSV ships with **no** `imagePullPolicy` (this PR does not set the override on `bundle-deploy-openshift`); the API server tag-defaults `Always` for `:latest`, kubelet pulls from the configured registry. `BPFMAN_IMAGE_PULL_POLICY` env on the Deployment is empty. `bpfman-daemon` 3/3 Running across all worker nodes.

Confirms `bundle-deploy-openshift` is unaffected by this change -- the target does not set `BPFMAN_IMAGE_PULL_POLICY`, so `patch-image-references` takes its default branch (strip `imagePullPolicy`, zero the env), exactly as on `main` before this commit.

### `make deploy` on kind

Verified by simulating `make deploy`'s manifest-mutation chain on both branches and diffing the result. On `main`, `patch-image-references` strips `imagePullPolicy` and zeros the env, then `deploy`'s recipe sets the env to `IfNotPresent` and injects `imagePullPolicy: IfNotPresent` on the container. On this PR, `patch-image-references` (with `BPFMAN_IMAGE_PULL_POLICY` unset, which is what `deploy` does) takes its else branch and behaves identically; `deploy`'s own recipe is unchanged. The resulting `deployment.yaml` is byte-identical between the two branches:

```sh
$ diff /tmp/deploy-main.yaml /tmp/deploy-postfix.yaml
$ # (no output -- identical)
```

### CI

`olm_bundle_test.yml` runs `bundle-run-on-kind` (which chains into `bundle-deploy`) with `IMAGE_TAG=int-test`. Before this change the API server tag-defaulted `IfNotPresent` for the non-`:latest` tag; after this change `imagePullPolicy: IfNotPresent` is set explicitly. Same end-state, identical kubelet behaviour. No integration-test assertions on `imagePullPolicy` exist under `test/`.

Fixes: c91c30fda969 ("Remove hard-coded imagePullPolicy from deployment manifests")