### PR TITLE
ci: prefer repo-local tools in make recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ version: ## Display the current VERSION, IMAGE_TAG, and image paths being used
 
 ## Location to install dependencies to
 LOCALBIN ?= bin
+export PATH := $(abspath $(LOCALBIN)):$(PATH)
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
@@ -286,11 +287,11 @@ test: fmt ## Run Unit tests.
 
 
 .PHONY: test-integration
-test-integration: patch-image-references ## Run Integration tests.
+test-integration: patch-image-references $(KIND) ## Run Integration tests.
 	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration/...
 
 .PHONY: test-integration-local
-test-integration-local: ## Run Integration tests against existing deployment. Use TEST= to specify test pattern.
+test-integration-local: $(KIND) ## Run Integration tests against existing deployment. Use TEST= to specify test pattern.
 	USE_EXISTING_KIND_CLUSTER=$(shell kubectl config current-context | sed 's/kind-//') \
 	SKIP_BPFMAN_DEPLOY=true \
 	GOFLAGS="-tags=integration_tests" go test -count=1 -race -v ./test/integration $(if $(TEST),-run $(TEST),)


### PR DESCRIPTION
Recent unrelated PRs started failing in the same way in the kind-backed integration suite, with attach and timeout errors (see #535 and #536). The trigger is the GitHub runner image: it bumped its preinstalled Kind from 0.31.0 to 0.32.0, and with it the default Kubernetes node from v1.35.0 to v1.36.1. The Makefile already pins `KIND_VERSION ?= v0.31.0` and downloads it to `bin/kind`, but nothing forced the recipes to use that copy: `bin` was not on PATH, and `test-integration` did not depend on `$(KIND)`, so the suite shelled out to whatever `kind` the runner happened to ship. The experimental commit on #535 (`b8d8090`) that forced the pinned binary turned its integration job green, which is the evidence this is the right fix; this change lands it generally so every PR benefits rather than each one carrying a local workaround.

The fix exports an absolute `bin` path at the front of PATH for every recipe, and makes both `test-integration` and `test-integration-local` depend on `$(KIND)` so the pinned binary is downloaded before the suite runs. The integration suite drives `kind` through Kong's testing framework, which execs the binary found on PATH; with these changes it resolves the repo-local, version-pinned `kind` rather than the image default. The path is absolute on purpose: a relative `bin` entry only resolves when a recipe happens to run from the repo root, and an absolute entry is also the safer choice when a command re-invokes itself under `sudo`. `test-integration-openshift` is deliberately left untouched, since it runs against an existing non-kind cluster and never invokes the binary.

## Test plan

Locally, `make -n test-integration` and `make -n test-integration-local` both now resolve `$(KIND)` as a prerequisite, so an absent `bin/kind` is fetched at the pinned `v0.31.0` before `go test` runs, and the exported PATH places that copy ahead of any system `kind`. The decisive check is this PR's own integration job on the bumped runner image: it should now create a v1.35.0 node and pass, matching the green result observed on #535.

Raised https://github.com/bpfman/bpfman-operator/issues/538 to cover the Kube bump issues.