### PR TITLE
Revert "Reverse program unload order to respect map ownership"

### DIFF
--- a/controllers/bpfman-agent/cl_application_program.go
+++ b/controllers/bpfman-agent/cl_application_program.go
@@ -764,11 +764,7 @@ func (r *ClBpfApplicationReconciler) load(ctx context.Context) error {
 }
 
 func (r *ClBpfApplicationReconciler) unload(ctx context.Context) {
-	// Unload in reverse order because the first program is the map owner
-	// and subsequent programs may share its maps. Dependents must be
-	// unloaded before the map owner.
-	for i := len(r.currentAppState.Status.Programs) - 1; i >= 0; i-- {
-		program := r.currentAppState.Status.Programs[i]
+	for i, program := range r.currentAppState.Status.Programs {
 		if program.ProgramId != nil {
 			err := bpfmanagentinternal.UnloadBpfmanProgram(ctx, r.BpfmanClient, *program.ProgramId)
 			if err != nil {

--- a/controllers/bpfman-agent/ns_application_program.go
+++ b/controllers/bpfman-agent/ns_application_program.go
@@ -681,11 +681,7 @@ func (r *NsBpfApplicationReconciler) load(ctx context.Context) error {
 }
 
 func (r *NsBpfApplicationReconciler) unload(ctx context.Context) {
-	// Unload in reverse order because the first program is the map owner
-	// and subsequent programs may share its maps. Dependents must be
-	// unloaded before the map owner.
-	for i := len(r.currentAppState.Status.Programs) - 1; i >= 0; i-- {
-		program := r.currentAppState.Status.Programs[i]
+	for i, program := range r.currentAppState.Status.Programs {
 		if program.ProgramId != nil {
 			err := bpfmanagentinternal.UnloadBpfmanProgram(ctx, r.BpfmanClient, *program.ProgramId)
 			if err != nil {


### PR DESCRIPTION
PR #493 reversed the BpfApplication unload iteration so that dependent programs are unloaded before the map owner, in both the cluster-scoped and namespace-scoped reconcilers. This reverts that change and restores forward-order unload.

#493 was made with the go-bpfman backend in mind. At the time go-bpfman's semantics did not fully match upstream Rust-bpfman: a multi-program load designated the first program the map owner and treated the rest as sharers of its maps, those shared maps were tied to the owner's lifetime, and go-bpfman refused to unload an owner while any dependent remained. Given that behaviour the risk #493 described was real -- unloading the owner before its dependents could leave the shared maps inconsistent. What is clear only now is that changing the operator's unload order was the wrong remedy: the defect was go-bpfman diverging from bpfman's contract, not the operator's order. Upstream (Rust) bpfman never imposed this constraint -- it does not fabricate ownership and its shared map sets already outlive the creating program.

go-bpfman has since been brought back in line with that contract. A multi-program load no longer creates the ownership relationship: without an explicit map owner, programs share nothing and each owns its own maps. Where maps are genuinely shared, the shared map set now has a lifetime independent of the program that created it, so the owner may be unloaded before its dependents and the maps survive until the last user is gone. With go-bpfman matching bpfman, the ordering #493 enforced is no longer necessary, and the operator should unload in its natural order as it does for every other resource.

Refs: https://github.com/frobware/go-bpfman/pull/162.
