### PR TITLE
Makefile: tidy kind, operator-sdk, and opm fetch rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,12 @@ LISTER_GEN ?= go run k8s.io/code-generator/cmd/lister-gen
 CLIENT_GEN ?= go run k8s.io/code-generator/cmd/client-gen
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 KIND ?= $(LOCALBIN)/kind
+OPM ?= $(LOCALBIN)/opm
 
 ## Tool Versions
 OPERATOR_SDK_VERSION ?= v1.37.0
 KIND_VERSION ?= v0.31.0
+OPM_VERSION ?= v1.45.0
 GOLANGCI_LINT_VERSION = v2.12.2
 
 
@@ -175,23 +177,12 @@ $(KIND): | $(LOCALBIN)
 	  chmod +x $@.tmp && \
 	  mv $@.tmp $@
 
-
-.PHONY: opm
-OPM = ./bin/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.45.0/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
+OPM_DL_NAME=$(shell go env GOOS)-$(shell go env GOARCH)-opm
+OPM_DL_URL=https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OPM_DL_NAME)
+$(OPM): | $(LOCALBIN)
+	curl -fLo $@.tmp $(OPM_DL_URL) && \
+	  chmod +x $@.tmp && \
+	  mv $@.tmp $@
 
 ##@ Development
 
@@ -417,7 +408,7 @@ endif
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
+catalog-build: $(OPM) ## Build a catalog image.
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 # Push the catalog image.
 .PHONY: catalog-push

--- a/Makefile
+++ b/Makefile
@@ -163,14 +163,17 @@ GOLANGCI_LINT_VERSION = v2.12.2
 
 OPERATOR_SDK_DL_NAME=operator-sdk_$(shell go env GOOS)_$(shell go env GOARCH)
 OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/$(OPERATOR_SDK_DL_NAME)
-$(OPERATOR_SDK): $(LOCALBIN)
-	test -s $(LOCALBIN)/operator-sdk || { curl -LO ${OPERATOR_SDK_DL_URL} && chmod +x ${OPERATOR_SDK_DL_NAME} &&\
-	 mv ${OPERATOR_SDK_DL_NAME} $(LOCALBIN)/operator-sdk; }
+$(OPERATOR_SDK): | $(LOCALBIN)
+	curl -fLo $@.tmp $(OPERATOR_SDK_DL_URL) && \
+	  chmod +x $@.tmp && \
+	  mv $@.tmp $@
 
 KIND_DL_NAME=kind-$(shell go env GOOS)-$(shell go env GOARCH)
 KIND_DL_URL=https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/$(KIND_DL_NAME)
-$(KIND): $(LOCALBIN)
-	test -s $(LOCALBIN)/kind || { curl -Lo $(LOCALBIN)/kind $(KIND_DL_URL) && chmod +x $(LOCALBIN)/kind; }
+$(KIND): | $(LOCALBIN)
+	curl -fLo $@.tmp $(KIND_DL_URL) && \
+	  chmod +x $@.tmp && \
+	  mv $@.tmp $@
 
 
 .PHONY: opm

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ version: ## Display the current VERSION, IMAGE_TAG, and image paths being used
 ##@ Local Dependencies
 
 ## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
+LOCALBIN ?= bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
@@ -163,16 +163,12 @@ GOLANGCI_LINT_VERSION = v2.12.2
 
 OPERATOR_SDK_DL_NAME=operator-sdk_$(shell go env GOOS)_$(shell go env GOARCH)
 OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/$(OPERATOR_SDK_DL_NAME)
-.PHONY: operator-sdk
-operator-sdk: $(OPERATOR_SDK)
 $(OPERATOR_SDK): $(LOCALBIN)
 	test -s $(LOCALBIN)/operator-sdk || { curl -LO ${OPERATOR_SDK_DL_URL} && chmod +x ${OPERATOR_SDK_DL_NAME} &&\
 	 mv ${OPERATOR_SDK_DL_NAME} $(LOCALBIN)/operator-sdk; }
 
 KIND_DL_NAME=kind-$(shell go env GOOS)-$(shell go env GOARCH)
 KIND_DL_URL=https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/$(KIND_DL_NAME)
-.PHONY: kind
-kind: $(KIND) ## Download kind locally if necessary.
 $(KIND): $(LOCALBIN)
 	test -s $(LOCALBIN)/kind || { curl -Lo $(LOCALBIN)/kind $(KIND_DL_URL) && chmod +x $(LOCALBIN)/kind; }
 
@@ -286,7 +282,7 @@ lint: prereqs ## Run linter (golangci-lint).
 .PHONY: test
 test: fmt ## Run Unit tests.
 	@set -e ; \
-	KUBEBUILDER_ASSETS="$$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" ; \
+	KUBEBUILDER_ASSETS="$$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(abspath $(LOCALBIN)) -p path)" ; \
 	if [ -z "$$KUBEBUILDER_ASSETS" ]; then \
 		echo "setup-envtest produced an empty KUBEBUILDER_ASSETS path" >&2 ; \
 		exit 1 ; \
@@ -314,7 +310,7 @@ test-lifecycle-local: ## Run lifecycle tests against existing deployment.
 ## as part of a pull request.
 ## See https://github.com/operator-framework/operator-sdk/issues/6285.
 .PHONY: bundle
-bundle: operator-sdk generate manifests patch-image-references ## Generate bundle manifests and metadata, then validate generated files.
+bundle: $(OPERATOR_SDK) generate manifests patch-image-references ## Generate bundle manifests and metadata, then validate generated files.
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	# Dependency on security-profiles-operator removed (file renamed to dependencies.yaml.disabled)
 	# https://github.com/kubernetes-sigs/security-profiles-operator/issues/2699
@@ -390,7 +386,7 @@ push-images: ## Push bpfman-agent and bpfman-operator images.
 	$(OCI_BIN) push ${BPFMAN_AGENT_IMG}
 
 .PHONY: load-images-kind
-load-images-kind: kind ## Load bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
+load-images-kind: $(KIND) ## Load bpfman-agent, and bpfman-operator images into the running local kind devel cluster.
 	KIND=$(KIND) ./hack/kind-load-image.sh ${KIND_CLUSTER_NAME} ${BPFMAN_OPERATOR_IMG} ${BPFMAN_AGENT_IMG}
 
 .PHONY: bundle-build
@@ -477,11 +473,11 @@ patch-image-references: ## Update all image references with environment variable
 ##@ Vanilla K8s Deployment
 
 .PHONY: setup-kind
-setup-kind: kind ## Setup Kind cluster
+setup-kind: $(KIND) ## Setup Kind cluster
 	$(KIND) delete cluster --name ${KIND_CLUSTER_NAME} && $(KIND) create cluster --config hack/kind-config.yaml --name ${KIND_CLUSTER_NAME}
 
 .PHONY: setup-kind-registry
-setup-kind-registry: kind ## Start a local registry for KIND and connect it to the KIND network.
+setup-kind-registry: $(KIND) ## Start a local registry for KIND and connect it to the KIND network.
 	$(OCI_BIN) inspect $(KIND_REGISTRY_NAME) >/dev/null 2>&1 || \
 	  $(OCI_BIN) run -d --restart=always -p "$(KIND_REGISTRY_PORT):5000" --name $(KIND_REGISTRY_NAME) registry:2
 	$(OCI_BIN) network connect kind $(KIND_REGISTRY_NAME) 2>/dev/null || true
@@ -491,7 +487,7 @@ setup-kind-registry: kind ## Start a local registry for KIND and connect it to t
 	done
 
 .PHONY: destroy-kind
-destroy-kind: kind ## Destroy Kind cluster
+destroy-kind: $(KIND) ## Destroy Kind cluster
 	$(KIND) delete cluster --name ${KIND_CLUSTER_NAME}
 	$(OCI_BIN) rm -f $(KIND_REGISTRY_NAME) 2>/dev/null || true
 
@@ -529,7 +525,7 @@ run-on-kind: setup-kind build-images load-images-kind install deploy ## Kind Dep
 
 .PHONY: bundle-deploy
 bundle-deploy: BPFMAN_IMAGE_PULL_POLICY := IfNotPresent
-bundle-deploy: operator-sdk build-images bundle bundle-build load-images-kind setup-kind-registry ## Deploy bpfman-operator via OLM bundle on the current cluster.
+bundle-deploy: $(OPERATOR_SDK) build-images bundle bundle-build load-images-kind setup-kind-registry ## Deploy bpfman-operator via OLM bundle on the current cluster.
 	$(OPERATOR_SDK) olm install 2>/dev/null || true
 	kubectl delete catalogsource operatorhubio-catalog -n olm 2>/dev/null || true
 	kubectl create namespace bpfman 2>/dev/null || true
@@ -541,12 +537,12 @@ bundle-deploy: operator-sdk build-images bundle bundle-build load-images-kind se
 bundle-run-on-kind: setup-kind bundle-deploy ## Create a KIND cluster and deploy bpfman-operator via OLM bundle.
 
 .PHONY: bundle-deploy-openshift
-bundle-deploy-openshift: operator-sdk build-images push-images bundle bundle-build bundle-push ## Deploy bpfman-operator via OLM bundle on OpenShift.
+bundle-deploy-openshift: $(OPERATOR_SDK) build-images push-images bundle bundle-build bundle-push ## Deploy bpfman-operator via OLM bundle on OpenShift.
 	kubectl create namespace bpfman 2>/dev/null || true
 	$(OPERATOR_SDK) run bundle $(BUNDLE_IMG) -n bpfman --timeout 5m
 
 .PHONY: bundle-undeploy
-bundle-undeploy: operator-sdk ## Remove the OLM bundle deployment.
+bundle-undeploy: $(OPERATOR_SDK) ## Remove the OLM bundle deployment.
 	$(OPERATOR_SDK) cleanup bpfman-operator -n bpfman
 
 ##@ Openshift Deployment


### PR DESCRIPTION
While working on #528 I noticed three things in the Makefile's tool-fetching rules that compounded each other. `LOCALBIN ?= $(shell pwd)/bin` made `$(KIND)` and `$(OPERATOR_SDK)` reachable only by absolute path -- `make bin/kind` failed with "no rule for target", and the `.PHONY: kind` / `.PHONY: operator-sdk` aliases existed only to give those targets a typeable name. Regular prerequisites on `$(LOCALBIN)` meant Make considered the binaries stale whenever the directory's mtime moved; the `test -s` guards inside the recipes were the only thing stopping an actual redownload. And `curl -Lo` without `-f` writes HTTP error bodies straight to the output path, so a 404 leaves a non-empty file the next run treats as already installed.

First commit switches `LOCALBIN` to a relative path, drops the `.PHONY` aliases (their job is now done by typing the file target directly), and updates the dependents (`load-images-kind`, `setup-kind`, `setup-kind-registry`, `destroy-kind`, `bundle`, `bundle-deploy`, `bundle-deploy-openshift`, `bundle-undeploy`) to depend on `$(KIND)` / `$(OPERATOR_SDK)` instead of the dropped aliases. The one consumer that still needs an absolute path is `setup-envtest --bin-dir`, because its output becomes `KUBEBUILDER_ASSETS` for per-package test binaries whose cwd changes; that single call site is wrapped with `$(abspath $(LOCALBIN))`.

Second commit switches both download rules to an order-only prerequisite on `$(LOCALBIN)` (so directory mtime no longer triggers rebuilds) and reshapes the recipes around `curl -fLo $@.tmp` followed by `mv $@.tmp $@`. The `-f` makes curl exit non-zero on HTTP errors, the rename keeps the canonical `$@` path absent until the full chain succeeds, and the `test -s` guards become redundant.

Third commit applies the same pattern to the `opm` rule, which was the most tangled of the three: a `.PHONY: opm` target whose recipe body was wrapped in nested `ifeq` blocks, plus a mid-rule reassignment where `OPM = ./bin/opm` was overwritten inside the else branch with `OPM = $(shell which opm)` -- so `$(OPM)` silently became whatever version happened to be in `$PATH` if the local download was missing, pinning `v1.45.0` in the URL while accepting whatever opm the user had installed. The rule now matches `$(KIND)` and `$(OPERATOR_SDK)` exactly: an `$(OPM)` file target with order-only `$(LOCALBIN)` prereq, atomic download, and `OPM_VERSION` lifted to the Tool Versions block alongside `KIND_VERSION` and `OPERATOR_SDK_VERSION`. `catalog-build` depends on `$(OPM)` directly. The system-opm fallback is dropped: override `OPM` on the command line if you want to point at something specific.

## Test plan

- [x] `make help` no longer lists the bare `kind`, `operator-sdk`, or `opm` aliases
- [x] `make bin/kind`, `make bin/operator-sdk`, `make bin/opm` trigger their download recipes
- [ ] `make test` runs with `KUBEBUILDER_ASSETS` resolved as an absolute path
- [ ] `make setup-kind`, `make bundle-deploy`, `make catalog-build` etc. fire their tool prereqs