### PR TITLE
Scope namespaced program pod selection to the owning namespace

### DIFF
--- a/controllers/bpfman-agent/ns_application_program.go
+++ b/controllers/bpfman-agent/ns_application_program.go
@@ -57,9 +57,19 @@ type NsBpfApplicationReconciler struct {
 }
 
 type NsProgramReconcilerCommon struct {
+	currentApp          *bpfmaniov1alpha1.BpfApplication
 	currentProgram      *bpfmaniov1alpha1.BpfApplicationProgram
 	currentProgramState *bpfmaniov1alpha1.BpfApplicationProgramState
-	namespace           string
+}
+
+// getNamespace returns the namespace a namespaced program's pod and network
+// namespace selectors are scoped to. That is always the owning
+// BpfApplication's namespace, derived here rather than copied into a field so
+// it cannot be left unset. This is deliberately unlike the cluster-scoped
+// variant, whose selector carries an explicit namespace where empty means all
+// namespaces.
+func (r *NsProgramReconcilerCommon) getNamespace() string {
+	return r.currentApp.Namespace
 }
 
 func (r *NsBpfApplicationReconciler) getAppStateName() string {
@@ -314,6 +324,7 @@ func (r *NsBpfApplicationReconciler) getProgramReconciler(prog *bpfmaniov1alpha1
 		rec = &NsUprobeProgramReconciler{
 			ReconcilerCommon: r.ReconcilerCommon,
 			NsProgramReconcilerCommon: NsProgramReconcilerCommon{
+				currentApp:          r.currentApp,
 				currentProgram:      prog,
 				currentProgramState: progState,
 			},
@@ -323,6 +334,7 @@ func (r *NsBpfApplicationReconciler) getProgramReconciler(prog *bpfmaniov1alpha1
 		rec = &NsTcProgramReconciler{
 			ReconcilerCommon: r.ReconcilerCommon,
 			NsProgramReconcilerCommon: NsProgramReconcilerCommon{
+				currentApp:          r.currentApp,
 				currentProgram:      prog,
 				currentProgramState: progState,
 			},
@@ -332,6 +344,7 @@ func (r *NsBpfApplicationReconciler) getProgramReconciler(prog *bpfmaniov1alpha1
 		rec = &NsTcxProgramReconciler{
 			ReconcilerCommon: r.ReconcilerCommon,
 			NsProgramReconcilerCommon: NsProgramReconcilerCommon{
+				currentApp:          r.currentApp,
 				currentProgram:      prog,
 				currentProgramState: progState,
 			},
@@ -341,6 +354,7 @@ func (r *NsBpfApplicationReconciler) getProgramReconciler(prog *bpfmaniov1alpha1
 		rec = &NsXdpProgramReconciler{
 			ReconcilerCommon: r.ReconcilerCommon,
 			NsProgramReconcilerCommon: NsProgramReconcilerCommon{
+				currentApp:          r.currentApp,
 				currentProgram:      prog,
 				currentProgramState: progState,
 			},

--- a/controllers/bpfman-agent/ns_pod_scoping_test.go
+++ b/controllers/bpfman-agent/ns_pod_scoping_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The bpfman Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfmanagent
+
+import (
+	"context"
+	"testing"
+
+	bpfmaniov1alpha1 "github.com/bpfman/bpfman-operator/apis/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientGoFake "k8s.io/client-go/kubernetes/fake"
+)
+
+// nsApp builds a namespaced BpfApplication in the given namespace.
+func nsApp(namespace string) *bpfmaniov1alpha1.BpfApplication {
+	return &bpfmaniov1alpha1.BpfApplication{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: namespace},
+	}
+}
+
+// TestNsProgramReconcilerNamespaceFromApp proves the namespace a namespaced
+// program scopes its selectors to is derived from the owning application, not
+// a separately-set field that could be left empty.
+func TestNsProgramReconcilerNamespaceFromApp(t *testing.T) {
+	common := NsProgramReconcilerCommon{currentApp: nsApp("tenant-a")}
+	require.Equal(t, "tenant-a", common.getNamespace())
+}
+
+// TestNsUprobeReconcilerScopesLookupToAppNamespace proves the derived
+// namespace actually reaches the container lookup: the value handed to
+// GetContainers -- which becomes Pods(namespace).List(...) -- is the owning
+// application's namespace, not the empty string that would list pods across
+// every namespace. The uprobe path is used because it calls GetContainers
+// without first resolving interfaces, so no node fixture is needed; all four
+// namespaced reconcilers share the same promoted getNamespace().
+func TestNsUprobeReconcilerScopesLookupToAppNamespace(t *testing.T) {
+	fake := &FakeContainerGetter{}
+	r := &NsUprobeProgramReconciler{
+		ReconcilerCommon: ReconcilerCommon{
+			Containers: fake,
+			Logger:     logr.Discard(),
+		},
+		NsProgramReconcilerCommon: NsProgramReconcilerCommon{
+			currentApp: nsApp("tenant-a"),
+		},
+	}
+
+	_, err := r.getExpectedLinks(context.TODO(), bpfmaniov1alpha1.UprobeAttachInfo{
+		Containers: bpfmaniov1alpha1.ContainerSelector{
+			Pods: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "tenant-a", fake.gotNamespace,
+		"container lookup must be scoped to the owning application's namespace")
+}
+
+// labelledPod builds a pod with identical labels in the given namespace on
+// the given node.
+func labelledPod(name, namespace, nodeName string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: v1.PodSpec{NodeName: nodeName},
+	}
+}
+
+// TestGetPodsForNodeEmptyNamespaceIsAllNamespaces proves the client-go
+// semantics that made the missing namespace dangerous: listing pods with an
+// empty namespace returns pods from every namespace on the node, filtered
+// only by the label and node-name selectors. Scoping the lookup to the
+// application's namespace (above) is what confines selection to one tenant.
+func TestGetPodsForNodeEmptyNamespaceIsAllNamespaces(t *testing.T) {
+	ctx := context.TODO()
+	nodeName := "test-node"
+
+	clientset := clientGoFake.NewSimpleClientset(
+		labelledPod("pod-a", "ns-a", nodeName),
+		labelledPod("pod-b", "ns-b", nodeName),
+	)
+
+	containerGetter := RealContainerGetter{
+		nodeName:  nodeName,
+		clientSet: clientset,
+	}
+
+	selector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "test"},
+	}
+
+	// Empty namespace: expect pods from BOTH namespaces.
+	podList, err := containerGetter.getPodsForNode(ctx, "", selector)
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, p := range podList.Items {
+		names[p.Namespace+"/"+p.Name] = true
+	}
+	require.Len(t, podList.Items, 2,
+		"empty namespace must list pods across all namespaces; got %v", names)
+	require.True(t, names["ns-a/pod-a"])
+	require.True(t, names["ns-b/pod-b"])
+
+	// Contrast: a specific namespace scopes the result to that namespace.
+	podList, err = containerGetter.getPodsForNode(ctx, "ns-a", selector)
+	require.NoError(t, err)
+	require.Len(t, podList.Items, 1)
+	require.Equal(t, "ns-a", podList.Items[0].Namespace)
+	require.Equal(t, "pod-a", podList.Items[0].Name)
+}

--- a/controllers/bpfman-agent/ns_tc_program.go
+++ b/controllers/bpfman-agent/ns_tc_program.go
@@ -90,10 +90,6 @@ func (r *NsTcProgramReconciler) getCurrentLinkStatus() bpfmaniov1alpha1.LinkStat
 	return r.currentLink.LinkStatus
 }
 
-func (r *NsTcProgramReconciler) getNamespace() string {
-	return r.namespace
-}
-
 func (r *NsTcProgramReconciler) getAttachRequest() *gobpfman.AttachRequest {
 
 	attachInfo := &gobpfman.TCAttachInfo{

--- a/controllers/bpfman-agent/ns_tcx_program.go
+++ b/controllers/bpfman-agent/ns_tcx_program.go
@@ -90,10 +90,6 @@ func (r *NsTcxProgramReconciler) getCurrentLinkStatus() bpfmaniov1alpha1.LinkSta
 	return r.currentLink.LinkStatus
 }
 
-func (r *NsTcxProgramReconciler) getNamespace() string {
-	return r.namespace
-}
-
 func (r *NsTcxProgramReconciler) getAttachRequest() *gobpfman.AttachRequest {
 
 	attachInfo := &gobpfman.TCXAttachInfo{

--- a/controllers/bpfman-agent/ns_uprobe_program.go
+++ b/controllers/bpfman-agent/ns_uprobe_program.go
@@ -275,7 +275,7 @@ func (r *NsUprobeProgramReconciler) getExpectedLinks(ctx context.Context, attach
 	// See if there are any matching containers on this node.
 	containerInfo, err := r.Containers.GetContainers(
 		ctx,
-		r.namespace,
+		r.getNamespace(),
 		attachInfo.Containers.Pods,
 		&attachInfo.Containers.ContainerNames,
 		r.Logger,

--- a/controllers/bpfman-agent/ns_xdp_program.go
+++ b/controllers/bpfman-agent/ns_xdp_program.go
@@ -90,10 +90,6 @@ func (r *NsXdpProgramReconciler) getCurrentLinkStatus() bpfmaniov1alpha1.LinkSta
 	return r.currentLink.LinkStatus
 }
 
-func (r *NsXdpProgramReconciler) getNamespace() string {
-	return r.namespace
-}
-
 func (r *NsXdpProgramReconciler) getAttachRequest() *gobpfman.AttachRequest {
 
 	attachInfo := &gobpfman.XDPAttachInfo{

--- a/controllers/bpfman-agent/test_common.go
+++ b/controllers/bpfman-agent/test_common.go
@@ -61,6 +61,10 @@ const (
 
 type FakeContainerGetter struct {
 	containerList *[]ContainerInfo
+	// gotNamespace records the namespace of the most recent GetContainers
+	// call so tests can assert that a namespaced reconciler scopes its lookup
+	// to the owning application's namespace.
+	gotNamespace string
 }
 
 func (f *FakeContainerGetter) GetContainers(
@@ -70,6 +74,7 @@ func (f *FakeContainerGetter) GetContainers(
 	selectorContainerNames *[]string,
 	logger logr.Logger,
 ) (*[]ContainerInfo, error) {
+	f.gotNamespace = selectorNamespace
 	return f.containerList, nil
 }
 

--- a/test/integration/ns_pod_scoping_test.go
+++ b/test/integration/ns_pod_scoping_test.go
@@ -1,0 +1,198 @@
+//go:build integration_tests
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/bpfman/bpfman-operator/apis/v1alpha1"
+)
+
+const (
+	xnsAppName          = "xns-pod-scope"
+	xnsAppNs            = "xns-pod-scope-app"
+	xnsForeignNs        = "xns-pod-scope-foreign"
+	xnsTargetPodApp     = "xns-target-app"
+	xnsTargetPodForeign = "xns-target-foreign"
+	xnsTargetLabel      = "xns-pod-scope-target"
+	xnsTargetImage      = "quay.io/quay/busybox:latest"
+	xnsBytecode         = "quay.io/bpfman-bytecode/go-app-counter:latest"
+)
+
+// TestNamespacedAppDoesNotSelectPodsInOtherNamespaces proves that a
+// namespaced BpfApplication's pod selectors are confined to the
+// application's own namespace.
+//
+// Two namespaces each hold an identically-labelled target pod on the
+// same node. A BpfApplication in one namespace carries a TC program
+// whose network-namespace selector matches that label. Correctly
+// scoped, the application attaches to exactly one pod: the target in
+// its own namespace. If the agent resolves the selector against an
+// empty namespace it attaches to both pods, reaching into a foreign
+// namespace's pod on the same node -- the isolation break this test
+// guards against. The number of TC links in the application's
+// BpfApplicationState is the observable: one when scoped, two when
+// leaking.
+func TestNamespacedAppDoesNotSelectPodsInOtherNamespaces(t *testing.T) {
+	nodes, err := env.Cluster().Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, nodes.Items)
+	// Pin both target pods to one node so they share a bpfman-agent,
+	// making the link count deterministic.
+	targetNode := nodes.Items[0].Name
+
+	// The two target pods carry the same labels but distinct names.
+	// Distinct names matter: TC link expansion runs the matched pods
+	// through GetOneContainerPerPod, which deduplicates by pod name, so
+	// identically-named pods would collapse to a single link and mask a
+	// cross-namespace match.
+	targets := []struct{ namespace, pod string }{
+		{xnsAppNs, xnsTargetPodApp},
+		{xnsForeignNs, xnsTargetPodForeign},
+	}
+
+	targetPod := func(name, namespace string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{"app": xnsTargetLabel},
+			},
+			Spec: corev1.PodSpec{
+				NodeName:    targetNode,
+				Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+				Containers: []corev1.Container{{
+					Name:    "target",
+					Image:   xnsTargetImage,
+					Command: []string{"sleep", "3600"},
+				}},
+			},
+		}
+	}
+
+	app := &v1alpha1.BpfApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      xnsAppName,
+			Namespace: xnsAppNs,
+		},
+		Spec: v1alpha1.BpfApplicationSpec{
+			BpfAppCommon: v1alpha1.BpfAppCommon{
+				NodeSelector: metav1.LabelSelector{},
+				ByteCode: v1alpha1.ByteCodeSelector{
+					Image: &v1alpha1.ByteCodeImage{Url: xnsBytecode},
+				},
+			},
+			Programs: []v1alpha1.BpfApplicationProgram{
+				{
+					Name: "stats",
+					Type: v1alpha1.ProgTypeTC,
+					TC: &v1alpha1.TcProgramInfo{
+						Links: []v1alpha1.TcAttachInfo{
+							{
+								InterfaceSelector: v1alpha1.InterfaceSelector{
+									Interfaces: []string{"eth0"},
+								},
+								NetworkNamespaces: v1alpha1.NetworkNamespaceSelector{
+									Pods: metav1.LabelSelector{
+										MatchLabels: map[string]string{"app": xnsTargetLabel},
+									},
+								},
+								Direction: v1alpha1.TCIngress,
+								Priority:  ptr.To(int32(55)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, ns := range []string{xnsAppNs, xnsForeignNs} {
+		t.Logf("creating namespace %s", ns)
+		_, err := env.Cluster().Client().CoreV1().Namespaces().Create(ctx,
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		cleanupLog("deleting BpfApplication %s/%s", xnsAppNs, xnsAppName)
+		bpfmanClient.BpfmanV1alpha1().BpfApplications(xnsAppNs).Delete(ctx, xnsAppName, metav1.DeleteOptions{})
+		// Wait for the agent to detach and remove its state objects
+		// before deleting the namespace so it doesn't hang on the
+		// state-object finalizer.
+		require.Eventually(t, func() bool {
+			states, err := bpfmanClient.BpfmanV1alpha1().BpfApplicationStates(xnsAppNs).List(ctx, metav1.ListOptions{})
+			return err == nil && len(states.Items) == 0
+		}, 2*time.Minute, 2*time.Second)
+		for _, ns := range []string{xnsAppNs, xnsForeignNs} {
+			cleanupLog("deleting namespace %s", ns)
+			env.Cluster().Client().CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+		}
+	})
+
+	// Both target pods must be running before the application appears,
+	// so the first reconcile already sees both candidates and the leak,
+	// if present, is immediate rather than racing pod startup.
+	for _, tgt := range targets {
+		t.Logf("creating target pod %s/%s on node %s", tgt.namespace, tgt.pod, targetNode)
+		_, err := env.Cluster().Client().CoreV1().Pods(tgt.namespace).Create(ctx, targetPod(tgt.pod, tgt.namespace), metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	for _, tgt := range targets {
+		t.Logf("waiting for target pod %s/%s to be running", tgt.namespace, tgt.pod)
+		require.Eventually(t, func() bool {
+			p, err := env.Cluster().Client().CoreV1().Pods(tgt.namespace).Get(ctx, tgt.pod, metav1.GetOptions{})
+			return err == nil && p.Status.Phase == corev1.PodRunning
+		}, 2*time.Minute, 2*time.Second)
+	}
+
+	t.Logf("creating BpfApplication %s/%s with a TC network-namespace selector", xnsAppNs, xnsAppName)
+	_, err = bpfmanClient.BpfmanV1alpha1().BpfApplications(xnsAppNs).Create(ctx, app, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Wait for the agent to expand the selector into attach links. The
+	// link entries appear in the state whether or not the attach itself
+	// succeeds, so this does not gate on the application's overall
+	// condition -- an attach into the foreign pod might fail and drive
+	// the application to Error, which must not hide the extra link.
+	t.Logf("waiting for BpfApplication %s/%s to attach within its own namespace", xnsAppNs, xnsAppName)
+	require.Eventually(t, func() bool {
+		return countNsTcLinks(t, xnsAppNs) >= 1
+	}, 2*time.Minute, 5*time.Second)
+
+	// The decisive check: the application must never expand to more than
+	// the single target pod in its own namespace. A second link means it
+	// selected the identically-labelled pod in the foreign namespace.
+	t.Logf("verifying BpfApplication %s/%s never selects the foreign namespace's pod", xnsAppNs, xnsAppName)
+	require.Never(t, func() bool {
+		return countNsTcLinks(t, xnsAppNs) > 1
+	}, 30*time.Second, 5*time.Second)
+}
+
+// countNsTcLinks sums the TC attach links across every
+// BpfApplicationState in the namespace. In a namespace holding a single
+// application this is that application's total number of TC attach
+// points on all nodes, regardless of whether each attach succeeded.
+func countNsTcLinks(t *testing.T, namespace string) int {
+	states, err := bpfmanClient.BpfmanV1alpha1().BpfApplicationStates(namespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	total := 0
+	for i := range states.Items {
+		// Ignore states whose application is being torn down.
+		if !states.Items[i].DeletionTimestamp.IsZero() {
+			continue
+		}
+		for _, prog := range states.Items[i].Status.Programs {
+			if prog.TC != nil {
+				total += len(prog.TC.Links)
+			}
+		}
+	}
+	return total
+}


### PR DESCRIPTION
A namespaced `BpfApplication` resolves its pod and network-namespace selectors against an empty namespace, which client-go treats as all namespaces, so the selectors match pods in every namespace on the node rather than only the application's own. A tenant confined to one namespace can therefore attach eBPF programs into other namespaces' pods on the same node. Issue #540 has the full analysis, the regression history (it dates to the load/attach split in 7c11035a), and a reproducer with captured output.

The namespace of a namespaced program is always its owning application's namespace, so this derives it from the owning `BpfApplication` held on `NsProgramReconcilerCommon` rather than copying it into a field that the reconciler constructions left unset. That removes the empty-able field and folds the three duplicated `getNamespace()` methods into one. All five namespaced program types (TC, TCX, XDP, uprobe, uretprobe) share this path, so all are covered.

The change is split into two discrete commits so the failure is reproducible before the fix. The first commit adds only the integration test, which reproduces the leak with two identically-labelled pods in different namespaces and one namespaced application. Build the agent at that commit and run the test, and it fails on the extra link into the foreign namespace; build again at the second commit, which applies the fix and the unit-level regression tests, and the same test passes. Checking the test commit out on its own is the intended way to watch it go from red to green.

Fixes #540

## Test plan

`go test ./controllers/bpfman-agent/` covers the unit tests, including the new derivation and container-lookup scoping tests. `make test-integration-local TEST=TestNamespacedAppDoesNotSelectPodsInOtherNamespaces` passes against an agent carrying this fix and fails against one built from `main` (the application's state holds two TC links, the second resolving to a pod in the foreign namespace), verified on a local single-node kind cluster.
