### PR TITLE
Mount bpffs into kind node via extraMounts

### DIFF
--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -6,3 +6,7 @@ containerdConfigPatches:
       config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
+    extraMounts:
+      - hostPath: /sys/fs/bpf
+        containerPath: /sys/fs/bpf
+        propagation: Bidirectional


### PR DESCRIPTION
Podman-based kind clusters do not propagate host sysfs mounts into the node container, so `/sys/fs/bpf` is not visible inside the node even when bpffs is mounted on the host. This causes the `mount-bpffs` init container to fail with "operation not permitted" because it cannot mount a new filesystem onto the isolated sysfs.

Add an `extraMounts` entry to bind-mount `/sys/fs/bpf` from the host into the kind node with bidirectional propagation. This is harmless on Docker (where the mount is already visible) and fixes the init container failure on Podman.

https://github.com/bpfman/bpfman-operator/pull/490 introduced a bpffs mount done by the agent itself however on machines with `podman` bpffs mount fails with `operation not permitted`:
```
$ oc -n bpfman logs bpfman-daemon-49n8w -c mount-bpffs
error: failed to mount bpffs at /sys/fs/bpf: mount syscall: operation not permitted
```