### PR TITLE
Scope BpfApplicationState lookup to the application namespace

### DIFF
--- a/controllers/bpfman-agent/ns_application_program.go
+++ b/controllers/bpfman-agent/ns_application_program.go
@@ -477,6 +477,7 @@ func (r *NsBpfApplicationReconciler) getBpfAppState(ctx context.Context) (*bpfma
 	appProgramList := &bpfmaniov1alpha1.BpfApplicationStateList{}
 
 	opts := []client.ListOption{
+		client.InNamespace(r.currentApp.Namespace),
 		client.MatchingLabels{
 			internal.BpfAppStateOwner: r.currentApp.GetName(),
 			internal.K8sHostLabel:     r.NodeName,

--- a/controllers/bpfman-agent/ns_application_program_test.go
+++ b/controllers/bpfman-agent/ns_application_program_test.go
@@ -28,6 +28,7 @@ import (
 	testutils "github.com/bpfman/bpfman-operator/internal/test-utils"
 	"github.com/bpfman/bpfman-operator/pkg/helpers"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -72,6 +73,76 @@ func TestNsBpfApplicationReconcilerGetBpfAppState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "test-app-state", result.Name)
+}
+
+func TestNsBpfApplicationReconcilerGetBpfAppStateIgnoresOtherNamespaces(t *testing.T) {
+	otherNamespaceAppState := &bpfmaniov1alpha1.BpfApplicationState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app-state",
+			Namespace: "test1",
+			Labels: map[string]string{
+				internal.BpfAppStateOwner: "test-app",
+				internal.K8sHostLabel:     "test-node",
+			},
+		},
+	}
+	objs := []runtime.Object{otherNamespaceAppState}
+
+	bpfApp := &bpfmaniov1alpha1.BpfApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "test2",
+		},
+	}
+	fakeNode := testutils.NewNode("test-node")
+	r := createFakeNamespaceReconciler(objs, bpfApp, fakeNode, nil)
+	r.currentApp = bpfApp
+
+	result, err := r.getBpfAppState(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestNsBpfApplicationReconcilerGetBpfAppStateSelectsOwnNamespace(t *testing.T) {
+	// State objects for same-named applications on the same node are
+	// label-identical, so only the namespace can tell them apart.
+	ownAppState := &bpfmaniov1alpha1.BpfApplicationState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app-state-own",
+			Namespace: "test2",
+			Labels: map[string]string{
+				internal.BpfAppStateOwner: "test-app",
+				internal.K8sHostLabel:     "test-node",
+			},
+		},
+	}
+	otherNamespaceAppState := &bpfmaniov1alpha1.BpfApplicationState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app-state-other",
+			Namespace: "test1",
+			Labels: map[string]string{
+				internal.BpfAppStateOwner: "test-app",
+				internal.K8sHostLabel:     "test-node",
+			},
+		},
+	}
+	objs := []runtime.Object{ownAppState, otherNamespaceAppState}
+
+	bpfApp := &bpfmaniov1alpha1.BpfApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-app",
+			Namespace: "test2",
+		},
+	}
+	fakeNode := testutils.NewNode("test-node")
+	r := createFakeNamespaceReconciler(objs, bpfApp, fakeNode, nil)
+	r.currentApp = bpfApp
+
+	result, err := r.getBpfAppState(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "test-app-state-own", result.Name)
+	require.Equal(t, "test2", result.Namespace)
 }
 
 func TestNsBpfApplicationControllerCreate(t *testing.T) {
@@ -406,6 +477,133 @@ func TestNsBpfApplicationControllerCreate(t *testing.T) {
 		verifyBpfApplicationState(t, bpfAppState3, fakeNode, testAppProgramName, bpfmaniov1alpha1.BpfAppStateCondSuccess)
 		// Check that the bpfAppState was not updated.
 		require.True(t, reflect.DeepEqual(bpfAppState2, bpfAppState3))
+	}
+}
+
+// TestNsBpfApplicationControllerSameNameDifferentNamespaces checks that
+// two BpfApplications with the same name in different namespaces, with
+// different program lists, each get their own BpfApplicationState and
+// reconcile to Success independently.
+//
+// See https://redhat.atlassian.net/browse/BPFMAN-45.
+func TestNsBpfApplicationControllerSameNameDifferentNamespaces(t *testing.T) {
+	var (
+		fakePid           = int32(1000)
+		fakeNode          = testutils.NewNode("fake-control-plane")
+		interfaceSelector = bpfmaniov1alpha1.InterfaceSelector{
+			Interfaces: []string{fakeInt0},
+		}
+		fakeNetNamespaces = bpfmaniov1alpha1.NetworkNamespaceSelector{
+			Pods: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+		}
+		tcProceedOn = []bpfmaniov1alpha1.TcProceedOnValue{bpfmaniov1alpha1.TcProceedOnValue("ok"),
+			bpfmaniov1alpha1.TcProceedOnValue("shot")}
+		ctx = context.TODO()
+	)
+
+	// Set development Logger, so we can see all logs in tests.
+	logf.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+
+	tcProgram := bpfmaniov1alpha1.BpfApplicationProgram{
+		Name: testTcBpfFunctionName,
+		Type: bpfmaniov1alpha1.ProgTypeTC,
+		TC: &bpfmaniov1alpha1.TcProgramInfo{
+			Links: []bpfmaniov1alpha1.TcAttachInfo{
+				{
+					InterfaceSelector: interfaceSelector,
+					Direction:         testDirectionIngress,
+					Priority:          ptr.To(int32(testPriority)),
+					NetworkNamespaces: fakeNetNamespaces,
+					ProceedOn:         tcProceedOn,
+				},
+			},
+		},
+	}
+	tcxProgram := bpfmaniov1alpha1.BpfApplicationProgram{
+		Name: testTcxBpfFunctionName,
+		Type: bpfmaniov1alpha1.ProgTypeTCX,
+		TCX: &bpfmaniov1alpha1.TcxProgramInfo{
+			Links: []bpfmaniov1alpha1.TcxAttachInfo{
+				{
+					InterfaceSelector: interfaceSelector,
+					NetworkNamespaces: fakeNetNamespaces,
+					Direction:         testDirectionIngress,
+					Priority:          ptr.To(int32(testPriority)),
+				},
+			},
+		},
+	}
+
+	newApp := func(namespace string, programs []bpfmaniov1alpha1.BpfApplicationProgram) *bpfmaniov1alpha1.BpfApplication {
+		return &bpfmaniov1alpha1.BpfApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testAppProgramName,
+				Namespace: namespace,
+			},
+			Spec: bpfmaniov1alpha1.BpfApplicationSpec{
+				BpfAppCommon: bpfmaniov1alpha1.BpfAppCommon{
+					NodeSelector: metav1.LabelSelector{},
+					ByteCode: bpfmaniov1alpha1.ByteCodeSelector{
+						Path: ptr.To(testBytecodePath),
+					},
+				},
+				Programs: programs,
+			},
+		}
+	}
+
+	appTest1 := newApp("test1", []bpfmaniov1alpha1.BpfApplicationProgram{tcProgram, tcxProgram})
+	appTest2 := newApp("test2", []bpfmaniov1alpha1.BpfApplicationProgram{tcProgram})
+
+	testContainers := FakeContainerGetter{
+		containerList: &[]ContainerInfo{
+			{
+				podName:       fakePodName,
+				containerName: fakeContainerName,
+				pid:           fakePid,
+			},
+		},
+	}
+
+	objs := []runtime.Object{fakeNode, appTest1, appTest2}
+	r := createFakeNamespaceReconciler(objs, appTest1, fakeNode, &testContainers)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testAppProgramName,
+			Namespace: "test1",
+		},
+	}
+
+	// Each reconcile pass returns as soon as one BpfApplicationState
+	// changes, so several passes are needed for both applications to
+	// converge: create each state object, then load and attach each
+	// application's programs.
+	for range 6 {
+		runReconciler(t, ctx, r, req, r.Logger)
+	}
+
+	for _, app := range []*bpfmaniov1alpha1.BpfApplication{appTest1, appTest2} {
+		stateList := &bpfmaniov1alpha1.BpfApplicationStateList{}
+		require.NoError(t, r.List(ctx, stateList, client.InNamespace(app.Namespace)))
+		require.Len(t, stateList.Items, 1,
+			"expected exactly one BpfApplicationState in namespace %s", app.Namespace)
+		bpfAppState := &stateList.Items[0]
+		verifyBpfApplicationState(t, bpfAppState, fakeNode, testAppProgramName, bpfmaniov1alpha1.BpfAppStateCondSuccess)
+		verifyNamespaceBpfProgramState(t, bpfAppState, app.Spec.Programs)
+
+		// getBpfAppState must select the state object from the
+		// application's own namespace even though the state object in
+		// the other namespace carries identical labels.
+		r.currentApp = app
+		found, err := r.getBpfAppState(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		require.Equal(t, app.Namespace, found.Namespace)
 	}
 }
 

--- a/test/integration/ns_app_test.go
+++ b/test/integration/ns_app_test.go
@@ -1,0 +1,211 @@
+//go:build integration_tests
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/bpfman/bpfman-operator/apis/v1alpha1"
+)
+
+const (
+	nsSameNameAppName  = "app-test-namespaced"
+	nsSameNameNs1      = "same-name-app-a"
+	nsSameNameNs2      = "same-name-app-b"
+	nsSameNameBytecode = "quay.io/bpfman-bytecode/go-app-counter:latest"
+)
+
+// TestNamespacedAppSameNameDifferentNamespaces checks that two
+// BpfApplications sharing a name across different namespaces, with
+// different program lists, each get their own BpfApplicationState
+// objects and reconcile to Success independently. Previously the
+// agent's state lookup was not scoped by namespace, so the second
+// application adopted the first application's state object, drove it
+// to Error, and never created its own, leaving the second application
+// Pending forever.
+//
+// See https://redhat.atlassian.net/browse/BPFMAN-45.
+func TestNamespacedAppSameNameDifferentNamespaces(t *testing.T) {
+	// The pod selector deliberately matches no pods: the programs
+	// load and the applications reconcile to Success with zero
+	// attachments, which is all the state-object accounting this
+	// test verifies needs.
+	netNsSelector := v1alpha1.NetworkNamespaceSelector{
+		Pods: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "same-name-app-target",
+			},
+		},
+	}
+
+	tcProgram := v1alpha1.BpfApplicationProgram{
+		Name: "stats",
+		Type: v1alpha1.ProgTypeTC,
+		TC: &v1alpha1.TcProgramInfo{
+			Links: []v1alpha1.TcAttachInfo{
+				{
+					InterfaceSelector: v1alpha1.InterfaceSelector{
+						Interfaces: []string{"eth0"},
+					},
+					NetworkNamespaces: netNsSelector,
+					Direction:         v1alpha1.TCIngress,
+					Priority:          ptr.To(int32(55)),
+				},
+			},
+		},
+	}
+
+	tcxProgram := v1alpha1.BpfApplicationProgram{
+		Name: "tcx_stats",
+		Type: v1alpha1.ProgTypeTCX,
+		TCX: &v1alpha1.TcxProgramInfo{
+			Links: []v1alpha1.TcxAttachInfo{
+				{
+					InterfaceSelector: v1alpha1.InterfaceSelector{
+						Interfaces: []string{"eth0"},
+					},
+					NetworkNamespaces: netNsSelector,
+					Direction:         v1alpha1.TCIngress,
+					Priority:          ptr.To(int32(500)),
+				},
+			},
+		},
+	}
+
+	newApp := func(namespace string, programs ...v1alpha1.BpfApplicationProgram) *v1alpha1.BpfApplication {
+		return &v1alpha1.BpfApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsSameNameAppName,
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.BpfApplicationSpec{
+				BpfAppCommon: v1alpha1.BpfAppCommon{
+					NodeSelector: metav1.LabelSelector{},
+					ByteCode: v1alpha1.ByteCodeSelector{
+						Image: &v1alpha1.ByteCodeImage{
+							Url: nsSameNameBytecode,
+						},
+					},
+				},
+				Programs: programs,
+			},
+		}
+	}
+
+	for _, ns := range []string{nsSameNameNs1, nsSameNameNs2} {
+		t.Logf("creating namespace %s", ns)
+		_, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx,
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		for _, ns := range []string{nsSameNameNs1, nsSameNameNs2} {
+			cleanupLog("deleting BpfApplication in namespace %s", ns)
+			bpfmanClient.BpfmanV1alpha1().BpfApplications(ns).Delete(ctx, nsSameNameAppName, metav1.DeleteOptions{})
+		}
+		// Wait for the agents to detach and remove their state objects
+		// before deleting the namespaces, so the namespaces don't hang
+		// on state-object finalizers.
+		for _, ns := range []string{nsSameNameNs1, nsSameNameNs2} {
+			require.Eventually(t, func() bool {
+				states, err := bpfmanClient.BpfmanV1alpha1().BpfApplicationStates(ns).List(ctx, metav1.ListOptions{})
+				return err == nil && len(states.Items) == 0
+			}, 2*time.Minute, 2*time.Second)
+			cleanupLog("deleting namespace %s", ns)
+			env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+		}
+	})
+
+	// The first application must be fully reconciled before the
+	// same-named second application appears, which is the ordering
+	// that triggered the original failure.
+	t.Logf("creating BpfApplication %s/%s with TC and TCX programs", nsSameNameNs1, nsSameNameAppName)
+	_, err := bpfmanClient.BpfmanV1alpha1().BpfApplications(nsSameNameNs1).Create(ctx,
+		newApp(nsSameNameNs1, tcProgram, tcxProgram), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("waiting for BpfApplication %s/%s to report its eBPF programs loaded and attached on all selected nodes (the Success status condition)",
+		nsSameNameNs1, nsSameNameAppName)
+	require.Eventually(t, namedBpfApplicationSuccess(t, nsSameNameNs1, nsSameNameAppName), 2*time.Minute, 5*time.Second)
+
+	t.Logf("creating BpfApplication %s/%s with only a TC program", nsSameNameNs2, nsSameNameAppName)
+	_, err = bpfmanClient.BpfmanV1alpha1().BpfApplications(nsSameNameNs2).Create(ctx,
+		newApp(nsSameNameNs2, tcProgram), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("waiting for BpfApplication %s/%s to report its eBPF programs loaded and attached on all selected nodes (the Success status condition)",
+		nsSameNameNs2, nsSameNameAppName)
+	require.Eventually(t, namedBpfApplicationSuccess(t, nsSameNameNs2, nsSameNameAppName), 2*time.Minute, 5*time.Second)
+
+	// The original failure oscillated the first application between
+	// Success and Error as the agent repeatedly adopted its state
+	// object on behalf of the second application, so a single
+	// point-in-time check could pass by luck. Sample both applications
+	// for a while to catch any flip.
+	t.Logf("verifying %s/%s and %s/%s both keep reporting their eBPF programs loaded and attached (the Success status condition)",
+		nsSameNameNs1, nsSameNameAppName, nsSameNameNs2, nsSameNameAppName)
+	require.Never(t, func() bool {
+		return !namedBpfApplicationSuccess(t, nsSameNameNs1, nsSameNameAppName)() ||
+			!namedBpfApplicationSuccess(t, nsSameNameNs2, nsSameNameAppName)()
+	}, 30*time.Second, 5*time.Second)
+
+	// Each namespace must hold its own state objects (one per node),
+	// owned by its own application and tracking that application's
+	// program list, not the other namespace's.
+	expectedPrograms := map[string]int{
+		nsSameNameNs1: 2,
+		nsSameNameNs2: 1,
+	}
+	var stateCounts []int
+	for ns, numPrograms := range expectedPrograms {
+		app, err := bpfmanClient.BpfmanV1alpha1().BpfApplications(ns).Get(ctx, nsSameNameAppName, metav1.GetOptions{})
+		require.NoError(t, err)
+		states, err := bpfmanClient.BpfmanV1alpha1().BpfApplicationStates(ns).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, states.Items, "expected BpfApplicationState objects in namespace %s", ns)
+		stateCounts = append(stateCounts, len(states.Items))
+		for _, state := range states.Items {
+			owner := metav1.GetControllerOf(&state)
+			require.NotNil(t, owner, "BpfApplicationState %s/%s should have a controller reference", ns, state.Name)
+			require.Equal(t, app.UID, owner.UID,
+				"BpfApplicationState %s/%s should be owned by its own namespace's application", ns, state.Name)
+			require.Len(t, state.Status.Programs, numPrograms,
+				"BpfApplicationState %s/%s should track its own application's programs", ns, state.Name)
+			c := meta.FindStatusCondition(state.Status.Conditions, string(v1alpha1.BpfAppStateCondSuccess))
+			require.NotNil(t, c, "BpfApplicationState %s/%s should have a Success condition", ns, state.Name)
+			require.Equal(t, metav1.ConditionTrue, c.Status)
+		}
+	}
+
+	require.Equal(t, stateCounts[0], stateCounts[1],
+		"both namespaces should have one BpfApplicationState per node")
+}
+
+// namedBpfApplicationSuccess returns a function that checks if a
+// namespaced BpfApplication has reached a successful state.
+func namedBpfApplicationSuccess(t *testing.T, namespace, name string) func() bool {
+	return func() bool {
+		app, err := bpfmanClient.BpfmanV1alpha1().BpfApplications(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("BpfApplication %s/%s not yet available: %v", namespace, name, err)
+			return false
+		}
+
+		c := meta.FindStatusCondition(app.Status.Conditions, string(v1alpha1.BpfAppCondSuccess))
+		if c == nil || c.Status != metav1.ConditionTrue {
+			t.Logf("BpfApplication %s/%s eBPF programs not yet loaded and attached on all selected nodes: %+v",
+				namespace, name, app.Status.Conditions)
+			return false
+		}
+
+		return true
+	}
+}


### PR DESCRIPTION
Creating two `BpfApplication` objects with the same name in different namespaces drove the first into `Error` ("BpfApplication Reconciliation failed on the following BpfApplicationState objects: [...]") and left the second stuck in `Pending`, never reconciled on any node. Reported in [BPFMAN-45](https://redhat.atlassian.net/browse/BPFMAN-45).

The trail started from the operator's error message, which pointed at the first application's `BpfApplicationState` object. The operator-side lookup that produced it is correctly scoped with `client.InNamespace`, so the corruption had to come from whoever wrote the Error condition into that object: the agent. Its `getBpfAppState` lists state objects by the `bpfman.io/ownedByProgram` and hostname labels alone, with no namespace filter.

That label carries the bare application name, so two same-named applications on the same node produce label-identical state objects. While reconciling the second application, the agent's lookup matched the first application's state object, compared the wrong program lists, concluded programs had been removed, and wrote an Error condition into the other namespace's object. Because the lookup "found" a state object, the second application's own state was never created, which is why it sat in `Pending`. Had both state objects existed, the same lookup would instead have failed with "more than one BpfApplicationState found" and wedged both applications.

The fix is one line: add `client.InNamespace(r.currentApp.Namespace)` to the lookup. State objects are always created in their application's namespace, so name-plus-node is unique again once the query is confined to that namespace, and neither the adoption nor the two-object failure mode can occur. This is a natural continuation of what the codebase already does rather than a new pattern: the operator's namespaced lister in `common_namespace.go` applies exactly this filter, and this was the only unscoped lookup left. The cluster-scoped equivalent needs no change because `ClusterBpfApplication` is cluster-scoped, so its names cannot collide.

## Test plan

Three unit regression tests in `ns_application_program_test.go`: the lookup returns nil when only a foreign namespace's state object exists, it selects the own-namespace object when label-identical objects exist in two namespaces, and a reconcile-level test drives two same-named applications (a TC+TCX app and a TC-only app) through several reconcile passes and asserts each ends up with its own state object tracking its own program list. Each was confirmed to fail before the fix, for the exact failure mode it targets, and `go test ./controllers/bpfman-agent/...` passes with it.

A new integration test in `test/integration/ns_app_test.go` reproduces the reported scenario on a running cluster: it creates the first application, waits for it to reach the Success status condition, then creates the same-named application in a second namespace and asserts both reach and hold Success, each owning its own `BpfApplicationState` objects with the expected program count. Run it with the usual `make test-integration` flow (or `make test-integration-local` against an existing kind cluster). Against agent images built without the fix it fails as reported, with the second application stuck in `Pending`.